### PR TITLE
Fix facts using jinja2 templating in when clause

### DIFF
--- a/ansible/setup_local_environment.yml
+++ b/ansible/setup_local_environment.yml
@@ -21,11 +21,11 @@
             Hostname:                  {{ hostname }}
             Web: https://{{ hostname }}:8443
             CLI: oc login --insecure-skip-tls-verify {{ hostname }}:8443 -u {{ cluster_user }} -p {{ cluster_user_password }}
-      when: "'{{ cluster }}' == 'openshift'"
+      when: cluster == 'openshift'
     - set_fact:
         msg: |
             Hostname:                  {{ hostname }}
             Kubernetes Cluster is running at http://{{ hostname }}:6443
-      when: "'{{ cluster }}' == 'kubernetes'"
+      when: cluster == 'kubernetes'
     - debug:
         msg: "{{ msg.split('\n') }}"


### PR DESCRIPTION
When statements should not include jinja2 templating.

Before fix:

```
TASK [set_fact]
**********************************************************************************************************************************************
 [WARNING]: when statements should not include jinja2 templating
 delimiters such as {{ }} or {% %}. Found: '{{ cluster }}' ==
 'openshift'

 ok: [localhost]

 TASK [set_fact]
 **********************************************************************************************************************************************
  [WARNING]: when statements should not include jinja2 templating
  delimiters such as {{ }} or {% %}. Found: '{{ cluster }}' ==
  'kubernetes'
```

After fix:

```
TASK [set_fact]
**********************************************************************************************************************************************
ok: [localhost]

TASK [set_fact]
**********************************************************************************************************************************************
skipping: [localhost]
```