### PR TITLE
Integrate templates into the playbooks

### DIFF
--- a/ansible/roles/ansible_service_broker_setup/defaults/main.yml
+++ b/ansible/roles/ansible_service_broker_setup/defaults/main.yml
@@ -1,1 +1,11 @@
 go_path: /root/go
+
+asb_registry: "ansibleplaybookbundle"
+
+broker_tag: "latest"
+broker_image_name: "{{ asb_registry }}/ansible-service-broker-apb"
+broker_image: "{{ broker_image_name }}:{{ broker_tag }}"
+
+etcd_tag: "latest"
+etcd_image_name: "{{ asb_registry }}/ansible-service-broker-etcd"
+etcd_image: "{{ etcd_image_name }}:{{ etcd_tag }}"

--- a/ansible/roles/ansible_service_broker_setup/files/route.yaml
+++ b/ansible/roles/ansible_service_broker_setup/files/route.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Route
+metadata:
+  name: asb-1338
+  namespace: ansible-service-broker
+  labels:
+    app: ansible-service-broker
+    service: asb
+spec:
+  to:
+    kind: Service
+    name: asb
+  port:
+    targetPort: port-1338

--- a/ansible/roles/ansible_service_broker_setup/files/services.yaml
+++ b/ansible/roles/ansible_service_broker_setup/files/services.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ansible-service-broker
+
+---
+apiVersion: v1
+kind: Service
+labels:
+   app: ansible-service-broker
+   service: asb
+metadata:
+   name: asb
+   namespace: ansible-service-broker
+spec:
+  ports:
+    - name: port-1338
+      port: 1338
+  selector:
+    app: ansible-service-broker
+    service: asb
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+   name: etcd
+   namespace: ansible-service-broker
+spec:
+  ports:
+    - name: etcd-advertise
+      port: 2379
+  selector:
+    app: ansible-service-broker
+    service: etcd

--- a/ansible/roles/ansible_service_broker_setup/tasks/main.yml
+++ b/ansible/roles/ansible_service_broker_setup/tasks/main.yml
@@ -1,70 +1,61 @@
 ---
-  # GOPATH is setup incase we want to complile things later
-  # Current approach is not building any go code.
-  - name: Setup GOPATH in /root/.bashrc
-    lineinfile: dest=/root/.bashrc line="{{ item }}" create=yes
-    with_items:
-      - export GOPATH="{{ go_path }}"
-      - export PATH=$GOPATH/bin:$PATH
-
-  - name:
-    file:
-      path: "{{ go_path }}/src/github.com/fusor"
-      state: directory
-      mode: 0755
-
-  - name: git clone ansible-service-broker
-    git:
-      repo: https://github.com/fusor/ansible-service-broker.git
-      dest: "{{ go_path }}/src/github.com/fusor/ansible-service-broker"
-      version: "forced-async-prov"
-    register: git_clone_asb
-
-  - name: Install asbcli requirements
-    pip:
-      requirements: "{{ go_path }}/src/github.com/fusor/ansible-service-broker/scripts/asbcli/requirements.txt"
-    when: git_clone_asb.changed
-
-  - name: Docker pull ansibleplaybookbundle/ansible-service-broker-apb:latest
+  - name: Docker pull {{ broker_image }}
     docker_image:
-      name: ansibleplaybookbundle/ansible-service-broker-apb:latest
+      name: "{{ broker_image }}"
 
-  - name: Check if ansible-service-broker project already exists from a prior run
-    shell: "{{ oc_cmd }} get projects | grep ansible-service-broker"
-    register: oc_get_projects_asb
-    ignore_errors: yes
+  - name: Docker pull {{ etcd_image }}
+    docker_image:
+      name: "{{ etcd_image }}"
 
-  - name: Use asbcli up to install Ansible Service Broker
-    shell: "./asbcli up {{ openshift_url }} --cluster-user={{ cluster_user }} --cluster-pass={{ cluster_user_password }} --dockerhub-user={{ dockerhub_user_name }} --dockerhub-pass={{ dockerhub_user_password }}"
-    args:
-      chdir: "{{ go_path }}/src/github.com/fusor/ansible-service-broker/scripts/asbcli"
-    retries: 2
-    register: asbcli_up
-    when: oc_get_projects_asb.rc != 0
+  - name: Copying services.yaml
+    copy:
+      src: services.yaml
+      dest: /tmp/services.yaml
 
-  - name: Switch project to ansible-service-broker
-    shell: "{{ oc_cmd }} project ansible-service-broker"
+  - name: Copying route.yaml
+    copy:
+      src: route.yaml
+      dest: /tmp/route.yaml
 
-  - name: Waiting 10 minutes for ASB pod
-    action:
-      shell "{{ oc_cmd }}" get pods | grep -iEm1 "asb.*?running" | grep -v deploy
-    register: wait_for_asb_pod
-    until: wait_for_asb_pod.rc == 0
-    retries: 60
+  - name: Creating etcd-deployment.yaml
+    template:
+      src: etcd-deployment.yaml.j2
+      dest: /tmp/etcd-deployment.yaml
+
+  - name: Creating broker-deployment.yaml
+    template:
+      src: broker-deployment.yaml.j2
+      dest: /tmp/broker-deployment.yaml
+
+  - name: Create ansible-service-broker namespace and services
+    shell: "{{ oc_cmd }} create -f /tmp/services.yaml"
+
+  - name: Create ansible-service-broker route
+    shell: "{{ oc_cmd }} create -f /tmp/route.yaml"
+
+  - name: Get route for ansible-service-broker
+    shell: "'{{ oc_cmd }}' get routes -n ansible-service-broker| grep ansible-service-broker | awk '{print $2}'"
+    retries: 6
     delay: 10
+
+  - name: Create etcd deployment
+    shell: "{{ oc_cmd }} create -f /tmp/etcd-deployment.yaml"
+
+  - name: Create ansible-service-broker deployment
+    shell: "{{ oc_cmd }} create -f /tmp/broker-deployment.yaml"
 
   - name: Waiting 10 minutes for ASB etcd pod
     action:
-      shell "{{ oc_cmd }}" get pods | grep -iEm1 "etcd.*?running" | grep -v deploy
-    register: wait_for_asb_etcd_pod
+      shell "{{ oc_cmd }}" get pods -n ansible-service-broker | grep -iEm1 "etcd.*?running" | grep -v deploy
     until: wait_for_asb_etcd_pod.rc == 0
     retries: 60
     delay: 10
 
-  - name: Get route for ansible-service-broker
-    shell: "'{{ oc_cmd }}' get routes | grep ansible-service-broker | awk '{print $2}'"
-    register: result_get_route_asb
-    retries: 6
+  - name: Waiting 10 minutes for ASB pod
+    action:
+      shell "{{ oc_cmd }}" get pods -n ansible-service-broker | grep -iEm1 "asb.*?running" | grep -v deploy
+    until: wait_for_asb_pod.rc == 0
+    retries: 60
     delay: 10
 
   - set_fact:
@@ -72,7 +63,6 @@
 
   - name: Bootstrap Ansible Service Broker
     shell: curl -X POST {{ ansible_service_broker_route }}/v2/bootstrap
-    when: asbcli_up.changed
 
   - name: Creating /tmp/ansible_service_broker.yaml
     template:
@@ -81,8 +71,6 @@
       owner: root
       group: root
       mode: 0644
-    register: ansible_service_broker_template
 
   - name: Create Broker resource in Service Catalog
     shell: "{{ kubectl_cmd }} --kubeconfig=/root/.kube/service-catalog.config create -f /tmp/ansible_service_broker.yaml"
-    when: asbcli_up.changed

--- a/ansible/roles/ansible_service_broker_setup/templates/broker-deployment.yaml.j2
+++ b/ansible/roles/ansible_service_broker_setup/templates/broker-deployment.yaml.j2
@@ -1,0 +1,37 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: asb
+  namespace: ansible-service-broker
+  labels:
+    app: ansible-service-broker
+    service: asb
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ansible-service-broker
+        service: asb
+    spec:
+      restartPolicy: Always
+      containers:
+        - image: {{ broker_image }}
+          name: main
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 1338
+              protocol: TCP
+          env:
+            - name: DOCKERHUB_PASS
+              value: {{ dockerhub_user_password }}
+            - name: DOCKERHUB_USER
+              value: {{ dockerhub_user_name }}
+            - name: OPENSHIFT_PASS
+              value: {{ cluster_user_password }}
+            - name: OPENSHIFT_TARGET
+              value: {{ openshift_url }}
+            - name: OPENSHIFT_USER
+              value: {{ cluster_user }}

--- a/ansible/roles/ansible_service_broker_setup/templates/etcd-deployment.yaml.j2
+++ b/ansible/roles/ansible_service_broker_setup/templates/etcd-deployment.yaml.j2
@@ -1,0 +1,35 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: etcd
+  namespace: ansible-service-broker
+  labels:
+    app: ansible-service-broker
+    service: etcd
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ansible-service-broker
+        service: etcd
+    spec:
+      restartPolicy: Always
+      containers:
+        - image: {{ etcd_image }}
+          name: main
+          imagePullPolicy: IfNotPresent
+          workingDir: /etcd
+          args:
+            - ./etcd
+            - --data-dir=/data
+            - --listen-client-urls=http://0.0.0.0:2379
+            - --advertise-client-urls=http://0.0.0.0:2379
+          ports:
+          - containerPort: 2379
+            protocol: TCP
+          env:
+          - name: ETCDCTL_API
+            value: "3"


### PR DESCRIPTION
Instead of using asbcli to create the broker, use templates and render them with jinja2.

I tested this by hooking asbcli up to it, not the service catalog.  I'll do the full e2e test with the catalog tomorrow.

The ansibleplaybookbundle broker image was not working, but the ansibleapp broker images was. I'm assuming that image was under development when I pulled it.  I'll do testing with the ansibleplaybookbundle broker image again tomorrow.

