### PR TITLE
Do not supply "DAO_TYPE" param to AWS Broker template.

### DIFF
--- a/ansible/roles/awsservicebroker_setup/tasks/main.yml
+++ b/ansible/roles/awsservicebroker_setup/tasks/main.yml
@@ -154,7 +154,6 @@
         -p AUTO_ESCALATE={{ broker_auto_escalate|bool }}
         -p KEEP_NAMESPACE={{ broker_keep_namespace|bool }}
         -p KEEP_NAMESPACE_ON_ERROR={{ broker_keep_namespace_on_error|bool }}
-        -p DAO_TYPE={{ broker_dao_type }}
         {% if broker_kind is defined %}-p BROKER_KIND={{ broker_kind }}{% endif %}
         {% if broker_auth is defined %}-p BROKER_AUTH='{{ broker_auth }}'{% endif %}
 


### PR DESCRIPTION
`DAO_TYPE` param does not and has never existed on the AWS Broker deploy template, should be removed from the corresponding catasb task. AWS Broker is not yet on 3.10.