### PR TITLE
Template the service-catalog

### DIFF
--- a/ansible/roles/service_catalog_setup/tasks/main.yml
+++ b/ansible/roles/service_catalog_setup/tasks/main.yml
@@ -27,19 +27,22 @@
     when: docker_pull_svc_cat.changed
     register: new_svc_cat_project
     ignore_errors: yes
-    
+
   - name: Ensuring service-catalog project is selected for those cases of being re-run and skipping the new-project creation
     shell: "{{ oc_cmd }} project service-catalog"
 
-  - name: Copy service-catalog.templ.yaml
-    copy:
-      src: service-catalog.templ.yaml
+  - name: Creating service-catalog.templ.yaml
+    template:
+      src: service-catalog.templ.yaml.j2
       dest: /tmp/service-catalog.templ.yaml
-    register: copy_svc_catalog_tmp
+      owner: root
+      group: root
+      mode: 0644
+    register: create_svc_catalog_tmp
 
   - name: Install Service Catalog through OC Template
     shell: "{{ oc_cmd }} process -f /tmp/service-catalog.templ.yaml | {{ oc_cmd }} create -f -"
-    when: copy_svc_catalog_tmp.changed
+    when: create_svc_catalog_tmp.changed
 
   - name: Waiting 10 minutes for API server pod to come up
     action:

--- a/ansible/roles/service_catalog_setup/templates/service-catalog.templ.yaml.j2
+++ b/ansible/roles/service_catalog_setup/templates/service-catalog.templ.yaml.j2
@@ -40,7 +40,7 @@ objects:
           - "10"
           - --cors-allowed-origins
           - ${CORS_ALLOWED_ORIGIN}
-          image: apiserver:canary
+          image: {{ svc_cat_apiserver_tag }}
           imagePullPolicy: Never
           name: apiserver
           ports:
@@ -127,7 +127,7 @@ objects:
           - "5"
           - --service-catalog-api-server-url
           - http://$(APISERVER_SERVICE_HOST):$(APISERVER_SERVICE_PORT)
-          image: controller-manager:canary
+          image: {{ svc_cat_controller_mgr_tag }}
           imagePullPolicy: Never
           name: controller-manager
           ports:


### PR DESCRIPTION
The service-catalog had hard-coded image tags.  Instead,
make the template a j2 template and use variables for the
images.