### PR TITLE
option added to enable anyuid scc  - defaults to off

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -78,17 +78,7 @@ tmp_mount_point: "/tmp"
 cluster_user: admin
 cluster_user_password: admin
 cluster_system_admin: "system:admin"
-service_catalog_user: "system:serviceaccount:service-catalog:default"
 scc_anyuid: False
-
-service_catalog_tag: "canary"
-svc_cat_apiserver_img_no_tag: "quay.io/kubernetes-service-catalog/apiserver"
-svc_cat_apiserver_img: "{{ svc_cat_apiserver_img_no_tag }}:{{ service_catalog_tag }}"
-svc_cat_apiserver_tag: "apiserver:{{ service_catalog_tag }}"
-svc_cat_controller_mgr_img_no_tag: "quay.io/kubernetes-service-catalog/controller-manager"
-svc_cat_controller_mgr_img: "{{ svc_cat_controller_mgr_img_no_tag }}:{{ service_catalog_tag }}"
-svc_cat_controller_mgr_tag: "controller-manager:{{ service_catalog_tag }}"
-svc_cat_controller_mgr_relist_interval: "5m"
 
 
 oc_client_install_path: "/usr/local/bin"

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -79,6 +79,7 @@ cluster_user: admin
 cluster_user_password: admin
 cluster_system_admin: "system:admin"
 service_catalog_user: "system:serviceaccount:service-catalog:default"
+scc_anyuid: False
 
 service_catalog_tag: "canary"
 svc_cat_apiserver_img_no_tag: "quay.io/kubernetes-service-catalog/apiserver"

--- a/ansible/roles/openshift_setup/tasks/main.yml
+++ b/ansible/roles/openshift_setup/tasks/main.yml
@@ -312,7 +312,7 @@
 
   - name: Add anyuid scc to system:authenticated
     shell: "{{ oc_cmd }} adm policy add-scc-to-group anyuid system:authenticated"
-    when: oc_cluster_up.changed
+    when: oc_cluster_up.changed and scc_anyuid == True
 
   - name: Login as {{ cluster_user }}
     shell: "{{ oc_cmd }} login -u {{ cluster_user }} -p {{ cluster_user_password }}"

--- a/config/my_vars.yml.example
+++ b/config/my_vars.yml.example
@@ -12,3 +12,6 @@ dockerhub_org_name: example_org
 # you can modify the hostname and suffix here:
 # openshift_hostname: 172.17.0.1
 # openshift_routing_suffix: 172.17.0.1.nip.io
+
+# Default to the "anyuid" scc for pod deployments
+# scc_anyuid: True

--- a/local/linux/README.md
+++ b/local/linux/README.md
@@ -39,7 +39,7 @@ These playbooks will do the following in a local environment:
       ```
   * Install python dependencies
     ```bash
-    $ pip install six
+    $ pip install six==1.10.0 docker==2.4.2 ansible==2.3.0
     ```
 
 ### Execute


### PR DESCRIPTION
Adding `scc_anyuid: True` to the my_vars.yml file... will enable anyuid for authenticated users.

addresses this issue:
https://github.com/fusor/catasb/issues/91