### PR TITLE
[RFC]Add option to deploy OpenShift ACME Controller

### DIFF
--- a/ansible/roles/acme_controller_setup/defaults/main.yml
+++ b/ansible/roles/acme_controller_setup/defaults/main.yml
@@ -1,0 +1,8 @@
+acme_tag: "latest"
+acme_image_url: "docker.io/appuio/openshift-acme"
+acme_image: "{{ acme_image_url }}:{{ acme_tag }}"
+
+acme_url: https://acme-staging.api.letsencrypt.org/directory
+acme_selfservicename: acme-controller
+acme_selfservicenamespace:  "{{ acme_selfservicename }}"
+acme_loglevel: "8"

--- a/ansible/roles/acme_controller_setup/tasks/main.yml
+++ b/ansible/roles/acme_controller_setup/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+  - name: Docker pull {{ acme_image }}
+    docker_image:
+      name: "{{ acme_image }}"
+    register: docker_pull_acme_controller
+
+  - name: Docker tag acme-controller
+    shell: docker tag {{ acme_image }} {{ acme_tag }}
+
+  - name: check if the acme-controller project exists
+    shell: "{{ oc_cmd }} get project --no-headers=true | awk '{ print $1 }' | grep -E '^{{ acme_selfservicenamespace }}( |$)' | cat"
+    register: acme_project
+
+  - name: Create a new project for the acme-controller
+    shell: "{{ oc_cmd }} new-project {{ acme_selfservicenamespace }}"
+    register: new_acme_controller_project
+    when: acme_project.stdout.find( "{{ acme_selfservicenamespace }}" ) == -1
+
+  - name: check if the apiserver deployment exists
+    shell: "{{ oc_cmd }} get deployment -n acme-controller --no-headers=true | awk '{ print $1}' | grep -E '^acme-controller( |$)' | cat"
+    register: acme_deployment
+
+  - name: Creating acme-cluster-controller.templ.yaml
+    template:
+      src: acme_controller.templ.yaml.j2
+      dest: /tmp/acme-cluster-controller.templ.yaml
+    register: copy_acme_controller_tmp
+    when: acme_deployment.stdout.find( "acme-controller" ) == -1
+
+  - name: Install ACME Controller through OC Template
+    shell: "{{ oc_cmd }} process -f /tmp/acme-cluster-controller.templ.yaml | {{ oc_cmd }} create -f -"
+    when: new_acme_controller_project|succeeded and acme_deployment.stdout.find( "acme-controller" ) == -1
+
+  - name: Waiting 10 minutes for ACME controller pod to come up
+    action:
+      shell "{{ oc_cmd }}" get pods -n acme-controller | grep -qiEm1 "acme-controller.*?running"
+    register: wait_for_acme_controller_running
+    until: wait_for_acme_controller_running.rc == 0
+    retries: 60
+    delay: 10

--- a/ansible/roles/acme_controller_setup/templates/acme_controller.templ.yaml.j2
+++ b/ansible/roles/acme_controller_setup/templates/acme_controller.templ.yaml.j2
@@ -1,0 +1,179 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: acme-controller
+parameters:
+- description: ACME Endpoint URL
+  name: OPENSHIFT_ACME_ACMEURL
+  value: {{ acme_url }}
+- description: Controller loglevel
+  name: OPENSHIFT_ACME_LOGLEVEL
+  value: "{{ acme_loglevel }}"
+- description: Name of the service pointing to ACME controller
+  name: OPENSHIFT_ACME_SELFSERVICENAME
+  value: {{ acme_selfservicename }}
+- description: Name of the namespace to instantiate the ACME controller under. Defaults to 'acme-controller'.
+  name: OPENSHIFT_ACME_SELFSERVICENAMESPACE
+  value: {{ acme_selfservicenamespace }}
+- description: Docker Image of ACME controller
+  name: DOCKER_IMAGE
+  value: {{ acme_image_url }}
+- description: Docker Image Tag of ACME controller
+  name: DOCKER_IMAGE_TAG
+  value: {{ acme_tag }}
+objects:
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: acme-controller
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    name: acme-controller
+  rules:
+  - apiGroups:
+    - ""
+    - "route.openshift.io"
+    resources:
+    - endpoints
+    - endpoints/restricted
+    - events
+    - routes
+    - routes/custom-host
+    - routes/status
+    - secrets
+    - services
+    verbs:
+    - '*'
+  - apiGroups:
+    - ""
+    resources:
+    - namespaces
+    verbs:
+    - get
+    - list
+    - watch
+- apiVersion: v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: acme-controller
+    labels:
+      app: acme-controller
+  roleRef:
+    kind: ClusterRole
+    name: acme-controller
+  subjects:
+  - kind: ServiceAccount
+    name: acme-controller
+    namespace: ${OPENSHIFT_ACME_SELFSERVICENAMESPACE}
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: acme-controller
+    labels:
+      type: acme-controller
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/imported-from: ${DOCKER_IMAGE}:${DOCKER_IMAGE_TAG}
+      from:
+        kind: DockerImage
+        name: ${DOCKER_IMAGE}:${DOCKER_IMAGE_TAG}
+      importPolicy:
+        scheduled: true
+      name: latest
+      referencePolicy:
+        type: Source
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: acme-controller
+    name: acme-controller
+  spec:
+    replicas: 1
+    selector:
+      app: acme-controller
+    strategy:
+      activeDeadlineSeconds: 21600
+      recreateParams:
+        timeoutSeconds: 600
+      resources: {}
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          app: acme-controller
+      spec:
+        containers:
+        - env:
+          - name: OPENSHIFT_ACME_ACMEURL
+            value: ${OPENSHIFT_ACME_ACMEURL}
+          - name: OPENSHIFT_ACME_LOGLEVEL
+            value: ${OPENSHIFT_ACME_LOGLEVEL}
+          - name: OPENSHIFT_ACME_SELFSERVICENAME
+            value: ${OPENSHIFT_ACME_SELFSERVICENAME}
+          - name: OPENSHIFT_ACME_SELFSERVICENAMESPACE
+            value: ${OPENSHIFT_ACME_SELFSERVICENAMESPACE}
+          image: acme-controller:latest
+          imagePullPolicy: IfNotPresent
+          name: acme-controller
+          ports:
+          - containerPort: 80
+            protocol: TCP
+          resources:
+            limits:
+              cpu: '500m'
+              memory: '512Mi'
+            requests:
+              cpu: '500m'
+              memory: '512Mi'
+          livenessProbe:
+            tcpSocket:
+              port: 5000
+            initialDelaySeconds: 10
+            timeoutSeconds: 2
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 5000
+            initialDelaySeconds: 10
+            timeoutSeconds: 2
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+        serviceAccountName: acme-controller
+    test: false
+    triggers:
+    - type: ImageChange
+      imageChangeParams:
+        automatic: true
+        containerNames:
+        - acme-controller
+        from:
+          kind: ImageStreamTag
+          name: acme-controller:latest
+    - type: ConfigChange
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: acme-controller
+  spec:
+    ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 5000
+    selector:
+      app: acme-controller

--- a/ansible/setup_environment.yml
+++ b/ansible/setup_environment.yml
@@ -20,6 +20,8 @@
     - name: Setting fact of security group id
       set_fact:
         my_security_group_id: "{{ hostvars.localhost.my_ec2_facts.instances[0].groups[0].id }}"
+  vars:
+    acme: False
   vars_prompt:
     - name: dockerhub_user_name
       prompt: "Enter your dockerhub username: "
@@ -40,6 +42,7 @@
     - env_hacks
     - ansible_service_broker_setup
     - demo_prep
+    - { role: acme_controller_setup, when: acme }
   post_tasks:
     - set_fact:
         msg: |

--- a/ansible/setup_local_environment.yml
+++ b/ansible/setup_local_environment.yml
@@ -3,6 +3,7 @@
   vars:
     demo: False
     broker_ci: False
+    acme: False
   vars_prompt:
     - name: dockerhub_user_name
       prompt: "Enter your dockerhub username"
@@ -17,6 +18,7 @@
     - "{{ cluster }}_setup"
     - { role: ansible_service_broker_setup, when: not broker_ci }
     - { role: local_demo_prep, when: demo }
+    - { role: acme_controller_setup, when: acme }
   post_tasks:
     - set_fact:
         msg: |

--- a/config/my_vars.yml.example
+++ b/config/my_vars.yml.example
@@ -17,6 +17,11 @@ dockerhub_org: ansibleplaybookbundle
 # openshift_hostname: 172.17.0.1
 # openshift_routing_suffix: 172.17.0.1.nip.io
 
+# OpenShift ACME Controller
+# Requires openshift_hostname and openshift_routing_suffix
+# be set and resolveable. To use it, uncomment the following line:
+# acme: true
+
 # Default to the "anyuid" scc for pod deployments.
 # scc_anyuid: true
 


### PR DESCRIPTION
This adds an `acme` var to deploy openshift-acme

I added the now redundant pr https://github.com/openshift/origin/pull/16393 a few days ago,
but maybe a bleeding edge feature like [openshift-acme](https://github.com/tnozicka/openshift-acme) better lives here while it's being tested and hardened.

Provisioning of the controller has been tested successfully, however I would appreciate if someone tested this to see if obtaining a lets encrypt cert on a route with a resolveable FQDN & IP works, too (by provisioning a route annotated like this:)
```
metadata:
  annotations:
    kubernetes.io/tls-acme: "true"
```

Potentially interested parties:
@tnozicka @dustymabe