### PR TITLE
On AWS, allow all outbound conn types, not only TCP.

### DIFF
--- a/ansible/roles/aws_infrastructure/tasks/minimal_network.yml
+++ b/ansible/roles/aws_infrastructure/tasks/minimal_network.yml
@@ -98,7 +98,7 @@
       vpc_id:           "{{ vpc_id }}"
       region:           "{{ aws_region }}"
       rules_egress:
-        - proto:        "tcp"
+        - proto:        "all"
           from_port:    "0"
           to_port:      "65535"
           cidr_ip:      "{{ vpc_cidr_block }}"
@@ -217,7 +217,7 @@
       vpc_id:           "{{ vpc_id }}"
       region:           "{{ aws_region }}"
       rules_egress:
-        - proto:        "tcp"
+        - proto:        "all"
           from_port:    "0"
           to_port:      "65535"
           cidr_ip:      "{{ vpc_cidr_block }}"
@@ -281,7 +281,7 @@
       vpc_id:           "{{ vpc_id }}"
       region:           "{{ aws_region }}"
       rules_egress:
-        - proto:        "tcp"
+        - proto:        "all"
           from_port:    "0"
           to_port:      "65535"
           cidr_ip:      "0.0.0.0/0"


### PR DESCRIPTION
During multi-node testing, we were seeing failure to communicate between containers scheduled to separate nodes. 

I added network egress restrictions when adding proxy support. During this process I accidentally restricted outgoing traffic to TCP only. 

ec2_group module reference: https://docs.ansible.com/ansible/2.4/ec2_group_module.html