### PR TITLE
Add support for outbound squid proxy on EC2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CATalogASB
 
-catasb is a collection of playbooks to create an OpenShift environment with a [Service Catalog](https://github.com/kubernetes-incubator/service-catalog) & [Ansible Service Broker](https://github.com/openshift/ansible-service-broker) in a local or EC-2 environment.
+catasb is a collection of playbooks to create an OpenShift environment with a [Service Catalog](https://github.com/kubernetes-incubator/service-catalog) & [Ansible Service Broker](https://github.com/openshift/ansible-service-broker) in a local or EC2 environment.
 
 
 For an overview of Ansible Service Broker and Ansible Playbook Bundles click [here](https://github.com/openshift/ansible-service-broker/blob/master/docs/introduction.md)
@@ -21,12 +21,12 @@ OpenShift
   * OpenShift doesn't require any flags to run
 
 
-### Local and EC-2 deployment options
+### Local and EC2 deployment options
   * To view individual Readme documents for these options click below
   * [Kubernetes setup](kubernetes/README.md)
   * [Local Linux deployment](local/linux/README.md)
   * [Local macOS deployment](local/mac/README.md)
-  * [EC-2 deployment](ec2/README.md)
+  * [EC2 deployment](ec2/README.md)
 
 
 ### Summit 2017 demo

--- a/ansible/display_aws_information.yml
+++ b/ansible/display_aws_information.yml
@@ -21,5 +21,13 @@
           "tag:Name": "*{{ aws_custom_prefix }}*"
         region: "{{ aws_region }}"
       register: my_ec2_facts
+    - name: Get EC2 Remote Facts for proxy instance
+      ec2_remote_facts:
+        filters:
+          instance-state-name: running
+          "tag:Name": "{{ proxy_instance_name }}"
+        region: "{{ aws_region }}"
+      register: proxy_ec2_facts
+      when: ec2_use_proxy
   roles:
     - aws_display_info

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -7,6 +7,7 @@ instance_lookup_value: ""
 aws_username: "ec2-user"
 ec2_install: true
 ec2_type: ""
+ec2_use_proxy: false
 
 #aws_tag_prefix is used to name the various VPC resources so they are only created once per account
 #even if shared with multiple IAM users
@@ -46,6 +47,7 @@ aws_ami_id: ami-b63769a1
 #aws_ami_id: ami-9062d0f4
 
 instance_type: c4.4xlarge
+proxy_instance_type: m4.large
 
 # For local setup, especially on Mac the hostname will be
 # different from the routing_suffix. We expect the hostname for

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -169,7 +169,7 @@ local_target_asb_template_processed: /tmp/deploy-ansible-service-broker.template
 
 deploy_rds_demo_instance: true
 
-aws_sec_group_name: "{{ aws_tag_prefix }}_security_group"
+aws_sec_group_name: "{{ aws_tag_prefix }}_sg"
 vpc_name: "{{ aws_tag_prefix }}_vpc"
 vpc_cidr_block: "10.0.0.0/16"
 vpc_subnet_cidr: "10.0.0.0/24"

--- a/ansible/reset_aws_environment.yml
+++ b/ansible/reset_aws_environment.yml
@@ -21,8 +21,6 @@
         proxy_private_ip: "{{ proxy_ec2_facts.instances[0].private_ip_address }}"
       when: ec2_use_proxy
 
-
-
 - hosts: localhost
   gather_facts: True
   tasks:

--- a/ansible/reset_aws_environment.yml
+++ b/ansible/reset_aws_environment.yml
@@ -3,6 +3,11 @@
 # so a later play can retrieve the data.
 #
 
+- hosts: tag_Name_{{ instance_lookup_value }}
+  gather_facts: False
+  roles:
+    - { role: awsservicebroker_prep, when: deploy_awsservicebroker == True}
+
 - hosts: localhost
   gather_facts: True
   tasks:
@@ -44,7 +49,6 @@
       prompt: "Enter the dockerhub organization you'd like to pull images from: "
       private: no
   roles:
-    - { role: awsservicebroker_prep, when: deploy_awsservicebroker == True}
     - { role: openshift_proxy_setup, when: ec2_use_proxy == True }
     - { role: ssl_setup, when: use_ssl == True }
     - { role: "{{ cluster }}_setup", reset_cluster: True }

--- a/ansible/reset_aws_environment.yml
+++ b/ansible/reset_aws_environment.yml
@@ -2,6 +2,27 @@
 # We are looking up the ec2 facts and storing them in a host variable
 # so a later play can retrieve the data.
 #
+
+- hosts: localhost
+  gather_facts: True
+  tasks:
+    - name: EC2 proxy remote facts
+      ec2_remote_facts:
+        filters:
+          instance-state-name: running
+          "tag:Name": "{{ proxy_instance_name }}"
+        region: "{{ aws_region }}"
+      register: proxy_ec2_facts
+      when: ec2_use_proxy
+
+    - name: Record squid proxy IP addresses
+      set_fact:
+        proxy_public_ip: "{{ proxy_ec2_facts.instances[0].public_ip_address }}"
+        proxy_private_ip: "{{ proxy_ec2_facts.instances[0].private_ip_address }}"
+      when: ec2_use_proxy
+
+
+
 - hosts: localhost
   gather_facts: True
   tasks:
@@ -26,6 +47,7 @@
       private: no
   roles:
     - { role: awsservicebroker_prep, when: deploy_awsservicebroker == True}
+    - { role: openshift_proxy_setup, when: ec2_use_proxy == True }
     - { role: ssl_setup, when: use_ssl == True }
     - { role: "{{ cluster }}_setup", reset_cluster: True }
     - { role: ansible_service_broker_setup, when: deploy_asb == True}
@@ -33,7 +55,7 @@
   post_tasks:
     - set_fact:
         msg: |
-            EC-2 Instance Tags:        Name={{ instance_name }}
+            EC2 Instance Tags:         Name={{ instance_name }}
             Hostname:                  {{ hostname }}
             SSH Key Name:              {{ ssh_key_name }}
             Region:                    {{ aws_region }}

--- a/ansible/roles/ansible_service_broker_setup/tasks/openshift.yml
+++ b/ansible/roles/ansible_service_broker_setup/tasks/openshift.yml
@@ -166,6 +166,17 @@
   - name: Switch project to {{ asb_project }}
     shell: "{{ oc_cmd }} project {{ asb_project }}"
 
+  - name: Set proxied broker vars
+    set_fact:
+      proxied_broker_project: "{{ asb_project }}"
+      proxied_broker_container: asb
+    when: ec2_use_proxy
+
+  - name: Configure ASB with outbound proxy
+    include_role:
+      name: broker_proxy_setup
+    when: ec2_use_proxy
+
   - name: Waiting 10 minutes for ASB deployment configs
     action:
       shell "{{ oc_cmd }}" get deploymentconfig "{{ item }}" -o go-template={% raw %}'{{if eq .spec.replicas .status.availableReplicas}}good{{end}}'{% endraw %} | grep 'good'

--- a/ansible/roles/aws_display_info/tasks/minimal.yml
+++ b/ansible/roles/aws_display_info/tasks/minimal.yml
@@ -2,17 +2,22 @@
 - debug: var=my_ec2_facts
 
 - block:
+    - debug:
+        msg:
+          -  "EC2 Instance Tags:        Name={{ item.tags.Name }}"
+          -  "EC2 Instance ID:          {{ item.id }}"
+          -  "Region:                    {{ aws_region }}"
+      with_items: "{{ my_ec2_facts.instances }}"
+
     - set_fact:
         msg: |
-            EC-2 Instance Tags:        Name={{ my_ec2_facts.instances[0].tags.Name }}
-            EC-2 Instance ID:          ID={{ my_ec2_facts.instances[0].id }}
             Hostname:                  {{ hostname }}
             OpenShift URL:             {{ cluster_url }}
             SSH Key Name:              {{ ssh_key_name }}
             Region:                    {{ aws_region }}
             Next steps:
-            If you have not done already, setup OpenShift with the following script 
-              $ ./run_setup_environment.sh' 
+            If you have not done already, setup OpenShift with the following script
+              $ ./run_setup_environment.sh'
             1) Visit https://apiserver-service-catalog.{{ openshift_routing_suffix }}
             2) Accept the certificate
             3) Visit https://{{ hostname }}:8443 for the console
@@ -30,12 +35,12 @@
 - block:
     - set_fact:
         msg: |
-            No EC-2 Instance Exists with the following attributes
-                EC-2 Instance Tags: {{ instance_name }}
+            No EC2 Instance Exists with the following attributes
+                EC2 Instance Tags: {{ instance_name }}
                 Hostname:           {{ hostname }}
                 Region:             {{ aws_region }}
             Next steps:
-                1) Create the EC-2 Infrastructure via './run_create_infrastructure.sh'
+                1) Create the EC2 Infrastructure via './run_create_infrastructure.sh'
                 2) Setup OpenShift Environment via './run_setup_environment.sh'
     - debug:
         msg: "{{ msg.split('\n') }}"

--- a/ansible/roles/aws_display_info/tasks/minimal.yml
+++ b/ansible/roles/aws_display_info/tasks/minimal.yml
@@ -11,6 +11,18 @@
 
     - set_fact:
         msg: |
+            The cluster has been configured to connect through a squid proxy for outgoing connections.
+
+            Proxy Instance Public IP:  {{ proxy_ec2_facts.instances[0].public_ip_address }}
+            Proxy Instance ID:         {{ proxy_ec2_facts.instances[0].id }}
+            On VPC Proxy URL:          http://{{ proxy_ec2_facts.instances[0].private_ip_address }}:3128
+      when: ec2_use_proxy and my_ec2_facts.instances
+    - debug:
+        msg: "{{ msg.split('\n') }}"
+      when: ec2_use_proxy and my_ec2_facts.instances
+
+    - set_fact:
+        msg: |
             Hostname:                  {{ hostname }}
             OpenShift URL:             {{ cluster_url }}
             SSH Key Name:              {{ ssh_key_name }}

--- a/ansible/roles/aws_docker_setup/tasks/main.yml
+++ b/ansible/roles/aws_docker_setup/tasks/main.yml
@@ -1,3 +1,6 @@
 ---
 - include: minimal.yml
   when: ec2_type == "minimal"
+
+- include: proxy.yml
+  when: ec2_use_proxy

--- a/ansible/roles/aws_docker_setup/tasks/proxy.yml
+++ b/ansible/roles/aws_docker_setup/tasks/proxy.yml
@@ -1,0 +1,14 @@
+---
+  - name: Configure docker proxy in /etc/sysconfig/docker
+    blockinfile:
+      path: /etc/sysconfig/docker
+      block: |
+          HTTP_PROXY="http://{{ hostvars['localhost']['proxy_private_ip'] }}:3128"
+          HTTPS_PROXY="http://{{ hostvars['localhost']['proxy_private_ip'] }}:3128"
+          NO_PROXY=".cluster.local,.svc,172.17.0.1,172.17.0.0/24,172.30.1.1"
+    become: true
+
+  - name: Restart docker service to pick up proxy changes
+    systemd:
+      name: docker
+      state: restarted

--- a/ansible/roles/aws_infrastructure/defaults/main.yml
+++ b/ansible/roles/aws_infrastructure/defaults/main.yml
@@ -8,7 +8,7 @@ instance_type: c4.2xlarge
 
 kubernetes_cluster_tag_value: "{{ aws_tag_prefix }}"
 
-aws_sec_group_name: "{{ aws_tag_prefix }}_security_group"
+aws_sec_group_name: "{{ aws_tag_prefix }}_sg"
 vpc_name: "{{ aws_tag_prefix }}_vpc"
 vpc_cidr_block: "10.0.0.0/16"
 

--- a/ansible/roles/aws_infrastructure/tasks/main.yml
+++ b/ansible/roles/aws_infrastructure/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
+  # Create minimal AWS network components
   - include: minimal_network.yml
     when: ec2_type == "minimal"
+
+  # Create proxy infrastructure
+  - include: proxy.yml
+    when: ec2_use_proxy
 
   # Create a single instance for the minimal (single node) cluster
   - include: minimal_instance.yml

--- a/ansible/roles/aws_infrastructure/tasks/minimal_instance.yml
+++ b/ansible/roles/aws_infrastructure/tasks/minimal_instance.yml
@@ -3,7 +3,7 @@
       host_fqdn: "{{ aws_custom_prefix }}.{{ target_dns_zone }}"
       wildcard_entry: "*.{{ aws_custom_prefix }}.{{ target_dns_zone }}"
 
-  - name:  Create EC2 Instance
+  - name:  Create EC2 instance for OpenShift
     ec2:
       key_name: "{{ ssh_key_name }}"
       instance_type: "{{ instance_type }}"
@@ -14,11 +14,41 @@
       exact_count: 1
       count_tag:
         Name: "{{ instance_name }}"
-      group_id: "{{ my_sec_group.group_id }}"
+      group_id:
+        - "{{ my_sec_group.group_id }}"
+        - "{{ sec_group_outbound_direct.group_id }}"
       vpc_subnet_id: "{{ public_subnet_a_id }}"
       assign_public_ip: yes
       region: "{{ aws_region }}"
-    register: my_ec2_instances
+    register: instance_result
+    when: not ec2_use_proxy
+
+  - set_fact:
+      my_ec2_instances: "{{ instance_result }}"
+    when: not ec2_use_proxy
+
+  - name:  Create EC2 instance for OpenShift with proxied internet access
+    ec2:
+      key_name: "{{ ssh_key_name }}"
+      instance_type: "{{ instance_type }}"
+      instance_tags:
+        Name: "{{ instance_name }}"
+      image: "{{ aws_ami_id }}"
+      wait: yes
+      exact_count: 1
+      count_tag:
+        Name: "{{ instance_name }}"
+      group_id:
+        - "{{ my_sec_group.group_id }}"
+      vpc_subnet_id: "{{ public_subnet_a_id }}"
+      assign_public_ip: yes
+      region: "{{ aws_region }}"
+    register: proxied_instance_result
+    when: ec2_use_proxy
+
+  - set_fact:
+      my_ec2_instances: "{{ proxied_instance_result }}"
+    when: ec2_use_proxy
 
   - name: Create EBS volumes for /tmp, docker_vg, /var/lib/docker, /persistedvolumes
     async: 200
@@ -26,15 +56,15 @@
     poll: 0
     ec2_vol:
       instance: "{{ my_ec2_instances.tagged_instances[0].id }}"
-      volume_size: '{{ item.volume_size }}'
+      volume_size: "{{ item.volume_size }}"
       region: "{{ aws_region }}"
-      device_name: '{{ item.device_name }}'
+      device_name: "{{ item.device_name }}"
       delete_on_termination: yes
     with_items:
-        - { device_name: '{{ tmp_ebs_device_name }}', volume_size: 50 }
-        - { device_name: '{{ docker_vg_ebs_device_name }}', volume_size: 250 }
-        - { device_name: '{{ var_lib_docker_ebs_device_name }}', volume_size: 100 }
-        - { device_name: '{{ persistedvol_ebs_device_name }}', volume_size: 100 }
+      - { device_name: '{{ tmp_ebs_device_name }}', volume_size: 50 }
+      - { device_name: '{{ docker_vg_ebs_device_name }}', volume_size: 250 }
+      - { device_name: '{{ var_lib_docker_ebs_device_name }}', volume_size: 100 }
+      - { device_name: '{{ persistedvol_ebs_device_name }}', volume_size: 100 }
 
   - name: Wait for EBS volumes to finish creating
     async_status: jid={{ item.ansible_job_id }}

--- a/ansible/roles/aws_infrastructure/tasks/minimal_network.yml
+++ b/ansible/roles/aws_infrastructure/tasks/minimal_network.yml
@@ -208,8 +208,8 @@
 
   - name: Create security group allowing OpenShift to connect directly to the internet
     ec2_group:
-      name:             "{{ aws_sec_group_name }}-outbound-direct"
-      description:      "{{ aws_sec_group_name }}-outbound-direct"
+      name:             "{{ aws_sec_group_name }}_outbound"
+      description:      "{{ aws_sec_group_name }}_outbound"
       vpc_id:           "{{ vpc_id }}"
       region:           "{{ aws_region }}"
       rules_egress:
@@ -220,12 +220,12 @@
     register: sec_group_outbound_direct
     when: not ec2_use_proxy
 
-  - name: Ensure the security group '{{ aws_sec_group_name }}-outbound-direct' is tagged
+  - name: Ensure the security group '{{ aws_sec_group_name }}_outbound' is tagged
     ec2_tag:
       region:   "{{ aws_region }}"
       resource: "{{ sec_group_outbound_direct.group_id }}"
       state:    "{{ state }}"
       tags:
-        Name: "{{ aws_sec_group_name }}-outbound-direct"
+        Name: "{{ aws_sec_group_name }}_outbound"
         KubernetesCluster: "{{ kubernetes_cluster_tag_value }}"
     when: not ec2_use_proxy

--- a/ansible/roles/aws_infrastructure/tasks/minimal_network.yml
+++ b/ansible/roles/aws_infrastructure/tasks/minimal_network.yml
@@ -56,7 +56,7 @@
 #       Name:              "{{ vpc_gateway_name }}"
 #       KubernetesCluster: "{{ kubernetes_cluster_tag_value }}"
 #
-# TODO: until Ansible v2.4 is released and fully supported, 
+# TODO: until Ansible v2.4 is released and fully supported,
 #       cannot use the 'resource_tags:'
 #       Therefore, using the 'ec2_tag' Ansible module below to tag the IGW
     register: my_vpc_igw
@@ -96,6 +96,11 @@
       state:            "{{ state }}"
       vpc_id:           "{{ vpc_id }}"
       region:           "{{ aws_region }}"
+      rules_egress:
+        - proto:        "tcp"
+          from_port:    "0"
+          to_port:      "65535"
+          cidr_ip:      "{{ vpc_cidr_block }}"
       rules:
         - proto:        "tcp"
           from_port:    "22"
@@ -191,7 +196,7 @@
           cidr_ip:      "0.0.0.0/0"
     register: my_sec_group
 
-  - name: Ensure the Security Group '{{ aws_sec_group_name }}' is tagged
+  - name: Ensure the security group '{{ aws_sec_group_name }}' is tagged
     ec2_tag:
       region:   "{{ aws_region }}"
       resource: "{{ my_sec_group.group_id }}"
@@ -200,3 +205,27 @@
         Name: "{{ aws_sec_group_name }}"
         KubernetesCluster: "{{ kubernetes_cluster_tag_value }}"
     when: my_sec_group
+
+  - name: Create security group allowing OpenShift to connect directly to the internet
+    ec2_group:
+      name:             "{{ aws_sec_group_name }}-outbound-direct"
+      description:      "{{ aws_sec_group_name }}-outbound-direct"
+      vpc_id:           "{{ vpc_id }}"
+      region:           "{{ aws_region }}"
+      rules_egress:
+        - proto:        "tcp"
+          from_port:    "0"
+          to_port:      "65535"
+          cidr_ip:      "0.0.0.0/0"
+    register: sec_group_outbound_direct
+    when: not ec2_use_proxy
+
+  - name: Ensure the security group '{{ aws_sec_group_name }}-outbound-direct' is tagged
+    ec2_tag:
+      region:   "{{ aws_region }}"
+      resource: "{{ sec_group_outbound_direct.group_id }}"
+      state:    "{{ state }}"
+      tags:
+        Name: "{{ aws_sec_group_name }}-outbound-direct"
+        KubernetesCluster: "{{ kubernetes_cluster_tag_value }}"
+    when: not ec2_use_proxy

--- a/ansible/roles/aws_infrastructure/tasks/proxy.yml
+++ b/ansible/roles/aws_infrastructure/tasks/proxy.yml
@@ -1,0 +1,50 @@
+---
+  - name: Create security group for squid proxy
+    ec2_group:
+      name:             "{{ aws_sec_group_name }}-squid-inbound"
+      description:      "{{ aws_sec_group_name }}-squid-inbound"
+      vpc_id:           "{{ vpc_id }}"
+      region:           "{{ aws_region }}"
+      rules:
+        - proto:        "tcp"
+          from_port:    "3128"
+          to_port:      "3128"
+          cidr_ip:      "{{ vpc_cidr_block }}"
+        - proto:        "tcp"
+          from_port:    "22"
+          to_port:      "22"
+          cidr_ip:      "0.0.0.0/0"
+      tags:
+        Name: "{{ aws_sec_group_name }}-squid-inbound"
+        KubernetesCluster: "{{ kubernetes_cluster_tag_value }}"
+    register: squid_inbound_sec_group
+
+  - name: Create EC2 instance for squid proxy
+    ec2:
+      key_name: "{{ ssh_key_name }}"
+      instance_type: "{{ proxy_instance_type }}"
+      instance_tags:
+        Name: "{{ proxy_instance_name }}"
+      image: "{{ aws_ami_id }}"
+      wait: yes
+      exact_count: 1
+      count_tag:
+        Name: "{{ proxy_instance_name }}"
+      group_id: "{{ squid_inbound_sec_group.group_id }}"
+      vpc_subnet_id: "{{ public_subnet_a_id }}"
+      assign_public_ip: yes
+      region: "{{ aws_region }}"
+    register: proxy_ec2_instance
+
+  - name: Record squid proxy IP addresses
+    set_fact:
+      proxy_public_ip: "{{ proxy_ec2_instance.tagged_instances[0].public_ip }}"
+      proxy_private_ip: "{{ proxy_ec2_instance.tagged_instances[0].private_ip }}"
+
+  - name: Wait for SSH to come up on squid proxy instance {{ proxy_public_ip }}
+    wait_for:
+      host: "{{ proxy_public_ip }}"
+      port: 22
+      delay: 0
+      timeout: 320
+      state: started

--- a/ansible/roles/aws_infrastructure/tasks/proxy.yml
+++ b/ansible/roles/aws_infrastructure/tasks/proxy.yml
@@ -1,8 +1,8 @@
 ---
   - name: Create security group for squid proxy
     ec2_group:
-      name:             "{{ aws_sec_group_name }}-squid-inbound"
-      description:      "{{ aws_sec_group_name }}-squid-inbound"
+      name:             "{{ aws_sec_group_name }}_squid_inbound"
+      description:      "{{ aws_sec_group_name }}_squid_inbound"
       vpc_id:           "{{ vpc_id }}"
       region:           "{{ aws_region }}"
       rules:
@@ -15,7 +15,7 @@
           to_port:      "22"
           cidr_ip:      "0.0.0.0/0"
       tags:
-        Name: "{{ aws_sec_group_name }}-squid-inbound"
+        Name: "{{ aws_sec_group_name }}_squid_inbound"
         KubernetesCluster: "{{ kubernetes_cluster_tag_value }}"
     register: squid_inbound_sec_group
 

--- a/ansible/roles/aws_terminate_ec2_instances/tasks/minimal.yml
+++ b/ansible/roles/aws_terminate_ec2_instances/tasks/minimal.yml
@@ -3,52 +3,58 @@
     host_fqdn: "{{ aws_custom_prefix }}.{{ target_dns_zone }}"
     wildcard_entry: "*.{{ aws_custom_prefix }}.{{ target_dns_zone }}"
 
-- name: Remove DNS A Record '{{ host_fqdn }}' for {{ my_ec2_facts.instances[0].public_ip_address }}
+- name: Attempt removal of DNS A Record '{{ host_fqdn }}'
   route53: >
     command=delete
     zone="{{ target_dns_zone }}"
     record="{{ host_fqdn }}"
     type=A
     ttl=60
-    value="{{ my_ec2_facts.instances[0].public_ip_address }}"
+    value="{{ item.public_ip_address }}"
   when: my_ec2_facts.instances
+  with_items: "{{ my_ec2_facts.instances }}"
+  ignore_errors: yes
 
-- name: Remove DNS A Record '{{ wildcard_entry }}' to Elastic IP {{ my_ec2_facts.instances[0].public_ip_address }}
+- name: Attempt removal of DNS A Record '{{ wildcard_entry }}'
   route53: >
     command=delete
     zone="{{ target_dns_zone }}"
     record="{{ wildcard_entry }}"
     type=A
     ttl=60
-    value="{{ my_ec2_facts.instances[0].public_ip_address }}"
+    value="{{ item.public_ip_address }}"
   when: my_ec2_facts.instances
+  with_items: "{{ my_ec2_facts.instances }}"
+  ignore_errors: yes
 
-- name: Delete EC-2 Instance {{ my_ec2_facts.instances[0].id }}
+- name: Delete EC2 instances
   ec2:
     state: absent
     wait: yes
     instance_ids:
-      - "{{ my_ec2_facts.instances[0].id }}"
+      - "{{ item.id }}"
     region: "{{ aws_region }}"
   when: my_ec2_facts.instances
+  with_items: "{{ my_ec2_facts.instances }}"
 
-- set_fact:
-    msg: |
-        Deleted Instance.
-        EC-2 Instance Tags:        Name={{ instance_name }}
-        EC-2 Instance ID:          {{ my_ec2_facts.instances[0].id }}
-        Region:                    {{ aws_region }}
-        Removed Route53 DNS:       {{ wildcard_entry }}
-                                   {{ host_fqdn }}
-
-        NOTE:
-          Only the EC2 Instance and its DNS entries listed above have been removed.
-          Common Network Services (i.e. VPC, GW, Subnets, Security groups, etc.)
-          created during the 'aws_infrastructure' setup step/role still remain.
-
-          Visit the AWS WebUI console and remove any other unwanted items manually.
+- debug:
+    msg:
+      -  "Deleted Instance."
+      -  "EC2 Instance Tags:        Name={{ item.tags.Name }}"
+      -  "EC2 Instance ID:          {{ item.id }}"
+      -  "Region:                    {{ aws_region }}"
+  with_items: "{{ my_ec2_facts.instances }}"
   when: my_ec2_facts.instances
 
 - debug:
-    msg: "{{ msg.split('\n') }}"
+    msg:
+      -  "Removed Route53 DNS:       {{ wildcard_entry }}"
+      -  "                           {{ host_fqdn }}"
+      -  ""
+      -  "NOTE:"
+      -  "  Only the EC2 Instances and DNS entries listed above have been removed."
+      -  "  Common Network Services (i.e. VPC, GW, Subnets, Security groups, etc.)"
+      -  "  created during the 'aws_infrastructure' setup step/role still remain."
+      -  ""
+      -  "  Visit the AWS Web Console and remove any other unwanted items manually."
   when: my_ec2_facts.instances

--- a/ansible/roles/awsservicebroker_setup/tasks/create_secrets.yml
+++ b/ansible/roles/awsservicebroker_setup/tasks/create_secrets.yml
@@ -56,12 +56,16 @@
     shell: "{{ oc_cmd }} get rc --no-headers --sort-by=\".metadata.name\" -n {{ awsservicebroker_asb_project }} | grep -v etcd | tail -n1|awk '{print $1}'"
     register: rc_latest_name
 
-  - name: Waiting up to 10 minutes for the ASB pod to restart ...
+  - name: Waiting up for the ASB pod to restart ...
     shell: "{{ oc_cmd }} get pods -n {{ awsservicebroker_asb_project }} | grep  {{ rc_latest_name.stdout }} | grep -v deploy | grep -iEm1 'asb.*?running'"
     register: wait_for_asb_pod
     until: wait_for_asb_pod.rc == 0
     retries: 10
-    delay: 60
+    delay: 10
+
+  - name: Wait 10 seconds for ASB pod to become ready
+    pause:
+      seconds: 10
 
   - name: Do 'apb relist'
     shell: "{{ apb_tools_cmd }} relist --broker-name {{ awsservicebroker_broker_name }}"

--- a/ansible/roles/awsservicebroker_setup/tasks/create_secrets.yml
+++ b/ansible/roles/awsservicebroker_setup/tasks/create_secrets.yml
@@ -56,21 +56,12 @@
     shell: "{{ oc_cmd }} get rc --no-headers --sort-by=\".metadata.name\" -n {{ awsservicebroker_asb_project }} | grep -v etcd | tail -n1|awk '{print $1}'"
     register: rc_latest_name
 
-  - name: Waiting up for the ASB pod to restart ...
+  - name: Waiting for the ASB pod to restart
     shell: "{{ oc_cmd }} get pods -n {{ awsservicebroker_asb_project }} | grep  {{ rc_latest_name.stdout }} | grep -v deploy | grep -iEm1 'asb.*?running'"
     register: wait_for_asb_pod
     until: wait_for_asb_pod.rc == 0
     retries: 10
     delay: 10
-
-  - name: Wait 10 seconds for ASB pod to become ready
-    pause:
-      seconds: 10
-
-  - name: Do 'apb relist'
-    shell: "{{ apb_tools_cmd }} relist --broker-name {{ awsservicebroker_broker_name }}"
-    register: apb_relist_result
-    failed_when: apb_relist_result.rc != 0
 
   - name: Get the ASB Pod name
     shell: "{{ oc_cmd }} get pods -n {{ awsservicebroker_asb_project }} | grep {{ rc_latest_name.stdout }} | awk '{print $1}' | grep -v deploy"
@@ -78,11 +69,11 @@
 
   - debug: var=asb_pod_name.stdout
 
-  - name: Wait until ASB pod has filtered the 'aws_access_key' (up to 10 minutes)
-    shell: "{{ oc_cmd }} logs {{ asb_pod_name.stdout }} -c aws-asb | grep 'EXTRA string=aws_access_key'"
+  - name: Do 'apb relist' and wait until ASB pod has filtered the 'aws_access_key'
+    shell: "{{ apb_tools_cmd }} relist --broker-name {{ awsservicebroker_broker_name }} && {{ oc_cmd }} logs {{ asb_pod_name.stdout }} -c aws-asb | grep 'EXTRA string=aws_access_key'"
     register: wait_for_aws_asb_filter_msg
     until: wait_for_aws_asb_filter_msg.rc == 0
-    retries: 60
+    retries: 10
     delay: 10
 
   - name: Download the 'refresh_broker_resoure.py' script to "{{ refresh_broker_resoure_script }}"

--- a/ansible/roles/awsservicebroker_setup/tasks/main.yml
+++ b/ansible/roles/awsservicebroker_setup/tasks/main.yml
@@ -200,19 +200,30 @@
   - name: Switch project to {{ awsservicebroker_asb_project }}
     shell: "{{ oc_cmd }} project {{ awsservicebroker_asb_project }}"
 
-  - name: Waiting 10 minutes for ASB pod
+  - name: Set proxied broker vars
+    set_fact:
+      proxied_broker_project: "{{ awsservicebroker_asb_project }}"
+      proxied_broker_container: aws-asb
+    when: ec2_use_proxy
+
+  - name: Configure ASB with outbound proxy
+    include_role:
+      name: broker_proxy_setup
+    when: ec2_use_proxy
+
+  - name: Waiting up to 5 minutes for ASB pod
     action:
       shell "{{ oc_cmd }}" get pods | grep -iEm1 "asb.*?running" | grep -v deploy
     register: wait_for_asb_pod
     until: wait_for_asb_pod.rc == 0
     retries: 60
-    delay: 10
+    delay: 5
 
   - name: Get route for aws-service-broker
     shell: "'{{ oc_cmd }}' get routes | grep aws-service-broker | awk '{print $2}'"
     register: result_get_route_asb
-    retries: 6
-    delay: 10
+    retries: 12
+    delay: 5
 
   - set_fact:
       aws_access_key: "{{ lookup('env','AWS_ACCESS_KEY_ID') }}"
@@ -223,4 +234,3 @@
 
   - include: create_secrets.yml
     when: (deploy_awsservicebroker == True) and (aws_access_key != "" and aws_secret_key != "" and aws_cloudformation_role_arn != "")
-

--- a/ansible/roles/awsservicebroker_setup/tasks/main.yml
+++ b/ansible/roles/awsservicebroker_setup/tasks/main.yml
@@ -213,7 +213,7 @@
 
   - name: Waiting up to 5 minutes for ASB pod
     action:
-      shell "{{ oc_cmd }}" get pods | grep -iEm1 "asb.*?running" | grep -v deploy
+      shell "{{ oc_cmd }}" get pods | grep -iEm1 "asb.*?running" | grep -v deploy | grep -v etcd
     register: wait_for_asb_pod
     until: wait_for_asb_pod.rc == 0
     retries: 60

--- a/ansible/roles/broker_proxy_setup/tasks/main.yml
+++ b/ansible/roles/broker_proxy_setup/tasks/main.yml
@@ -15,7 +15,7 @@
     shell: "{{ oc_cmd }} patch dc {{ proxied_broker_container}} -p '{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"{{ proxied_broker_container}}\",\"envFrom\":[{\"configMapRef\":{\"name\":\"broker-proxy-config\"}}]}]}}}}' -n {{ proxied_broker_project }}"
 
   - name: Waiting up a minute for the broker pod to terminate ...
-    shell: "{{ oc_cmd }} get pods -n {{ proxied_broker_project }} | grep  {{ rc_latest_name.stdout }} | grep -v deploy | grep -iEm1 'asb.*?running'"
+    shell: "{{ oc_cmd }} get pods -n {{ proxied_broker_project }} | grep  {{ rc_latest_name.stdout }} | grep -v deploy | grep -v etcd | grep -iEm1 'asb.*?running'"
     register: wait_for_asb_pod
     until: wait_for_asb_pod.rc == 1
     retries: 20

--- a/ansible/roles/broker_proxy_setup/tasks/main.yml
+++ b/ansible/roles/broker_proxy_setup/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+  - name: Copy broker-proxy-config template to OpenShift host
+    template:
+      src: broker-proxy-config.yml.j2
+      dest: /tmp/broker-proxy-config.yml
+
+  - name: Create broker-proxy-config object
+    shell: "{{ oc_cmd }} create -f /tmp/broker-proxy-config.yml -n {{ proxied_broker_project }}"
+
+  - name: Get name of latest RC for broker
+    shell: "{{ oc_cmd }} get rc --no-headers --sort-by=\".metadata.name\" -n {{ proxied_broker_project }} | grep -v etcd | tail -n1|awk '{print $1}'"
+    register: rc_latest_name
+
+  - name: Patch broker DC to reference broker-proxy-configmap
+    shell: "{{ oc_cmd }} patch dc {{ proxied_broker_container}} -p '{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"{{ proxied_broker_container}}\",\"envFrom\":[{\"configMapRef\":{\"name\":\"broker-proxy-config\"}}]}]}}}}' -n {{ proxied_broker_project }}"
+
+  - name: Waiting up a minute for the broker pod to terminate ...
+    shell: "{{ oc_cmd }} get pods -n {{ proxied_broker_project }} | grep  {{ rc_latest_name.stdout }} | grep -v deploy | grep -iEm1 'asb.*?running'"
+    register: wait_for_asb_pod
+    until: wait_for_asb_pod.rc == 1
+    retries: 20
+    delay: 5
+    failed_when: wait_for_asb_pod.rc > 1
+
+  - name: Wait 5 seconds for new broker RC to show up
+    pause:
+      seconds: 5
+
+  - name: Get name of latest RC for broker
+    shell: "{{ oc_cmd }} get rc --no-headers --sort-by=\".metadata.name\" -n {{ proxied_broker_project }} | grep -v etcd | tail -n1|awk '{print $1}'"
+    register: rc_latest_name
+
+  - name: Waiting up a minute for the broker deploy pod to finish executing ...
+    shell: "{{ oc_cmd }} get pods -n {{ proxied_broker_project }} | grep  {{ rc_latest_name.stdout }}-deploy | grep -iEm1 'asb.*?running'"
+    register: wait_for_asb_pod
+    until: wait_for_asb_pod.rc == 1
+    retries: 20
+    delay: 5
+    failed_when: wait_for_asb_pod.rc > 1

--- a/ansible/roles/broker_proxy_setup/templates/broker-proxy-config.yml.j2
+++ b/ansible/roles/broker_proxy_setup/templates/broker-proxy-config.yml.j2
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  HTTP_PROXY: http://{{ hostvars['localhost']['proxy_private_ip'] }}:3128
+  HTTPS_PROXY: http://{{ hostvars['localhost']['proxy_private_ip'] }}:3128
+  NO_PROXY: .cluster.local,.svc,172.30.0.0/16,172.30.0.1
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: ansible-service-broker
+  name: broker-proxy-config

--- a/ansible/roles/openshift_proxy_setup/tasks/main.yml
+++ b/ansible/roles/openshift_proxy_setup/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+  - name: Set proxy_private_ip var for OpenShift host
+    set_fact:
+      proxy_private_ip: "{{ hostvars['localhost']['proxy_private_ip'] }}"
+
+  - name: Configure system-wide proxy for OpenShift instance in /etc/environment
+    blockinfile:
+      path: /etc/environment
+      block: |
+          export http_proxy=http://{{ proxy_private_ip }}:3128/
+          export https_proxy=http://{{ proxy_private_ip }}:3128/
+          export no_proxy=.cluster.local,.svc,172.17.0.1,172.17.0.0/24
+          export HTTP_PROXY=http://{{ proxy_private_ip }}:3128/
+          export HTTPS_PROXY=http://{{ proxy_private_ip }}:3128/
+          export NO_PROXY=.cluster.local,.svc,172.17.0.1,172.17.0.0/24
+    become: true
+    register: proxy_update_result
+
+  - name: Restart OpenShift instance to pick up proxy env vars
+    become: yes
+    shell: sleep 2 && /sbin/shutdown -r now
+    async: 1
+    poll: 0
+    when: proxy_update_result|changed
+
+  - name: Pause for 10 seconds so that OpenShift instance can stop
+    pause:
+      seconds: 10
+    when: proxy_update_result|changed
+
+  - name: Wait for SSH to come up on OpenShift instance {{ hostname }}
+    local_action: wait_for host="{{ hostname }}" port=22 delay=0 timeout=320 state=started
+    when: proxy_update_result|changed

--- a/ansible/roles/openshift_setup/tasks/main.yml
+++ b/ansible/roles/openshift_setup/tasks/main.yml
@@ -122,15 +122,6 @@
       mode: 0755
     register: get_kubernetes_client_release
 
-  - name: Wait, up to 20 minutes, till we can SSH into the host with the DNS name '{{ hostname }}'
-    wait_for:
-      host: "{{ hostname }}"
-      port: 22
-      delay: 0
-      timeout: 1200
-      state: started
-    when: ec2_install
-
   - name: Resetting cluster
     shell: "{{ oc_cmd }} cluster down"
     when: reset_cluster
@@ -218,6 +209,11 @@
         --version={{ origin_image_tag }}
         {% if use_custom_config %}--host-config-dir={{ oc_host_config_dir }}{% endif %}
         --service-catalog=true
+
+  - name: Add proxy options to oc cluster up command
+    set_fact:
+      oc_cluster_up_cmd: "{{ oc_cluster_up_cmd }} --http-proxy='http://{{ proxy_private_ip }}:3128' --https-proxy='http://{{ proxy_private_ip }}:3128'"
+    when: ec2_use_proxy
 
   - debug:
       var: use_custom_config

--- a/ansible/roles/squid_instance_configure/tasks/main.yml
+++ b/ansible/roles/squid_instance_configure/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+
+  - name: Install squid proxy package
+    yum:
+      name: squid
+      state: installed
+
+  - name: Copy squid.conf to OpenShift host
+    template:
+      src: squid.conf.j2
+      dest: /etc/squid/squid.conf
+    become: true
+
+  - name: Restart and enable squid proxy service
+    systemd:
+      name: squid
+      state: restarted
+      daemon_reload: yes
+      enabled: yes

--- a/ansible/roles/squid_instance_configure/templates/squid.conf.j2
+++ b/ansible/roles/squid_instance_configure/templates/squid.conf.j2
@@ -1,0 +1,34 @@
+# Allow systems on our VPC to connect through this proxy
+acl localnet src {{ vpc_cidr_block }}
+
+# Only allow cachemgr access from localhost
+http_access allow localhost manager
+http_access deny manager
+
+# We strongly recommend the following be uncommented to protect innocent
+# web applications running on the proxy server who think the only
+# one who can access services on "localhost" is a local user
+#http_access deny to_localhost
+
+# Example rule allowing access from your local networks.
+# Adapt localnet in the ACL section to list your (internal) IP networks
+# from where browsing should be allowed
+http_access allow localnet
+http_access allow localhost
+
+# And finally deny all other access to this proxy
+http_access deny all
+
+# Squid normally listens to port 3128
+http_port 3128
+
+# Leave coredumps in the first cache dir
+coredump_dir /var/spool/squid
+
+#
+# Add any of your own refresh_pattern entries above these.
+#
+refresh_pattern ^ftp:           1440    20%     10080
+refresh_pattern ^gopher:        1440    0%      1440
+refresh_pattern -i (/cgi-bin/|\?) 0     0%      0
+refresh_pattern .               0       20%     4320

--- a/ansible/setup_aws_environment.yml
+++ b/ansible/setup_aws_environment.yml
@@ -2,6 +2,12 @@
 # We are looking up the ec2 facts and storing them in a host variable
 # so a later play can retrieve the data.
 #
+
+- hosts: tag_Name_{{ instance_lookup_value }}
+  gather_facts: False
+  roles:
+    - { role: awsservicebroker_prep, when: deploy_awsservicebroker == True}
+
 - hosts: localhost
   gather_facts: True
   tasks:
@@ -19,7 +25,6 @@
         proxy_public_ip: "{{ proxy_ec2_facts.instances[0].public_ip_address }}"
         proxy_private_ip: "{{ proxy_ec2_facts.instances[0].private_ip_address }}"
       when: ec2_use_proxy
-
 
 - hosts: tag_Name_{{ proxy_instance_lookup_value }}
   gather_facts: True
@@ -50,7 +55,6 @@
       prompt: "Enter the dockerhub organization you'd like to pull images from: "
       private: no
   roles:
-    - { role: awsservicebroker_prep, when: deploy_awsservicebroker == True}
     - aws_ebs_volumes
     - { role: openshift_proxy_setup, when: ec2_use_proxy == True }
     - aws_repo_setup

--- a/ansible/setup_aws_environment.yml
+++ b/ansible/setup_aws_environment.yml
@@ -5,7 +5,32 @@
 - hosts: localhost
   gather_facts: True
   tasks:
-    - name: EC2 Remote Facts
+    - name: EC2 proxy remote facts
+      ec2_remote_facts:
+        filters:
+          instance-state-name: running
+          "tag:Name": "{{ proxy_instance_name }}"
+        region: "{{ aws_region }}"
+      register: proxy_ec2_facts
+      when: ec2_use_proxy
+
+    - name: Record squid proxy IP addresses
+      set_fact:
+        proxy_public_ip: "{{ proxy_ec2_facts.instances[0].public_ip_address }}"
+        proxy_private_ip: "{{ proxy_ec2_facts.instances[0].private_ip_address }}"
+      when: ec2_use_proxy
+
+
+- hosts: tag_Name_{{ proxy_instance_lookup_value }}
+  gather_facts: True
+  become: True
+  roles:
+    - squid_instance_configure
+
+- hosts: localhost
+  gather_facts: True
+  tasks:
+    - name: EC2 OpenShift Remote Facts
       ec2_remote_facts:
         filters:
           instance-state-name: running
@@ -27,6 +52,7 @@
   roles:
     - { role: awsservicebroker_prep, when: deploy_awsservicebroker == True}
     - aws_ebs_volumes
+    - { role: openshift_proxy_setup, when: ec2_use_proxy == True }
     - aws_repo_setup
     - aws_packages
     - aws_docker_setup
@@ -38,7 +64,7 @@
   post_tasks:
     - set_fact:
         msg: |
-            EC-2 Instance Tags:        Name={{ instance_name }}
+            EC2 Instance Tags:        Name={{ instance_name }}
             Hostname:                  {{ hostname }}
             SSH Key Name:              {{ ssh_key_name }}
             Region:                    {{ aws_region }}

--- a/ansible/setup_aws_infrastructure.yml
+++ b/ansible/setup_aws_infrastructure.yml
@@ -17,10 +17,17 @@
   roles:
     - aws_infrastructure
   tasks:
+    - debug:
+        msg:
+          -  "EC2 Instance Tags:        Name={{ item.tags.Name }}"
+          -  "EC2 Instance ID:          {{ item.id }}"
+          -  "Region:                    {{ aws_region }}"
+      with_items: "{{ ec2_instances.instances }}"
+
     - set_fact:
         msg: |
-            EC-2 Instance Tags:        Name={{ instance_name }}
-            EC-2 Instance ID:          {{ ec2_instances.tagged_instances[0].id }}
+            EC2 Instance Tags:        Name={{ instance_name }}
+            EC2 Instance ID:          {{ ec2_instances.tagged_instances[0].id }}
             Associated to Elastic IP:  {{ elastic_ip.public_ip }}
             Hostname:                  {{ host_fqdn }}
             DNS WildCard Entry:        {{ wildcard_entry }}

--- a/config/ec2_env_vars
+++ b/config/ec2_env_vars
@@ -22,6 +22,10 @@ export INSTANCE_NAME="${OWNERS_NAME}-${AWS_CUSTOM_PREFIX}.${TARGET_DNS_ZONE}"
 export INSTANCE_LOOKUP_VALUE=`echo ${INSTANCE_NAME//./_}`
 export INSTANCE_LOOKUP_VALUE=`echo ${INSTANCE_LOOKUP_VALUE//-/_}`
 
+export PROXY_INSTANCE_NAME="${OWNERS_NAME}-proxy-${AWS_CUSTOM_PREFIX}.${TARGET_DNS_ZONE}"
+export PROXY_INSTANCE_LOOKUP_VALUE=`echo ${PROXY_INSTANCE_NAME//./_}`
+export PROXY_INSTANCE_LOOKUP_VALUE=`echo ${PROXY_INSTANCE_LOOKUP_VALUE//-/_}`
+
 export EC2_USER="ec2-user"
 
 export EXTRA_VARS="{\
@@ -30,6 +34,8 @@ export EXTRA_VARS="{\
 \"aws_custom_prefix\":\"${AWS_CUSTOM_PREFIX}\", \
 \"instance_name\":\"${INSTANCE_NAME}\", \
 \"instance_lookup_value\":\"${INSTANCE_LOOKUP_VALUE}\", \
+\"proxy_instance_name\":\"${PROXY_INSTANCE_NAME}\", \
+\"proxy_instance_lookup_value\":\"${PROXY_INSTANCE_LOOKUP_VALUE}\", \
 \"cluster\":\"${CLUSTER}\", \
 \"ec2_type\":\"${EC2_TYPE}\" \
 }"

--- a/config/my_vars.yml.example
+++ b/config/my_vars.yml.example
@@ -63,6 +63,11 @@ dockerhub_org: ansibleplaybookbundle
 # aws_region: ca-central-1
 # aws_ami_id: ami-9062d0f4
 
+
+# Enable ec2_use_proxy to tunnel outgoing OpenShift traffic through a squid proxy
+# ec2_use_proxy: True
+# ec2_proxy_instance_type: m4.large
+
 #
 # Deploy AWS Broker
 # Note: You may set BOTH 'deploy_awsservicebroker' AND 'deploy_asb' to 'True'
@@ -81,7 +86,7 @@ dockerhub_org: ansibleplaybookbundle
 # awsservicebroker_apbtag: nightly
 # awsservicebroker_apbtag: canary
 
-# EC-2 Instance Type - 't2.medium' or higher is recommended
+# EC2 Instance Type - 't2.medium' or higher is recommended
 # instance_type: c4.4xlarge
 
 # AWS CloudFormation Role ARN Name

--- a/ec2/README.md
+++ b/ec2/README.md
@@ -3,11 +3,11 @@
 OpenShift with the Service Catalog and the Ansible Service Broker can be deployed in the [Amazon Web Services](https://aws.amazon.com/) (AWS) environment in the following configurations:
 
 * [Minimal](./minimal)
-  * Single EC-2 Instance
+  * Single EC2 Instance
   * Installs [Origin](https://www.openshift.org/) via **`oc cluster up`**
 
 * [Multi-Node](./multi_node)
-  * Multiple EC-2 Instances
+  * Multiple EC2 Instances
   * Installs [OpenShift Container Platform](https://www.openshift.com/container-platform/index.html) or [Origin](https://www.openshift.org/) via [OpenShift Ansible](https://github.com/openshift/openshift-ansible)
     * Configurable Contents
       * RH CDN

--- a/ec2/minimal/README.md
+++ b/ec2/minimal/README.md
@@ -1,6 +1,6 @@
-# CatASB EC-2 Deployment
+# CatASB EC2 Deployment
 
-OpenShift environment with a Service Catalog & Ansible Service Broker in a single EC-2 Instance.
+OpenShift environment with a Service Catalog & Ansible Service Broker in a single EC2 Instance.
 
 ## Overview
 
@@ -8,7 +8,7 @@ These playbooks will:
 
 * Create a public VPC if it does not exist
 * Create a security group if it does not exist
-* Create a single EC-2 instance with a specific Name if does not exist
+* Create a single EC2 instance with a specific Name if does not exist
 * Associate an elastic ip to instance
 * Configure a hostname with elastic ip through Route53
 * Setup *Origin* through `oc cluster up`
@@ -53,7 +53,7 @@ These playbooks will:
     $ pip install boto boto3 six
     ```
 
-* Configure a SSH Key in your AWS EC-2 account for the given region
+* Configure a SSH Key in your AWS EC2 account for the given region
 * Create a hosted zone in Route53
 * Set these environment variables:
 

--- a/ec2/multi_node/README.md
+++ b/ec2/multi_node/README.md
@@ -1,2 +1,2 @@
 # Multi-Node AWS OpenShift Deployment 
-OpenShift environment with the Service Catalog & Ansible Service Broker configured in AWS with multiple EC-2 instances
+OpenShift environment with the Service Catalog & Ansible Service Broker configured in AWS with multiple EC2 instances


### PR DESCRIPTION
 - Add boolean switch "ec2_use_proxy"
   - Deploys an additional EC2 instance with squid proxy configured
   - EC2 instance for squid will forward traffic for any machine on-VPC
   - Sends all outbound OpenShift traffic through squid
   - Configures system level proxy
   - Configures docker proxy
   - Configures oc cluster up proxy
   - Configures broker proxies with "oc patch"

 - Misc changes required for multi-instance (OpenShift + squid) deploy
   - Add support for termination of multiple instances
   - Add support for listing info on multiple instances

 - Add delay before running apb relist during secret filter, seemed to speed up process
 - Change all mentions of "EC-2" to "EC2" to reflect the official name
 - Tweaked various delays to speed up deploy process