### PR TITLE
Don't use sudo when waiting for SSH on OpenShift host

### DIFF
--- a/ansible/roles/openshift_proxy_setup/tasks/main.yml
+++ b/ansible/roles/openshift_proxy_setup/tasks/main.yml
@@ -30,4 +30,5 @@
 
   - name: Wait for SSH to come up on OpenShift instance {{ hostname }}
     local_action: wait_for host="{{ hostname }}" port=22 delay=0 timeout=320 state=started
+    become: false
     when: proxy_update_result|changed


### PR DESCRIPTION
The task which waits for SSH to come up on the OpenShift instance was using a default setting of `become: true` which caused the operation to fail on machines where a password is required for sudo.