### PR TITLE
Fix SSL on EC2 for 3.10

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -96,9 +96,20 @@ origin_image_tag: latest
 oc_cluster_up_retries: 0
 oc_cluster_up_base_dir: /tmp/openshift.local.clusterup
 oc_host_config_dir: "{{ oc_cluster_up_base_dir }}"
-cluster_master_config_file: "{{ oc_host_config_dir }}/master/master-config.yaml"
-cluster_auth_htpasswd_file: "{{ oc_host_config_dir }}/master/catasb_auth_htpasswd"
 persistent_vol_mount_point: "{{ oc_cluster_up_base_dir }}/openshift.local.pv"
+cluster_master_config_file: "{{ oc_host_config_dir }}/kube-apiserver/master-config.yaml"
+
+cluster_auth_htpasswd_file_name: catasb_auth_htpasswd
+cluster_auth_htpasswd_config_ref: "{{ cluster_auth_htpasswd_file_name }}"
+cluster_auth_htpasswd_dest_path: "{{ oc_host_config_dir }}/kube-apiserver/{{ cluster_auth_htpasswd_file_name }}"
+
+console_cert_file_name: console-fullchain.pem
+console_cert_config_ref: "{{ console_cert_file_name }}"
+console_cert_dest_path: "{{ oc_host_config_dir }}/kube-apiserver/{{ console_cert_file_name }}"
+
+console_key_file_name: console-privkey.pem
+console_key_config_ref: "{{ console_key_file_name }}"
+console_key_dest_path: "{{ oc_host_config_dir }}/kube-apiserver/{{ console_key_file_name }}"
 
 asb_project: ansible-service-broker
 

--- a/ansible/roles/openshift_setup/tasks/main.yml
+++ b/ansible/roles/openshift_setup/tasks/main.yml
@@ -303,13 +303,40 @@
     when: generate_config and use_ssl == True
     become: true
 
-  - name: Edit master-config servingInfo.namedCertificates to use SSL
-    lineinfile:
-      dest: "{{ cluster_master_config_file }}"
-      regexp: "namedCertificates: null"
-      line: "  namedCertificates:\n    - certFile: {{ console_cert_config_ref }}\n      keyFile: {{ console_key_config_ref }}\n      names:\n      - \"{{ hostname }}\"\n"
+  - name: Put base64 contents of {{ cluster_master_config_file }} into master_config
+    slurp:
+      src: "{{ cluster_master_config_file }}"
+    register: master_config
     when: generate_config and use_ssl == True
     become: true
+
+  - name: Parse master_config as YAML
+    set_fact:
+      master_config: "{{ master_config.content | b64decode |from_yaml }}"
+    when: generate_config and use_ssl == True
+
+  - name: Create named_certificates_config var with references to LetsEncrypt cert/key
+    set_fact:
+      named_certificates_config:
+        servingInfo:
+          namedCertificates:
+          - certFile: "{{ console_cert_config_ref }}"
+            keyFile: "{{ console_key_config_ref }}"
+            names:
+              - "{{ hostname }}"
+    when: generate_config and use_ssl == True
+
+  - name: Merge master_config with named_certicates_config
+    set_fact:
+      master_config: "{{ master_config | combine(named_certificates_config, recursive=True) }}"
+    when: generate_config and use_ssl == True
+
+  - name: Copy master_config back to {{ cluster_master_config_file }}
+    copy:
+      content: "{{ master_config }}"
+      dest: "{{ cluster_master_config_file }}"
+    become: true
+    when: generate_config and use_ssl == True
 
   - name: Edit node config cgroup-driver
     become: true
@@ -352,7 +379,7 @@
     when: use_ssl == True
     become: true
 
-  # --use-existing-config is has been removed in 3.10
+  # --use-existing-config has been removed in 3.10
   - name: Update oc cluster up command to use --use-existing-config
     set_fact:
       oc_cluster_up_cmd: "{{ oc_cluster_up_cmd }} --use-existing-config"

--- a/ansible/roles/openshift_setup/tasks/main.yml
+++ b/ansible/roles/openshift_setup/tasks/main.yml
@@ -212,12 +212,16 @@
       oc_cluster_up_base_dir: /var/lib/origin/openshift.local.config
       oc_host_config_dir: /var/lib/origin/openshift.local.config
       cluster_master_config_file: /var/lib/origin/openshift.local.config/master/master-config.yaml
-      cluster_auth_htpasswd_file: /var/lib/origin/openshift.local.config/master/catasb_auth_htpasswd
+      cluster_auth_htpasswd_dest_path: /var/lib/origin/openshift.local.config/master/{{ cluster_auth_htpasswd_file_name }}
+      cluster_auth_htpasswd_config_ref: /var/lib/origin/openshift.local.config/master/{{ cluster_auth_htpasswd_file_name }}
+      console_cert_dest_path: /var/lib/origin/openshift.local.config/master/{{ console_cert_file_name }}
+      console_key_dest_path: /var/lib/origin/openshift.local.config/master/{{ console_key_file_name }}
+      console_cert_config_ref: /var/lib/origin/openshift.local.config/master/{{ console_cert_file_name }}
+      console_key_config_ref: /var/lib/origin/openshift.local.config/master/{{ console_key_file_name }}
     when:
     - ("v3.9" in origin_image_tag) or
         ("v3.7" in origin_image_tag) or
         ("v3.6" in origin_image_tag)
-
 
   - name: Create command line for oc cluster up execution for older oc clients, up to 3.9
     set_fact:
@@ -280,8 +284,8 @@
   - name: Copy credentials into host dir
     copy:
       remote_src: True
-      src: /tmp/console-fullchain.pem
-      dest: "{{ oc_host_config_dir }}/console-fullchain.pem"
+      src: /tmp/{{ console_cert_file_name }}
+      dest: "{{ console_cert_dest_path }}"
       owner: root
       group: root
       mode: 0644
@@ -291,8 +295,8 @@
   - name: Copy credentials into host dir
     copy:
       remote_src: True
-      src: /tmp/console-privkey.pem
-      dest: "{{ oc_host_config_dir }}/console-privkey.pem"
+      src: /tmp/{{ console_key_file_name }}
+      dest: "{{ console_key_dest_path }}"
       owner: root
       group: root
       mode: 0644
@@ -301,9 +305,9 @@
 
   - name: Edit master-config servingInfo.namedCertificates to use SSL
     lineinfile:
-      dest: "{{ oc_host_config_dir }}/master/master-config.yaml"
+      dest: "{{ cluster_master_config_file }}"
       regexp: "namedCertificates: null"
-      line: "  namedCertificates:\n    - certFile: /var/lib/origin/openshift.local.config/console-fullchain.pem\n      keyFile: /var/lib/origin/openshift.local.config/console-privkey.pem\n      names:\n      - \"{{ hostname }}\"\n"
+      line: "  namedCertificates:\n    - certFile: {{ console_cert_config_ref }}\n      keyFile: {{ console_key_config_ref }}\n      names:\n      - \"{{ hostname }}\"\n"
     when: generate_config and use_ssl == True
     become: true
 
@@ -319,19 +323,19 @@
     package:
       name: python-passlib
       state: installed
-    become: 'true'
     when: use_ssl == True
+    become: true
 
   - name: Create htpasswd file for cluster user auth
     htpasswd:
-      path: "{{ cluster_auth_htpasswd_file }}"
+      path: "{{ cluster_auth_htpasswd_dest_path }}"
       name: "{{ cluster_user }}"
       password: "{{ cluster_user_password }}"
       owner: root
       group: root
       mode: 0640
-    become: 'true'
     when: use_ssl == True
+    become: true
 
   - name: Copy update_oauth_provider_to_htpasswd.py
     copy:
@@ -341,15 +345,21 @@
       group: root
       mode: 0755
     when: use_ssl == True
+    become: true
 
   - name: Update master-config.yaml with htpasswd file
-    shell: "/tmp/update_oauth_provider_to_htpasswd.py {{ cluster_master_config_file }} {{ cluster_auth_htpasswd_file }}"
+    shell: "/tmp/update_oauth_provider_to_htpasswd.py {{ cluster_master_config_file }} {{ cluster_auth_htpasswd_config_ref }}"
     when: use_ssl == True
+    become: true
 
+  # --use-existing-config is has been removed in 3.10
   - name: Update oc cluster up command to use --use-existing-config
     set_fact:
       oc_cluster_up_cmd: "{{ oc_cluster_up_cmd }} --use-existing-config"
-    when: use_custom_config
+    when: use_custom_config and
+      ( ("v3.9" in origin_image_tag) or
+        ("v3.7" in origin_image_tag) or
+        ("v3.6" in origin_image_tag) )
 
   - debug:
       msg: "Looking at oc cluster up command:  '{{ oc_cluster_up_cmd }}'"


### PR DESCRIPTION
Origin 3.10 introduced componentization, which moved our master-config file of interest from `master/master-config.yaml` to `kube-apiserver/master-config.yaml`. 

 **Changes necessary to get SSL working on 3.10**
- Path of master-config file changes
- Config directives in `kube-apiserver/master-config.yaml` must now use relative path (relative to `kube-apiserver` dir) to reference namedCertificate values
- Removed `--use-existing-config`, for 3.10+ (option no longer exists)
- Replaced `lineinfile` file editing with ansible dictionary `combine` filter since we are starting to see some YAML files actually containing JSON.


**Already tested with**
- 3.10 with SSL
- 3.10 no SSL
- 3.9 with SSL
