### PR TITLE
Update catasb to deploy openshift 3.7 images

### DIFF
--- a/ansible/roles/openshift_setup/defaults/main.yml
+++ b/ansible/roles/openshift_setup/defaults/main.yml
@@ -1,6 +1,7 @@
 reset_cluster: False
 openshift_release_url: https://github.com/openshift/origin/releases/download/v3.6.0-alpha.2
 openshift_client_release_ver: openshift-origin-client-tools-v3.6.0-alpha.2-3c221d5
+openshift_client_version: '3.6'
 oc_tools_dir: /usr/local/bin
 
 # Temporary fix until release version of oc client works with latest images.

--- a/ansible/roles/openshift_setup/files/get_oc_url.py
+++ b/ansible/roles/openshift_setup/files/get_oc_url.py
@@ -5,11 +5,13 @@ import sys
 import re
 from HTMLParser import HTMLParser
 
+oc_clients_url = 'https://mirror.openshift.com/pub/openshift-v3/clients/'
 
 class CientListHTMLParser(HTMLParser):
-    def __init__(self):
+    def __init__(self, version):
         HTMLParser.__init__(self)
         self.processing_anchor = False
+        self.version = version
         self.latest_version = None
 
     def handle_starttag(self, tag, attrs):
@@ -22,22 +24,9 @@ class CientListHTMLParser(HTMLParser):
 
     def handle_data(self, data):
         if self.processing_anchor:
-            match = re.search('(\d+)\.(\d+)\.(\d+)\.(\d+)\.(\d+)', data) or re.search('(\d+)\.(\d+)\.(\d+)\.(\d+)', data) or re.search('(\d+)\.(\d+)\.(\d+)[^\-]', data)
-            if match:
-                if self.latest_version is None:
-                    self.latest_version = match.groups()
-                else:
-                    for idx, version_str in enumerate(match.groups()):
-                        if idx >= len(self.latest_version):
-                            self.latest_version = match.groups()
-                            break
-                        latest = int(self.latest_version[idx])
-                        current = int(version_str)
-                        if current > latest:
-                            self.latest_version = match.groups()
-                            break
-                        if version_str < self.latest_version[idx]:
-                            break
+            # We are counting on the client list to already be sorted from low to high
+            if re.search('^' + self.version, data):
+                self.latest_version = data
 
 if re.match('linux', sys.platform):
     platform = 'linux'
@@ -46,12 +35,12 @@ elif re.match('darwin', sys.platform):
 else:
     sys.exit(1)
 
-client_list_html = urllib.urlopen('https://mirror.openshift.com/pub/openshift-v3/clients/').read()
+client_list_html = urllib.urlopen(oc_clients_url).read()
 
-parser = CientListHTMLParser()
+parser = CientListHTMLParser(sys.argv[1])
 parser.feed(client_list_html)
 if parser.latest_version is None:
     sys.exit(1)
-version = '.'.join(parser.latest_version)
-sys.stdout.write('https://mirror.openshift.com/pub/openshift-v3/clients/' + version + '/' + platform + '/oc.tar.gz')
+version = parser.latest_version
+sys.stdout.write(oc_clients_url + version + platform + '/oc.tar.gz')
 sys.stdout.flush()

--- a/ansible/roles/openshift_setup/tasks/main.yml
+++ b/ansible/roles/openshift_setup/tasks/main.yml
@@ -46,7 +46,7 @@
 
   # Temporary fix until release version of oc client is stable
   - name: Get URL of latest version of oc client packaged by OpenShift
-    script: get_oc_url.py
+    script: get_oc_url.py "{{ openshift_client_version }}"
     register: get_oc_url_output
 
   - set_fact:

--- a/config/my_vars.yml.example
+++ b/config/my_vars.yml.example
@@ -8,6 +8,10 @@ dockerhub_org_name: example_org
 # Omit this unless you want to store your password in plain text to skip prompts.
 # dockerhub_user_password: example_password
 
+# To use openshift origin 3.7, uncomment these lines
+# origin_image_tag: latest # or v3.7.0-alpha.1
+# openshift_client_version: '3.7'
+
 # You can override other variables as needed.  For example to change your OpenShift hostname
 # you can modify the hostname and suffix here:
 # openshift_hostname: 172.17.0.1


### PR DESCRIPTION
In order for catasb to deploy openshift 3.7, you must get the 3.7 client
and grab the latest openshift-origin images.

- Update the `get_oc_url.py` to get the latest client based on version,
  only tested with 3.6/3.7 but should just work with other versions.
- Update the openshift setup "get url" task to default to getting the
  3.6' client.
- Update the my_vars.yml.example file to show how to launch openshift
  origin 3.7 + ansible service broker.