### PR TITLE
Add check for ec2_install var on proxy setup tasks.

### DIFF
--- a/ansible/roles/ansible_service_broker_setup/tasks/openshift.yml
+++ b/ansible/roles/ansible_service_broker_setup/tasks/openshift.yml
@@ -170,12 +170,12 @@
     set_fact:
       proxied_broker_project: "{{ asb_project }}"
       proxied_broker_container: asb
-    when: ec2_use_proxy
+    when: ec2_use_proxy and ec2_install
 
   - name: Configure ASB with outbound proxy
     include_role:
       name: broker_proxy_setup
-    when: ec2_use_proxy
+    when: ec2_use_proxy and ec2_install
 
   - name: Waiting 10 minutes for ASB deployment configs
     action:

--- a/ansible/roles/awsservicebroker_setup/tasks/main.yml
+++ b/ansible/roles/awsservicebroker_setup/tasks/main.yml
@@ -204,12 +204,12 @@
     set_fact:
       proxied_broker_project: "{{ awsservicebroker_asb_project }}"
       proxied_broker_container: aws-asb
-    when: ec2_use_proxy
+    when: ec2_use_proxy and ec2_install
 
   - name: Configure ASB with outbound proxy
     include_role:
       name: broker_proxy_setup
-    when: ec2_use_proxy
+    when: ec2_use_proxy and ec2_install
 
   - name: Waiting up to 5 minutes for ASB pod
     action:

--- a/ansible/roles/openshift_setup/tasks/main.yml
+++ b/ansible/roles/openshift_setup/tasks/main.yml
@@ -213,7 +213,7 @@
   - name: Add proxy options to oc cluster up command
     set_fact:
       oc_cluster_up_cmd: "{{ oc_cluster_up_cmd }} --http-proxy='http://{{ proxy_private_ip }}:3128' --https-proxy='http://{{ proxy_private_ip }}:3128'"
-    when: ec2_use_proxy
+    when: ec2_use_proxy and ec2_install
 
   - debug:
       var: use_custom_config


### PR DESCRIPTION
Still running a test on this at the moment, but should fix the issue of setup failing when running locally with the ec2_use_proxy option set.

This is a fix for an issue introduced by https://github.com/fusor/catasb/pull/207