### PR TITLE
Fix k8s template url link

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -97,7 +97,7 @@ asb_project: ansible-service-broker
 # remember to use a file:// path as in:
 # asb_template_url: file:///path/to/file/deploy.yaml.j2
 asb_template_url: https://raw.githubusercontent.com/openshift/ansible-service-broker/master/templates/deploy-ansible-service-broker.template.yaml
-k8s_asb_template_url: https://raw.githubusercontent.com/rthallisey/ansible-service-broker/kube-template/templates/k8s-ansible-service-broker.yaml.j2
+k8s_asb_template_url: https://raw.githubusercontent.com/openshift/ansible-service-broker/master/templates/k8s-ansible-service-broker.yaml.j2
 
 broker_registry_type: dockerhub
 broker_registry_url: docker.io


### PR DESCRIPTION
The url link the k8s template was set to a patch that hadn't merged yet.
Change the link the proper location.