### PR TITLE
Add origin- prefix to ansible-service-broker image

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -113,9 +113,8 @@ broker_enable_basic_auth: true
 broker_insecure_mode: false
 broker_endpoint_termination: Reencrypt
 
+broker_image_name: docker.io/ansibleplaybookbundle/origin-ansible-service-broker
 broker_tag: "latest"
-
-broker_image_name: docker.io/ansibleplaybookbundle/ansible-service-broker
 broker_image: "{{ broker_image_name }}:{{ broker_tag }}"
 
 


### PR DESCRIPTION
The work to create the origin-ansible-service-broker image has already
been done via Jenkins pipelines and automated builds on dockerhub. This
makes it so that automated environment setups get the correct image
(`origin-ansible-service-broker`).