### PR TITLE
configure broker with auth secret

### DIFF
--- a/ansible/roles/ansible_service_broker_setup/templates/ansible_service_broker.yaml.j2
+++ b/ansible/roles/ansible_service_broker_setup/templates/ansible_service_broker.yaml.j2
@@ -4,3 +4,7 @@ metadata:
   name: ansible-service-broker
 spec:
   url: https://{{ ansible_service_broker_route }}
+  authInfo:
+    basicAuthSecret:
+      namespace: ansible-service-broker
+      name: asb-auth-secret


### PR DESCRIPTION
Tell the service-catalog to use the asb-auth-secret when making api calls to the service-broker. This depends on PR [#308](https://github.com/openshift/ansible-service-broker/pull/308)