### PR TITLE
remove duplicated }"

### DIFF
--- a/config/mac_env_vars
+++ b/config/mac_env_vars
@@ -5,4 +5,4 @@ sudo ifconfig lo0 alias ${PUBLIC_IP}
 export HOSTNAME="${PUBLIC_IP}"
 export OPENSHIFT_ROUTING_SUFFIX="${PUBLIC_IP}.nip.io"
 
-export EXTRA_VARS="{\"hostname\":\"${HOSTNAME}\", \"openshift_routing_suffix\":\"${OPENSHIFT_ROUTING_SUFFIX}\", \"cluster\":\"${CLUSTER}\" }" }"
+export EXTRA_VARS="{\"hostname\":\"${HOSTNAME}\", \"openshift_routing_suffix\":\"${OPENSHIFT_ROUTING_SUFFIX}\", \"cluster\":\"${CLUSTER}\" }"


### PR DESCRIPTION
```unexpected EOF while looking for matching `"'```

looks like a copy paste error that was introduced in the [latest commit](https://github.com/fusor/catasb/commit/78c4e35e45a61dcc953ef018d90be77220e1298a#diff-d5898cae480808679f10826637f0a64fR8)