### PR TITLE
Workaround to shorten dockerhub registry name.

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -109,12 +109,17 @@ asb_template_url: https://raw.githubusercontent.com/openshift/ansible-service-br
 
 broker_registry_type: dockerhub
 broker_registry_url: docker.io
+# Need to shortern registry_name for short term due to below issue where podpreset
+# name needs to be under 63 chars
+#https://github.com/openshift/ansible-service-broker/issues/283
+broker_registry_name: dh
 broker_dev_broker: false
 broker_launch_apb_on_bind: false
 broker_output_request: false
 broker_recovery: true
 
 broker_tag: "latest"
+
 broker_image_name: docker.io/ansibleplaybookbundle/ansible-service-broker
 broker_image: "{{ broker_image_name }}:{{ broker_tag }}"
 

--- a/ansible/roles/ansible_service_broker_setup/tasks/main.yml
+++ b/ansible/roles/ansible_service_broker_setup/tasks/main.yml
@@ -34,6 +34,7 @@
       -p ETCD_PATH={{ etcd_path }}
       -p REGISTRY_TYPE={{ broker_registry_type }}
       -p REGISTRY_URL={{ broker_registry_url }}
+      -p REGISTRY_NAME={{ broker_registry_name }}
       -p DEV_BROKER={{ broker_dev_broker }}
       -p DOCKERHUB_ORG={{ dockerhub_org_name }}
       -p DOCKERHUB_PASS={{ dockerhub_user_password }}


### PR DESCRIPTION
Required so we can create a binding on postgres apb and consume it