### PR TITLE
Add explicit cluster_url with oc login

### DIFF
--- a/ansible/roles/openshift_setup/tasks/main.yml
+++ b/ansible/roles/openshift_setup/tasks/main.yml
@@ -355,7 +355,7 @@
     when: oc_cluster_up.changed and scc_anyuid == True
 
   - name: Login as {{ cluster_user }}
-    shell: "{{ oc_cmd }} login -u {{ cluster_user }} -p {{ cluster_user_password }}"
+    shell: "{{ oc_cmd }} login -u {{ cluster_user }} -p {{ cluster_user_password }} {{ cluster_url }} --insecure-skip-tls-verify=true"
     when: oc_cluster_up.changed
 
   - name: Get the name for service-catalog project


### PR DESCRIPTION
This PR fixes the issue I've hit recently when trying to deploy latest 3.7 origin builds with our ec2 scripts which replace the cluster cert with letsencrypt signed certificates.  I think the replacement of the CA may be causing issues.

I changed these variables in  my_vars.yml
origin_image_tag: latest
openshift_client_version: latest

./run_setup_environment.sh
...
<snip>
...

TASK [openshift_setup : Login as admin] *******************************************************************************
fatal: [34.233.221.91]: FAILED! => {"changed": true, "cmd": "/usr/bin/oc login -u admin -p admin", "delta": "0:00:00.177283", "end": "2017-10-01 13:56:55.907736", "failed": true, "rc": 1, "start": "2017-10-01 13:56:55.730453", "stderr": "error: x509: certificate signed by unknown authority", "stderr_lines": ["error: x509: certificate signed by unknown authority"], "stdout": "", "stdout_lines": []}


If I log into the instance I see same error trying to execute "oc login":

[ec2-user@ip-10-0-0-70 ~]$ sudo su -
[root@ip-10-0-0-70 ~]# oc login
error: x509: certificate signed by unknown authority


Part of the problem was that the default context specified the 127.0.0.1 entry in ~/.kube/config, so I added an explicit cluster_url.

Have tested this with both ec2 and local/linux deployments.



