### PR TITLE
Force origin-service-catalog image to be refreshed on each run

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -156,6 +156,7 @@ asb_scheme: https
 # These docker images we want to remove and fetch on each setup
 docker_images_group1:
   - { img: "{{ broker_image_name }}", tag: "{{ broker_tag }}" }
+  - { img: "{{ origin_image_name }}-service-catalog", tag: "{{ origin_image_tag }}" }
 
 # These docker images change less frequently, we are OK pulling them once and reusing
 docker_images_group2:
@@ -166,7 +167,6 @@ docker_images_group2:
   - { img: "{{ origin_image_name }}-docker-registry", tag: "{{ origin_image_tag }}" }
   - { img: "{{ origin_image_name }}-pod", tag: "{{ origin_image_tag }}" }
   - { img: "{{ origin_image_name }}-haproxy-router", tag: "{{ origin_image_tag }}" }
-  - { img: "{{ origin_image_name }}-service-catalog", tag: "{{ origin_image_tag }}" }
 
 coalmine_apiserver: quay.io/kubernetes-service-catalog/apiserver:canary
 coalmine_controller: quay.io/kubernetes-service-catalog/controller-manager:canary


### PR DESCRIPTION
With this PR applied we will see that the existing service catalog image is deleted and re-fetched on each run.

Example:


TASK [openshift_setup : Removing certain docker images if they exist so we are sure we are pulling latest] ************
changed: [localhost] => (item={u'tag': u'latest', u'img': u'docker.io/ansibleplaybookbundle/origin-ansible-service-broker'})
changed: [localhost] => (item={u'tag': u'latest', u'img': u'docker.io/openshift/origin-service-catalog'})

TASK [openshift_setup : Pulling all docker images we require] *********************************************************
changed: [localhost] => (item={u'tag': u'latest', u'img': u'docker.io/ansibleplaybookbundle/origin-ansible-service-broker'})
changed: [localhost] => (item={u'tag': u'latest', u'img': u'docker.io/openshift/origin-service-catalog'})
