### PR TITLE
Fix libselinux package install issues

### DIFF
--- a/ansible/roles/openshift_setup/tasks/main.yml
+++ b/ansible/roles/openshift_setup/tasks/main.yml
@@ -48,7 +48,8 @@
   - package:
       name: "libselinux-python"
       state: installed
-    when: ansible_os_family == "RedHat" and ansible_selinux.mode == "enforcing"
+    become: true
+    when: ansible_os_family == "RedHat"
 
   - file:
       path: "{{ oc_tools_dir }}"


### PR DESCRIPTION
`and ansible_selinux.mode == "enforcing"` only works if `libselinux-python` is already installed.

I also needed `become: true` to get this to run with sudo.

