### PR TITLE
Fix misnamed playbook for the gate

### DIFF
--- a/local/gate/reset_environment.sh
+++ b/local/gate/reset_environment.sh
@@ -2,4 +2,4 @@
 
 source ../../gather_config
 
-ansible-playbook ${ANS_CODE}/setup_gate_environment.yml --extra-vars "${EXTRA_VARS}" ${extra_args} $@
+ansible-playbook ${ANS_CODE}/setup_local_environment.yml --extra-vars "${EXTRA_VARS}" ${extra_args} $@


### PR DESCRIPTION
In an early patch, the gate had its own playbook called
setup-gate-environment.yml, but it was combined with
setup-local-environment.yml.