### PR TITLE
Add no_proxy rule for localhost and 127.0.0.1 to fix apb tool actions.

### DIFF
--- a/ansible/roles/aws_docker_setup/tasks/proxy.yml
+++ b/ansible/roles/aws_docker_setup/tasks/proxy.yml
@@ -5,7 +5,7 @@
       block: |
           HTTP_PROXY="http://{{ hostvars['localhost']['proxy_private_ip'] }}:3128"
           HTTPS_PROXY="http://{{ hostvars['localhost']['proxy_private_ip'] }}:3128"
-          NO_PROXY=".cluster.local,.svc,172.17.0.1,172.17.0.0/24,172.30.1.1"
+          NO_PROXY="localhost,127.0.0.1,.cluster.local,.svc,172.17.0.1,172.17.0.0/24,172.30.1.1"
     become: true
 
   - name: Restart docker service to pick up proxy changes

--- a/ansible/roles/broker_proxy_setup/templates/broker-proxy-config.yml.j2
+++ b/ansible/roles/broker_proxy_setup/templates/broker-proxy-config.yml.j2
@@ -2,7 +2,7 @@ apiVersion: v1
 data:
   HTTP_PROXY: http://{{ hostvars['localhost']['proxy_private_ip'] }}:3128
   HTTPS_PROXY: http://{{ hostvars['localhost']['proxy_private_ip'] }}:3128
-  NO_PROXY: .cluster.local,.svc,172.30.0.0/16,172.30.0.1
+  NO_PROXY: localhost,127.0.0.1,.cluster.local,.svc,172.30.0.0/16,172.30.0.1
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/ansible/roles/openshift_proxy_setup/tasks/main.yml
+++ b/ansible/roles/openshift_proxy_setup/tasks/main.yml
@@ -9,10 +9,10 @@
       block: |
           export http_proxy=http://{{ proxy_private_ip }}:3128/
           export https_proxy=http://{{ proxy_private_ip }}:3128/
-          export no_proxy=.cluster.local,.svc,172.17.0.1,172.17.0.0/24
+          export no_proxy=localhost,127.0.0.1,.cluster.local,.svc,172.17.0.1,172.17.0.0/24
           export HTTP_PROXY=http://{{ proxy_private_ip }}:3128/
           export HTTPS_PROXY=http://{{ proxy_private_ip }}:3128/
-          export NO_PROXY=.cluster.local,.svc,172.17.0.1,172.17.0.0/24
+          export NO_PROXY=localhost,127.0.0.1,.cluster.local,.svc,172.17.0.1,172.17.0.0/24
     become: true
     register: proxy_update_result
 


### PR DESCRIPTION
I found that trying to run `apb relist` and `apb bootstrap` didn't work in a proxied EC2 env after deployment. This fixed the issue for me. I plan to test this on Monday.