### PR TITLE
Ignore etcd RC when restarting ASB.

### DIFF
--- a/ansible/roles/helios_broker_setup/tasks/create_secrets.yml
+++ b/ansible/roles/helios_broker_setup/tasks/create_secrets.yml
@@ -52,7 +52,7 @@
     shell: "{{ oc_cmd }} rollout latest aws-asb"
 
   - name: Get name of latest RC for aws-asb
-    shell: "{{ oc_cmd }} get rc --no-headers --sort-by=\".metadata.name\" -n {{ helios_asb_project }} |tail -n1|awk '{print $1}'"
+    shell: "{{ oc_cmd }} get rc --no-headers --sort-by=\".metadata.name\" -n {{ helios_asb_project }} | grep -v etcd | tail -n1|awk '{print $1}'"
     register: rc_latest_name
 
   - name: Waiting up to 10 minutes for the ASB pod to restart ...


### PR DESCRIPTION
Helios was accidentally getting the wrong RC when checking to ASB has restarted.  This would go straight through, do a relist, and then query the wrong log (the etcd log) for the filtered secret message.