### PR TITLE
add broker_dao_type to enable crd

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -129,6 +129,8 @@ broker_image: "{{ broker_image_name }}:{{ broker_tag }}"
 # Used to determine if the APB namespace should be kept
 broker_keep_namespace: false
 broker_keep_namespace_on_error: true
+# crd is also valid
+broker_dao_type: "etcd"
 
 # AWS Broker
 deploy_asb: True

--- a/ansible/roles/ansible_service_broker_setup/tasks/openshift.yml
+++ b/ansible/roles/ansible_service_broker_setup/tasks/openshift.yml
@@ -122,6 +122,7 @@
         -p AUTO_ESCALATE={{ broker_auto_escalate|bool }}
         -p KEEP_NAMESPACE={{ broker_keep_namespace|bool }}
         -p KEEP_NAMESPACE_ON_ERROR={{ broker_keep_namespace_on_error|bool }}
+        -p DAO_TYPE={{ broker_dao_type }}
         {% if broker_kind is defined %}-p BROKER_KIND={{ broker_kind }}{% endif %}
         {% if broker_auth is defined %}-p BROKER_AUTH='{{ broker_auth }}'{% endif %}
 

--- a/ansible/roles/awsservicebroker_setup/tasks/main.yml
+++ b/ansible/roles/awsservicebroker_setup/tasks/main.yml
@@ -154,6 +154,7 @@
         -p AUTO_ESCALATE={{ broker_auto_escalate|bool }}
         -p KEEP_NAMESPACE={{ broker_keep_namespace|bool }}
         -p KEEP_NAMESPACE_ON_ERROR={{ broker_keep_namespace_on_error|bool }}
+        -p DAO_TYPE={{ broker_dao_type }}
         {% if broker_kind is defined %}-p BROKER_KIND={{ broker_kind }}{% endif %}
         {% if broker_auth is defined %}-p BROKER_AUTH='{{ broker_auth }}'{% endif %}
 


### PR DESCRIPTION
This will allow you to enable CRD in the broker. When CRDs are enabled you can use `oc` to see what's being stored.

For example, `oc get bundles -o yaml` will show you all of the apbs you have.

