### PR TITLE
Support latest service-catalog in OS 3.7

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -112,6 +112,7 @@ broker_recovery: true
 broker_enable_basic_auth: true
 broker_insecure_mode: false
 broker_insecure_edge: None
+broker_ssl: true
 broker_endpoint_termination: Reencrypt
 broker_bootstrap_refresh_interval: 600s
 broker_sandbox_role: edit

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -111,6 +111,7 @@ broker_output_request: false
 broker_recovery: true
 broker_enable_basic_auth: true
 broker_insecure_mode: false
+broker_insecure_edge: None
 broker_endpoint_termination: Reencrypt
 broker_bootstrap_refresh_interval: 600s
 broker_sandbox_role: edit
@@ -166,3 +167,6 @@ docker_images_group2:
   - { img: "{{ origin_image_name }}-pod", tag: "{{ origin_image_tag }}" }
   - { img: "{{ origin_image_name }}-haproxy-router", tag: "{{ origin_image_tag }}" }
   - { img: "{{ origin_image_name }}-service-catalog", tag: "{{ origin_image_tag }}" }
+
+coalmine_apiserver: quay.io/kubernetes-service-catalog/apiserver:canary
+coalmine_controller: quay.io/kubernetes-service-catalog/controller-manager:canary

--- a/ansible/roles/ansible_service_broker_setup/tasks/main.yml
+++ b/ansible/roles/ansible_service_broker_setup/tasks/main.yml
@@ -32,6 +32,14 @@
     register: new_asb_project
     when: project.stdout.find( asb_project ) == -1
 
+  - name: Update broker settings if not using ssl
+    set_fact:
+      asb_scheme: http
+      broker_endpoint_termination: edge
+      broker_insecure_mode: true
+      broker_insecure_edge: Allow
+    when: not broker_ssl
+
   - name: Check that termination and insecure settings will work
     fail:
       msg: "The current configuration of termination: {{ broker_endpoint_termination|lower }}

--- a/ansible/roles/ansible_service_broker_setup/tasks/main.yml
+++ b/ansible/roles/ansible_service_broker_setup/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+  - name: Waiting 1 minutes for service-catalog
+    action: >-
+      shell "{{ oc_cmd }}" get deployments -n {{ oc_service_catalog }} apiserver
+      -o go-template={% raw %}'{{ .status.availableReplicas }}'{% endraw %}
+    register: apiserver_deployment
+    until: apiserver_deployment.stdout == '1'
+    retries: 6
+    delay: 10
+
   - name: Curling ansible-service-broker-all.yaml
     get_url:
       url: "{{ asb_template_url }}"

--- a/ansible/roles/ansible_service_broker_setup/tasks/main.yml
+++ b/ansible/roles/ansible_service_broker_setup/tasks/main.yml
@@ -82,6 +82,8 @@
         -p TAG={{ apbtag | default('latest') }}
         -p SANDBOX_ROLE={{ broker_sandbox_role }}
         -p IMAGE_PULL_POLICY={{ broker_pull_policy }}
+        {% if broker_kind is defined %}-p BROKER_KIND={{ broker_kind }}{% endif %}
+        {% if broker_auth is defined %}-p BROKER_AUTH='{{ broker_auth }}'{% endif %}
     when: "not rcm"
 
   - name: Process template "{{ local_target_asb_template }}"

--- a/ansible/roles/ansible_service_broker_setup/tasks/main.yml
+++ b/ansible/roles/ansible_service_broker_setup/tasks/main.yml
@@ -77,6 +77,7 @@
         -p REGISTRY_NAME={{ broker_registry_name }}
         -p ENABLE_BASIC_AUTH={{ broker_enable_basic_auth }}
         -p INSECURE={{ broker_insecure_mode|lower }}
+        -p INSECURE_EDGE={{ broker_insecure_edge }}
         -p TERMINATION={{ broker_endpoint_termination }}
         -p REFRESH_INTERVAL={{ broker_bootstrap_refresh_interval }}
         -p TAG={{ apbtag | default('latest') }}
@@ -85,6 +86,14 @@
         {% if broker_kind is defined %}-p BROKER_KIND={{ broker_kind }}{% endif %}
         {% if broker_auth is defined %}-p BROKER_AUTH='{{ broker_auth }}'{% endif %}
     when: "not rcm"
+
+  - name: Update Broker Kind and Auth when using coalmine
+    set_fact:
+      cmd_process_asb_template: >-
+        {{ cmd_process_asb_template }}
+        -p BROKER_KIND='ServiceBroker'
+        -p BROKER_AUTH='{ "basic": { "secretRef": { "namespace": "ansible-service-broker", "name": "asb-auth-secret" } } }'
+    when: coalmine is defined and coalmine
 
   - name: Process template "{{ local_target_asb_template }}"
     shell: >

--- a/ansible/roles/env_hacks/tasks/main.yml
+++ b/ansible/roles/env_hacks/tasks/main.yml
@@ -24,6 +24,9 @@
     become: true
 
   - block:
+    - name: Give service-catalog permissions it needs
+      shell: "{{ oc_cmd }} adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:{{ oc_service_catalog }}:service-catalog-controller"
+
     - block:
       - name: Update service-catalog (OpenShift 3.6)
         block:

--- a/ansible/roles/env_hacks/tasks/main.yml
+++ b/ansible/roles/env_hacks/tasks/main.yml
@@ -25,21 +25,36 @@
 
   - block:
     - block:
-      - name: Workaround canary permissions issue
-        shell: "{{ oc_cmd }} adm policy add-cluster-role-to-user cluster-admin system:anonymous"
+      - name: Update service-catalog (OpenShift 3.6)
+        block:
+          - name: Workaround canary permissions issue
+            shell: "{{ oc_cmd }} adm policy add-cluster-role-to-user cluster-admin system:anonymous"
 
-      - name: Get current apiserver args and update them
-        shell: "{{ oc_cmd }} export -n service-catalog deployment apiserver -o json | python -c 'import json, sys; args=json.load(sys.stdin)[\"spec\"][\"template\"][\"spec\"][\"containers\"][0][\"args\"]; args.remove(\"--insecure-bind-address\"); args.remove(\"0.0.0.0\"); args.remove(\"--insecure-port\"); args.remove(\"8081\"); print json.dumps(args)'"
-        register: arglist
+          - name: Get current apiserver args and update them
+            shell: "{{ oc_cmd }} export -n {{ oc_service_catalog }} deployment apiserver -o json | python -c 'import json, sys; args=json.load(sys.stdin)[\"spec\"][\"template\"][\"spec\"][\"containers\"][0][\"args\"]; args.remove(\"--insecure-bind-address\"); args.remove(\"0.0.0.0\"); args.remove(\"--insecure-port\"); args.remove(\"8081\"); print json.dumps(args)'"
+            register: arglist
 
-      - name: Use canary apiserver
-        shell: "{{ oc_cmd }} patch -n service-catalog deployment/apiserver -p '{\"spec\":{\"template\": {\"spec\": {\"containers\": [{\"name\":\"apiserver\",\"image\":\"{{ coalmine_apiserver }}\", \"command\": [\"/opt/services/apiserver\"], \"args\": {{ arglist.stdout }} }]}}}}'"
+          - name: Use canary apiserver
+            shell: "{{ oc_cmd }} patch -n {{ oc_service_catalog }} deployment/apiserver -p '{\"spec\":{\"template\": {\"spec\": {\"containers\": [{\"name\":\"apiserver\",\"image\":\"{{ coalmine_apiserver }}\", \"command\": [\"/opt/services/apiserver\"], \"args\": {{ arglist.stdout }} }]}}}}'"
 
-      - name: Get current controller-manager args and update them
-        shell: "{{ oc_cmd }} export -n service-catalog deployment controller-manager -o json | python -c 'import json, sys; args=json.load(sys.stdin)[\"spec\"][\"template\"][\"spec\"][\"containers\"][0][\"args\"]; args.remove(\"--service-catalog-api-server-url\"); args.remove(\"http://$(APISERVER_SERVICE_HOST):$(APISERVER_SERVICE_PORT)\"); args.append(\"--service-catalog-api-server-url\"); args.append(\"https://$(APISERVER_SERVICE_HOST):$(APISERVER_PORT_443_TCP_PORT)\"); args.append(\"--service-catalog-insecure-skip-verify\"); print json.dumps(args)'"
-        register: arglist
+          - name: Get current controller-manager args and update them
+            shell: "{{ oc_cmd }} export -n {{ oc_service_catalog }} deployment controller-manager -o json | python -c 'import json, sys; args=json.load(sys.stdin)[\"spec\"][\"template\"][\"spec\"][\"containers\"][0][\"args\"]; args.remove(\"--service-catalog-api-server-url\"); args.remove(\"http://$(APISERVER_SERVICE_HOST):$(APISERVER_SERVICE_PORT)\"); args.append(\"--service-catalog-api-server-url\"); args.append(\"https://$(APISERVER_SERVICE_HOST):$(APISERVER_PORT_443_TCP_PORT)\"); args.append(\"--service-catalog-insecure-skip-verify\"); print json.dumps(args)'"
+            register: arglist
 
-      - name: Use canary controller-manager
-        shell: "{{ oc_cmd }} patch -n service-catalog deployment/controller-manager -p '{\"spec\":{\"template\": {\"spec\": {\"containers\": [{\"name\":\"controller-manager\",\"image\":\"{{ coalmine_controller }}\", \"command\": [\"/opt/services/controller-manager\"], \"args\": {{ arglist.stdout }} }]}}}}'"
+          - name: Use canary controller-manager
+            shell: "{{ oc_cmd }} patch -n {{ oc_service_catalog }} deployment/controller-manager -p '{\"spec\":{\"template\": {\"spec\": {\"containers\": [{\"name\":\"controller-manager\",\"image\":\"{{ coalmine_controller }}\", \"command\": [\"/opt/services/controller-manager\"], \"args\": {{ arglist.stdout }} }]}}}}'"
+        when: openshift_client_version == '3.6'
+
+      - name: Update service-catalog (OpenShift 3.7)
+        block:
+        - name: Workaround canary permissions issue
+          shell: "{{ oc_cmd }} adm policy add-cluster-role-to-user cluster-admin system:anonymous"
+
+        - name: Use canary apiserver
+          shell: "{{ oc_cmd }} patch -n {{ oc_service_catalog }} deployment/apiserver -p '{\"spec\":{\"template\": {\"spec\": {\"containers\": [{\"name\":\"apiserver\",\"image\":\"{{ coalmine_apiserver }}\", \"command\": [\"/opt/services/apiserver\"] }]}}}}'"
+
+        - name: Use canary controller-manager
+          shell: "{{ oc_cmd }} patch -n {{ oc_service_catalog }} deployment/controller-manager -p '{\"spec\":{\"template\": {\"spec\": {\"containers\": [{\"name\":\"controller-manager\",\"image\":\"{{ coalmine_controller }}\", \"command\": [\"/opt/services/controller-manager\"]}]}}}}'"
+        when: openshift_client_version == '3.7'
       when: coalmine
     when: coalmine is defined

--- a/ansible/roles/openshift_setup/tasks/main.yml
+++ b/ansible/roles/openshift_setup/tasks/main.yml
@@ -390,4 +390,3 @@
     fail:
       msg: "Failed to get the service-catalog project"
     when: oc_service_catalog == ""
-

--- a/ansible/roles/openshift_setup/tasks/main.yml
+++ b/ansible/roles/openshift_setup/tasks/main.yml
@@ -374,3 +374,20 @@
   - name: Login as {{ cluster_user }}
     shell: "{{ oc_cmd }} login -u {{ cluster_user }} -p {{ cluster_user_password }}"
     when: oc_cluster_up.changed
+
+  - name: Get the name for service-catalog project
+    shell: "{{ oc_cmd }} get projects --no-headers | grep 'service-catalog' | awk '{ printf \"%s\", $1}'"
+    register: oc_sc_project
+
+  - name: Save name for service-catalog project
+    set_fact:
+      oc_service_catalog: "{{ oc_sc_project.stdout }}"
+
+  - debug:
+      msg: "Looking at service-catalog project name {{ oc_service_catalog }}"
+
+  - name: Fail if service-catalog project does not exit
+    fail:
+      msg: "Failed to get the service-catalog project"
+    when: oc_service_catalog == ""
+

--- a/config/my_vars.yml.example
+++ b/config/my_vars.yml.example
@@ -22,6 +22,8 @@ dockerhub_org_name: example_org
 
 # Use the quay.io canary images for bleeding edge development
 # coalmine: true
+
+# Override the service-catalog's apiserver + controller images
 # coalmine_apiserver: quay.io/kubernetes-service-catalog/apiserver:canary
 # coalmine_controller: quay.io/kubernetes-service-catalog/controller-manager:canary
 


### PR DESCRIPTION
Update the ansible service broker setup to wait for the service-catalog
to be available. This prevents a race condition when we are working with
coalmine and the service-catalog (giving it time to redeploy).