### PR TITLE
Update get_oc_url.py to match the latest release of oc tool.

### DIFF
--- a/ansible/roles/openshift_setup/files/get_oc_url.py
+++ b/ansible/roles/openshift_setup/files/get_oc_url.py
@@ -22,7 +22,7 @@ class CientListHTMLParser(HTMLParser):
 
     def handle_data(self, data):
         if self.processing_anchor:
-            match = re.search('(\d+)\.(\d+)\.(\d+)\.(\d+)\.(\d+)', data) or re.search('(\d+)\.(\d+)\.(\d+)\.(\d+)', data) or re.search('(\d+)\.(\d+)\.(\d+)', data)
+            match = re.search('(\d+)\.(\d+)\.(\d+)\.(\d+)\.(\d+)', data) or re.search('(\d+)\.(\d+)\.(\d+)\.(\d+)', data) or re.search('(\d+)\.(\d+)\.(\d+)[^\-]', data)
             if match:
                 if self.latest_version is None:
                     self.latest_version = match.groups()


### PR DESCRIPTION
The latest version of the oc tool from openshift is `3.7.0-0.104.0` (for macosx anyway) which is throwing off the regex in this file. Updated it here to work around versions like this.

Before:
```
TASK [openshift_setup : debug] ********************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "openshift_client_release_url": "https://mirror.openshift.com/pub/openshift-v3/clients/3.7.0/macosx/oc.tar.gz"
}

TASK [openshift_setup : Delete previous downloaded client (readonly) file] ************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [openshift_setup : Delete previous decompressed client file] *********************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [openshift_setup : Download oc client "https://mirror.openshift.com/pub/openshift-v3/clients/3.7.0/macosx/oc.tar.gz"] ************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "dest": "/tmp/oc.tar.gz", "failed": true, "msg": "Request failed", "response": "HTTP Error 404: Not Found", "state": "absent", "status_code": 404, "url": "https://mirror.openshift.com/pub/openshift-v3/clients/3.7.0/macosx/oc.tar.gz"}
	to retry, use: --limit @/Users/pbrookes/repos/catasb/ansible/setup_local_environment.retry
```

After:
```
TASK [openshift_setup : debug] ********************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "openshift_client_release_url": "https://mirror.openshift.com/pub/openshift-v3/clients/3.6.173.0.7/macosx/oc.tar.gz"
}

TASK [openshift_setup : Delete previous downloaded client (readonly) file] ************************************************************************************************************************************************************************************************************************************************
changed: [localhost]

TASK [openshift_setup : Delete previous decompressed client file] *********************************************************************************************************************************************************************************************************************************************************
changed: [localhost]

TASK [openshift_setup : Download oc client "https://mirror.openshift.com/pub/openshift-v3/clients/3.6.173.0.7/macosx/oc.tar.gz"] ******************************************************************************************************************************************************************************************
changed: [localhost]
```