### PR TITLE
defaulting auto escalate to false

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -113,7 +113,7 @@ broker_enable_basic_auth: false
 broker_bootstrap_refresh_interval: 600s
 broker_sandbox_role: edit
 broker_pull_policy: "IfNotPresent"
-broker_auto_escalate: true
+broker_auto_escalate: false
 
 broker_image_name: docker.io/ansibleplaybookbundle/origin-ansible-service-broker
 broker_tag: "latest"


### PR DESCRIPTION
Update the auto escalate parameter to default to false.

This is helping CATASB match downstream environments for testing. 