### PR TITLE
Add ability to deploy OLM + Admin Console for 3.11+

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -20,31 +20,31 @@ aws_role_arn_name: "aws-broker-cloudformation"
 # us-east-1
 ##
 aws_region: us-east-1
-aws_ami_id: ami-26ebbc5c
+aws_ami_id: ami-6871a115
 
 ##
 # us-east-2
 ##
 #aws_region: us-east-2
-#aws_ami_id: ami-0b1e356e
+#aws_ami_id: ami-03291866
 
 ##
 # us-west-1
 ##
 #aws_region: us-west-1
-#aws_ami_id:  ami-77a2a317
+#aws_ami_id: ami-18726478
 
 ##
 # us-west-2
 ##
 #aws_region: us-west-2
-#aws_ami_id: ami-223f945a
+#aws_ami_id: ami-28e07e50
 
 ##
 # Canada
 ##
 #aws_region: ca-central-1
-#aws_ami_id: ami-c1cb4ea5
+#aws_ami_id: ami-49f0762d
 
 instance_type: c4.4xlarge
 proxy_instance_type: m4.large

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -252,3 +252,5 @@ docker_images_group6:
   - { img: "{{ origin_image_name }}-sti-builder", tag: "{{ origin_image_tag }}" }
 
 coalmine_svc_catalog: quay.io/kubernetes-service-catalog/service-catalog:canary
+
+deploy_olm: true

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -253,4 +253,12 @@ docker_images_group6:
 
 coalmine_svc_catalog: quay.io/kubernetes-service-catalog/service-catalog:canary
 
-deploy_olm: true
+# OLM / Admin Console deploy controls
+# Note: The admin console is currently deployed without login support.
+# This means that the admin console URL will let anyone with access control the cluster
+deploy_olm: false
+deploy_admin_console: false
+olm_version: "0.6.0"
+admin_console_image: "quay.io/openshift/origin-console:latest"
+
+

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -253,12 +253,5 @@ docker_images_group6:
 
 coalmine_svc_catalog: quay.io/kubernetes-service-catalog/service-catalog:canary
 
-# OLM / Admin Console deploy controls
-# Note: The admin console is currently deployed without login support.
-# This means that the admin console URL will let anyone with access control the cluster
-deploy_olm: false
-deploy_admin_console: false
-olm_version: "0.6.0"
-admin_console_image: "quay.io/openshift/origin-console:latest"
 
 

--- a/ansible/reset_aws_environment.yml
+++ b/ansible/reset_aws_environment.yml
@@ -62,7 +62,7 @@
             SSH Key Name:              {{ ssh_key_name }}
             Region:                    {{ aws_region }}
             Next steps:
-            Web: https://{{ hostname }}:8443
+            OpenShift Web Console: https://{{ hostname }}:8443/console
             CLI: oc login --insecure-skip-tls-verify {{ hostname }}:8443 -u {{ cluster_user }} -p {{ cluster_user_password }}
       when: cluster == 'openshift'
 

--- a/ansible/reset_aws_environment.yml
+++ b/ansible/reset_aws_environment.yml
@@ -53,6 +53,7 @@
     - { role: "{{ cluster }}_setup", reset_cluster: True }
     - { role: ansible_service_broker_setup, when: deploy_asb == True}
     - { role: awsservicebroker_setup, when: deploy_awsservicebroker == True}
+    - role: olm_setup
   post_tasks:
     - set_fact:
         msg: |
@@ -76,3 +77,7 @@
 
     - debug:
         msg: "{{ msg.split('\n') }}"
+
+    - debug:
+        msg: "OpenShift Admin Console: http://{{ admin_console_url }}"
+      when: (cluster == 'openshift') and (deploy_admin_console == true)

--- a/ansible/roles/aws_docker_setup/tasks/minimal.yml
+++ b/ansible/roles/aws_docker_setup/tasks/minimal.yml
@@ -54,3 +54,12 @@
       file:
         path: /var/run/docker.sock
         mode: 0666
+
+  - name: Remove /home/ec2-user/.docker directory if present
+    file:
+      state: absent
+      path: /home/ec2-user/.docker
+    become: true
+
+  - name: "Reinitialize /home/ec2-user/.docker"
+    shell: mkdir /home/ec2-user/.docker && echo "{}" > /home/ec2-user/.docker/config.json

--- a/ansible/roles/olm_setup/defaults/main.yml
+++ b/ansible/roles/olm_setup/defaults/main.yml
@@ -1,7 +1,7 @@
 deploy_admin_console: true
 deploy_olm: true
 
-olm_version: "0.6.0"
+olm_version: "0.7.0"
 admin_console_image: "quay.io/openshift/origin-console:latest"
 
 

--- a/ansible/roles/olm_setup/defaults/main.yml
+++ b/ansible/roles/olm_setup/defaults/main.yml
@@ -1,1 +1,7 @@
+deploy_admin_console: true
+deploy_olm: true
+
 olm_version: "0.6.0"
+admin_console_image: "quay.io/openshift/origin-console:latest"
+
+

--- a/ansible/roles/olm_setup/defaults/main.yml
+++ b/ansible/roles/olm_setup/defaults/main.yml
@@ -1,0 +1,1 @@
+olm_version: "0.6.0"

--- a/ansible/roles/olm_setup/files/0.6.0/01-alm-operator.serviceaccount.yaml
+++ b/ansible/roles/olm_setup/files/0.6.0/01-alm-operator.serviceaccount.yaml
@@ -1,0 +1,9 @@
+##---
+# Source: olm/templates/01-alm-operator.serviceaccount.yaml
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: olm-operator-serviceaccount
+  namespace: kube-system
+imagePullSecrets:
+- name: coreos-pull-secret

--- a/ansible/roles/olm_setup/files/0.6.0/01-alm-operator.serviceaccount.yaml
+++ b/ansible/roles/olm_setup/files/0.6.0/01-alm-operator.serviceaccount.yaml
@@ -4,6 +4,6 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: olm-operator-serviceaccount
-  namespace: kube-system
+  namespace: operator-lifecycle-manager
 imagePullSecrets:
 - name: coreos-pull-secret

--- a/ansible/roles/olm_setup/files/0.6.0/02-alm-operator.rolebinding.yaml
+++ b/ansible/roles/olm_setup/files/0.6.0/02-alm-operator.rolebinding.yaml
@@ -1,0 +1,14 @@
+##---
+# Source: olm/templates/02-alm-operator.rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: olm-operator-binding-kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: olm-operator-serviceaccount
+  namespace: kube-system

--- a/ansible/roles/olm_setup/files/0.6.0/02-alm-operator.rolebinding.yaml
+++ b/ansible/roles/olm_setup/files/0.6.0/02-alm-operator.rolebinding.yaml
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: olm-operator-serviceaccount
-  namespace: kube-system
+  namespace: operator-lifecycle-manager

--- a/ansible/roles/olm_setup/files/0.6.0/03-clusterserviceversion.crd.yaml
+++ b/ansible/roles/olm_setup/files/0.6.0/03-clusterserviceversion.crd.yaml
@@ -1,0 +1,438 @@
+##---
+# Source: olm/templates/03-clusterserviceversion.crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterserviceversions.operators.coreos.com
+  annotations:
+    displayName: Operator Version
+    description: Represents an Operator that should be running on the cluster, including requirements and install strategy.
+spec:
+  names:
+    plural: clusterserviceversions
+    singular: clusterserviceversion
+    kind: ClusterServiceVersion
+    listKind: ClusterServiceVersionList
+    shortNames:
+    - csv
+    categories:
+    - all
+    - olm
+  additionalPrinterColumns:
+  - name: Display
+    type: string
+    description: The name of the CSV
+    JSONPath: .spec.displayName
+  - name: Version
+    type: string
+    description: The version of the CSV
+    JSONPath: .spec.version
+  - name: Replaces
+    type: string
+    description: The name of a CSV that this one replaces
+    JSONPath: .spec.replaces
+  - name: Phase
+    type: string
+    JSONPath: .status.phase
+  group: operators.coreos.com
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  scope: Namespaced
+  subresources:
+    # status enables the status subresource.
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          description: Spec for a ClusterServiceVersion
+          required:
+          - displayName
+          - install
+          properties:
+            displayName:
+              type: string
+              description: Human readable name of the application that will be displayed in the ALM UI
+
+            description:
+              type: string
+              description: Human readable description of what the application does
+
+            keywords:
+              type: array
+              description: List of keywords which will be used to discover and categorize app types
+              items:
+                type: string
+
+            maintainers:
+              type: array
+              description: Those responsible for the creation of this specific app type
+              items:
+                type: object
+                description: Information for a single maintainer
+                required:
+                - name
+                - email
+                properties:
+                  name:
+                    type: string
+                    description: Maintainer's name
+                  email:
+                    type: string
+                    description: Maintainer's email address
+                    format: email
+                optionalProperties:
+                  type: string
+                  description: "Any additional key-value metadata you wish to expose about the maintainer, e.g. github: <username>"
+
+            links:
+              type: array
+              description: Interesting links to find more information about the project, such as marketing page, documentation, or github page
+              items:
+                type: object
+                description: A single link to describe one aspect of the project
+                required:
+                - name
+                - url
+                properties:
+                  name:
+                    type: string
+                    description: Name of the link type, e.g. homepage or github url
+                  url:
+                    type: string
+                    description: URL to which the link should point
+                    format: uri
+
+            icon:
+              type: array
+              description: Icon which should be rendered with the application information
+              required:
+              - base64data
+              - mediatype
+              properties:
+                base64data:
+                  type: string
+                  description: Base64 binary representation of the icon image
+                  pattern: ^(?:[A-Za-z0-9+/]{4}){0,16250}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$
+                mediatype:
+                  type: string
+                  description: Mediatype for the binary data specified in the base64data property
+                  enum:
+                  - image/gif
+                  - image/jpeg
+                  - image/png
+                  - image/svg+xml
+            version:
+              type: string
+              description: Version string, recommended that users use semantic versioning
+              pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$
+
+            replaces:
+              type: string
+              description: Name of the ClusterServiceVersion custom resource that this version replaces
+
+            maturity:
+              type: string
+              description: What level of maturity the software has achieved at this version
+              enum:
+              - planning
+              - pre-alpha
+              - alpha
+              - beta
+              - stable
+              - mature
+              - inactive
+              - deprecated
+            labels:
+              type: object
+              description: Labels that will be applied to associated resources created by the operator.
+            selector:
+              type: object
+              description: Label selector to find resources associated with or managed by the operator
+              properties:
+                matchLabels:
+                  type: object
+                  description: Label key:value pairs to match directly
+                matchExpressions:
+                  type: array
+                  description: A set of expressions to match against the resource.
+                  items:
+                    allOf:
+                      - type: object
+                        required:
+                        - key
+                        - operator
+                        - values
+                        properties:
+                          key:
+                            type: string
+                            description: the key to match
+                          operator:
+                            type: string
+                            description: the operator for the expression
+                            enum:
+                            - In
+                            - NotIn
+                            - Exists
+                            - DoesNotExist
+                          values:
+                            type: array
+                            description: set of values for the expression
+            customresourcedefinitions:
+              type: object
+              properties:
+                owned:
+                  type: array
+                  description: What resources this operator is responsible for managing. No two running operators should manage the same resource.
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - version
+                      - kind
+                      - displayName
+                      - description
+                    properties:
+                      name:
+                        type: string
+                        description: Fully qualified name of the CustomResourceDefinition (e.g. my-resource-v1.app.coreos.com)
+                      version:
+                        type: string
+                        description: The version field of the CustomResourceDefinition
+                      kind:
+                        type: string
+                        description: The kind field of the CustomResourceDefinition
+                      displayName:
+                        type: string
+                        description: A human-readable name for the CRD.
+                      description:
+                        type: string
+                        description: A description of the CRD
+                      resources:
+                        type: array
+                        items:
+                          type: object
+                          description: A list of resources that should be displayed for the CRD
+                          required:
+                            - kind
+                            - version
+                          properties:
+                            name:
+                              type: string
+                              description: If a CRD, the fully qualified name of the CustomResourceDefinition (e.g. my-resource-v1.app.coreos.com)
+                            version:
+                              type: string
+                              description: The version of the resource kind
+                            kind:
+                              type: string
+                              description: The kind field of the resource kind
+                      statusDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the status block of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the status object on the CR where the the status value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the status entry.
+                            description:
+                              type: string
+                              description: A description of the status entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the status entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              type: object
+                              description: If present, the value of this status is the same for all instances of the CRD and can be found here instead of on the CR.
+                      specDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the spec block of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the spec object on the CR where the the spec value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the spec entry.
+                            description:
+                              type: string
+                              description: A description of the spec entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the spec entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              type: object
+                              description: If present, the value of this spec is the same for all instances of the CRD and can be found here instead of on the CR.
+                required:
+                  type: array
+                  description: What resources this operator is responsible for managing. No two running operators should manage the same resource.
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - version
+                      - kind
+                      - displayName
+                      - description
+                    properties:
+                      name:
+                        type: string
+                        description: Fully qualified name of the CustomResourceDefinition (e.g. my-resource-v1.app.coreos.com)
+                      version:
+                        type: string
+                        description: The version field of the CustomResourceDefinition
+                      kind:
+                        type: string
+                        description: The kind field of the CustomResourceDefinition
+                      displayName:
+                        type: string
+                        description: A human-readable name for the CRD.
+                      description:
+                        type: string
+                        description: A description of the CRD
+                      statusDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the status block of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the status object on the CR where the the status value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the status entry.
+                            description:
+                              type: string
+                              description: A description of the status entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the status entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              type: object
+                              description: If present, the value of this status is the same for all instances of the CRD and can be found here instead of on the CR.
+
+
+            install:
+              type: object
+              description: Information required to install this specific version of the operator software
+              oneOf:
+              - type: object
+                required:
+                - strategy
+                - spec
+                properties:
+                  strategy:
+                    type: string
+                    enum: ['image']
+                  spec:
+                    type: object
+                    required:
+                    - image
+                    properties:
+                      image:
+                        type: string
+              - type: object
+                required:
+                - strategy
+                - spec
+                properties:
+                  strategy:
+                    type: string
+                    enum: ['deployment']
+                  spec:
+                    type: object
+                    required:
+                    - deployments
+                    properties:
+                      deployments:
+                        type: array
+                        description: List of deployments to create
+                        items:
+                          type: object
+                          description: A name and deployment to create in the cluster
+                          required:
+                            - name
+                            - spec
+                          properties:
+                            name:
+                              type: string
+                              description: the consistent name of the deployment
+                            spec:
+                              type: object
+                              description: The deployment spec to create in the cluster
+                      permissions:
+                        type: array
+                        description: Permissions needed by the deployement to run correctly
+                        items:
+                          type: object
+                          required:
+                            - serviceAccountName
+                            - rules
+                          properties:
+                            serviceAccountName:
+                              type: string
+                              description: The service account name to create for the deployment
+                            rules:
+                              type: array
+                              items:
+                                type: object
+                                description: a rule required by the service account
+                                properties:
+                                  apiGroups:
+                                    type: array
+                                    description: apiGroups the rule applies to
+                                    items:
+                                      type: string
+                                  resources:
+                                    type: array
+                                    items:
+                                      type: string
+                                  resourceNames:
+                                    type: array
+                                    items:
+                                      type: string
+                                  verbs:
+                                    type: array
+                                    items:
+                                      type: string
+                                      enum:
+                                        - "*"
+                                        - get
+                                        - list
+                                        - watch
+                                        - create
+                                        - update
+                                        - patch
+                                        - delete
+                                        - deletecollection
+        status:
+          type: object
+          description: Status for a ClusterServiceVersion

--- a/ansible/roles/olm_setup/files/0.6.0/05-catalogsource.crd.yaml
+++ b/ansible/roles/olm_setup/files/0.6.0/05-catalogsource.crd.yaml
@@ -1,0 +1,81 @@
+##---
+# Source: olm/templates/05-catalogsource.crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: catalogsources.operators.coreos.com
+  annotations:
+    displayName: CatalogSource
+    description: A source configured to find packages and updates.
+spec:
+  group: operators.coreos.com
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: catalogsources
+    singular: catalogsource
+    kind: CatalogSource
+    listKind: CatalogSourceList
+    categories:
+    - all
+    - olm
+  additionalPrinterColumns:
+  - name: Name
+    type: string
+    description: The pretty name of the catalog
+    JSONPath: .spec.displayName
+  - name: Type
+    type: string
+    description: The type of the catalog
+    JSONPath: .spec.sourceType
+  - name: Publisher
+    type: string
+    description: The publisher of the catalog
+    JSONPath: .spec.publisher
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    # status enables the status subresource.
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          description: Represents a subscription to a source and channel
+          required:
+          - spec
+          type: object
+          description: Spec for a catalog source.
+          required:
+          - sourceType
+          properties:
+            sourceType:
+              type: string
+              description: The type of the source. Currently the only supported type is "internal".
+              enum:
+              - internal
+
+            configMap:
+              type: string
+              description: The name of a ConfigMap that holds the entries for an in-memory catalog.
+
+            displayName:
+              type: string
+              description: Pretty name for display
+
+            publisher:
+              type: string
+              description: The name of an entity that publishes this catalog
+
+            secrets:
+              type: array
+              description: A set of secrets that can be used to access the contents of the catalog. It is best to keep this list small, since each will need to be tried for every catalog entry.
+              items:
+                type: string
+                description: A name of a secret in the namespace where the CatalogSource is defined.

--- a/ansible/roles/olm_setup/files/0.6.0/06-installplan.crd.yaml
+++ b/ansible/roles/olm_setup/files/0.6.0/06-installplan.crd.yaml
@@ -1,0 +1,78 @@
+##---
+# Source: olm/templates/06-installplan.crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: installplans.operators.coreos.com
+  annotations:
+    displayName: Install Plan
+    description: Represents a plan to install and resolve dependencies for Cluster Services
+spec:
+  group: operators.coreos.com
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: installplans
+    singular: installplan
+    kind: InstallPlan
+    listKind: InstallPlanList
+    categories:
+    - all
+    - olm
+  additionalPrinterColumns:
+  - name: CSV
+    type: string
+    description: The first CSV in the list of clusterServiceVersionNames
+    JSONPath: .spec.clusterServiceVersionNames[0]
+  - name: Source
+    type: string
+    description: The catalog source for the specified CSVs.
+    JSONPath: .spec.source
+  - name: Approval
+    type: string
+    description: The approval mode
+    JSONPath: .spec.approval
+  - name: Approved
+    type: boolean
+    JSONPath: .spec.approved
+  subresources:
+    # status enables the status subresource.
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          description: Spec for an InstallPlan
+          required:
+          - clusterServiceVersionNames
+          - approval
+          properties:
+            source:
+              type: string
+              description: Name of the preferred CatalogSource
+            sourceNamespace:
+              type: string
+              description: Namespace that contains the preffered CatalogSource
+            clusterServiceVersionNames:
+              type: array
+              description: A list of the names of the Cluster Services
+              items:
+                type: string
+          anyOf:
+            - properties:
+                approval:
+                  enum:
+                    - Manual
+                approved:
+                  type: boolean
+              required:
+                - approved
+            - properties:
+                approval:
+                  enum:
+                    - Automatic

--- a/ansible/roles/olm_setup/files/0.6.0/07-subscription.crd.yaml
+++ b/ansible/roles/olm_setup/files/0.6.0/07-subscription.crd.yaml
@@ -1,0 +1,72 @@
+##---
+# Source: olm/templates/07-subscription.crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: subscriptions.operators.coreos.com
+  annotations:
+    displayName: Subscription
+    description: Subcribes service catalog to a source and channel to recieve updates for packages.
+spec:
+  group: operators.coreos.com
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: subscriptions
+    singular: subscription
+    kind: Subscription
+    listKind: SubscriptionList
+    categories:
+    - all
+    - olm
+  additionalPrinterColumns:
+  - name: Package
+    type: string
+    description: The package subscribed to
+    JSONPath: .spec.name
+  - name: Source
+    type: string
+    description: The catalog source for the specified package
+    JSONPath: .spec.source
+  - name: Channel
+    type: string
+    description: The channel of updates to subscribe to
+    JSONPath: .spec.channel
+  subresources:
+    # status enables the status subresource.
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          description: Spec for a Subscription
+          required:
+          - source
+          - name
+          properties:
+            source:
+              type: string
+              description: Name of a CatalogSource that defines where and how to find the channel
+            sourceNamespace:
+              type: string
+              description: The Kubernetes namespace where the CatalogSource used is located
+            name:
+              type: string
+              description: Name of the package that defines the application
+            channel:
+              type: string
+              description: Name of the channel to track
+            startingCSV:
+              type: string
+              description: Name of the AppType that this subscription tracks
+            installPlanApproval:
+              type: string
+              description: Approval mode for emitted InstallPlans
+              enum:
+              - Manual
+              - Automatic

--- a/ansible/roles/olm_setup/files/0.6.0/08-ocs.configmap.yaml
+++ b/ansible/roles/olm_setup/files/0.6.0/08-ocs.configmap.yaml
@@ -1,0 +1,7254 @@
+##---
+# Source: olm/templates/08-ocs.configmap.yaml
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ocs
+  namespace: kube-system
+
+data:
+  customResourceDefinitions: |-
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: alertmanagers.monitoring.coreos.com
+      spec:
+        group: monitoring.coreos.com
+        names:
+          kind: Alertmanager
+          plural: alertmanagers
+        scope: Namespaced
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                description: 'Specification of the desired behavior of the Alertmanager
+                  cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+                properties:
+                  affinity:
+                    description: Affinity is a group of affinity scheduling rules.
+                    properties:
+                      nodeAffinity:
+                        description: Node affinity is a group of node affinity scheduling
+                          rules.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes
+                              that satisfy the affinity expressions specified by this field,
+                              but it may choose a node that violates one or more of the
+                              expressions. The node that is most preferred is the one with
+                              the greatest sum of weights, i.e. for each node that meets
+                              all of the scheduling requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating through
+                              the elements of this field and adding "weight" to the sum
+                              if the node matches the corresponding matchExpressions; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all
+                                objects with implicit weight 0 (i.e. it's a no-op). A null
+                                preferred scheduling term matches no objects (i.e. is also
+                                a no-op).
+                              properties:
+                                preference:
+                                  description: A null or empty node selector term matches
+                                    no objects. The requirements of them are ANDed. The
+                                    TopologySelectorTerm type implements a subset of the
+                                    NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the
+                                              operator is In or NotIn, the values array
+                                              must be non-empty. If the operator is Exists
+                                              or DoesNotExist, the values array must be
+                                              empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will
+                                              be interpreted as an integer. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the
+                                              operator is In or NotIn, the values array
+                                              must be non-empty. If the operator is Exists
+                                              or DoesNotExist, the values array must be
+                                              empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will
+                                              be interpreted as an integer. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                weight:
+                                  description: Weight associated with matching the corresponding
+                                    nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - preference
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: A node selector represents the union of the results
+                              of one or more label queries over a set of nodes; that is,
+                              it represents the OR of the selectors represented by the node
+                              selector terms.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The
+                                  terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches
+                                    no objects. The requirements of them are ANDed. The
+                                    TopologySelectorTerm type implements a subset of the
+                                    NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the
+                                              operator is In or NotIn, the values array
+                                              must be non-empty. If the operator is Exists
+                                              or DoesNotExist, the values array must be
+                                              empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will
+                                              be interpreted as an integer. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the
+                                              operator is In or NotIn, the values array
+                                              must be non-empty. If the operator is Exists
+                                              or DoesNotExist, the values array must be
+                                              empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will
+                                              be interpreted as an integer. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                      podAffinity:
+                        description: Pod affinity is a group of inter pod affinity scheduling
+                          rules.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes
+                              that satisfy the affinity expressions specified by this field,
+                              but it may choose a node that violates one or more of the
+                              expressions. The node that is most preferred is the one with
+                              the greatest sum of weights, i.e. for each node that meets
+                              all of the scheduling requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating through
+                              the elements of this field and adding "weight" to the sum
+                              if the node has pods which matches the corresponding podAffinityTerm;
+                              the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Defines a set of pods (namely those matching
+                                    the labelSelector relative to the given namespace(s))
+                                    that this pod should be co-located (affinity) or not
+                                    co-located (anti-affinity) with, where co-located is
+                                    defined as running on a node whose value of the label
+                                    with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label selector is a label query over
+                                        a set of resources. The result of matchLabels and
+                                        matchExpressions are ANDed. An empty label selector
+                                        matches all objects. A null label selector matches
+                                        no objects.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label
+                                            selector requirements. The requirements are
+                                            ANDed.
+                                          items:
+                                            description: A label selector requirement is
+                                              a selector that contains values, a key, and
+                                              an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If
+                                                  the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array
+                                                  is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                          type: array
+                                        matchLabels:
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is "In",
+                                            and the values array contains only "value".
+                                            The requirements are ANDed.
+                                          type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified namespaces,
+                                        where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches
+                                        that of any node on which any of the selected pods
+                                        is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                weight:
+                                  description: weight associated with matching the corresponding
+                                    podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - podAffinityTerm
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this
+                              field are not met at scheduling time, the pod will not be
+                              scheduled onto the node. If the affinity requirements specified
+                              by this field cease to be met at some point during pod execution
+                              (e.g. due to a pod label update), the system may or may not
+                              try to eventually evict the pod from its node. When there
+                              are multiple elements, the lists of nodes corresponding to
+                              each podAffinityTerm are intersected, i.e. all terms must
+                              be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s)) that
+                                this pod should be co-located (affinity) or not co-located
+                                (anti-affinity) with, where co-located is defined as running
+                                on a node whose value of the label with key <topologyKey>
+                                matches that of any node on which a pod of the set of pods
+                                is running
+                              properties:
+                                labelSelector:
+                                  description: A label selector is a label query over a
+                                    set of resources. The result of matchLabels and matchExpressions
+                                    are ANDed. An empty label selector matches all objects.
+                                    A null label selector matches no objects.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector
+                                        requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator is
+                                              Exists or DoesNotExist, the values array must
+                                              be empty. This array is replaced during a
+                                              strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                    matchLabels:
+                                      description: matchLabels is a map of {key,value} pairs.
+                                        A single {key,value} in the matchLabels map is equivalent
+                                        to an element of matchExpressions, whose key field
+                                        is "key", the operator is "In", and the values array
+                                        contains only "value". The requirements are ANDed.
+                                      type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the
+                                    labelSelector applies to (matches against); null or
+                                    empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where
+                                    co-located is defined as running on a node whose value
+                                    of the label with key topologyKey matches that of any
+                                    node on which any of the selected pods is running. Empty
+                                    topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                            type: array
+                      podAntiAffinity:
+                        description: Pod anti affinity is a group of inter pod anti affinity
+                          scheduling rules.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes
+                              that satisfy the anti-affinity expressions specified by this
+                              field, but it may choose a node that violates one or more
+                              of the expressions. The node that is most preferred is the
+                              one with the greatest sum of weights, i.e. for each node that
+                              meets all of the scheduling requirements (resource request,
+                              requiredDuringScheduling anti-affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field
+                              and adding "weight" to the sum if the node has pods which
+                              matches the corresponding podAffinityTerm; the node(s) with
+                              the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Defines a set of pods (namely those matching
+                                    the labelSelector relative to the given namespace(s))
+                                    that this pod should be co-located (affinity) or not
+                                    co-located (anti-affinity) with, where co-located is
+                                    defined as running on a node whose value of the label
+                                    with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label selector is a label query over
+                                        a set of resources. The result of matchLabels and
+                                        matchExpressions are ANDed. An empty label selector
+                                        matches all objects. A null label selector matches
+                                        no objects.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label
+                                            selector requirements. The requirements are
+                                            ANDed.
+                                          items:
+                                            description: A label selector requirement is
+                                              a selector that contains values, a key, and
+                                              an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If
+                                                  the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array
+                                                  is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                          type: array
+                                        matchLabels:
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is "In",
+                                            and the values array contains only "value".
+                                            The requirements are ANDed.
+                                          type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified namespaces,
+                                        where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches
+                                        that of any node on which any of the selected pods
+                                        is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                weight:
+                                  description: weight associated with matching the corresponding
+                                    podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - podAffinityTerm
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by
+                              this field are not met at scheduling time, the pod will not
+                              be scheduled onto the node. If the anti-affinity requirements
+                              specified by this field cease to be met at some point during
+                              pod execution (e.g. due to a pod label update), the system
+                              may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding
+                              to each podAffinityTerm are intersected, i.e. all terms must
+                              be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s)) that
+                                this pod should be co-located (affinity) or not co-located
+                                (anti-affinity) with, where co-located is defined as running
+                                on a node whose value of the label with key <topologyKey>
+                                matches that of any node on which a pod of the set of pods
+                                is running
+                              properties:
+                                labelSelector:
+                                  description: A label selector is a label query over a
+                                    set of resources. The result of matchLabels and matchExpressions
+                                    are ANDed. An empty label selector matches all objects.
+                                    A null label selector matches no objects.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector
+                                        requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator is
+                                              Exists or DoesNotExist, the values array must
+                                              be empty. This array is replaced during a
+                                              strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                    matchLabels:
+                                      description: matchLabels is a map of {key,value} pairs.
+                                        A single {key,value} in the matchLabels map is equivalent
+                                        to an element of matchExpressions, whose key field
+                                        is "key", the operator is "In", and the values array
+                                        contains only "value". The requirements are ANDed.
+                                      type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the
+                                    labelSelector applies to (matches against); null or
+                                    empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where
+                                    co-located is defined as running on a node whose value
+                                    of the label with key topologyKey matches that of any
+                                    node on which any of the selected pods is running. Empty
+                                    topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                            type: array
+                  baseImage:
+                    description: Base image that is used to deploy pods, without tag.
+                    type: string
+                  containers:
+                    description: Containers allows injecting additional containers. This
+                      is meant to allow adding an authentication proxy to an Alertmanager
+                      pod.
+                    items:
+                      description: A single application container that you want to run within
+                        a pod.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The docker image''s
+                            CMD is used if this is not provided. Variable references $(VAR_NAME)
+                            are expanded using the container''s environment. If a variable
+                            cannot be resolved, the reference in the input string will be
+                            unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                            $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot be
+                            updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell. The
+                            docker image''s ENTRYPOINT is used if this is not provided.
+                            Variable references $(VAR_NAME) are expanded using the container''s
+                            environment. If a variable cannot be resolved, the reference
+                            in the input string will be unchanged. The $(VAR_NAME) syntax
+                            can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable exists
+                            or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the container.
+                            Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable present
+                              in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must be a
+                                  C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are expanded
+                                  using the previous defined environment variables in the
+                                  container and any service environment variables. If a
+                                  variable cannot be resolved, the reference in the input
+                                  string will be unchanged. The $(VAR_NAME) syntax can be
+                                  escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                                  will never be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
+                                type: string
+                              valueFrom:
+                                description: EnvVarSource represents a source for the value
+                                  of an EnvVar.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key from a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or it's
+                                          key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                  fieldRef:
+                                    description: ObjectFieldSelector selects an APIVersioned
+                                      field of an object.
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in the
+                                          specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                  resourceFieldRef:
+                                    description: ResourceFieldSelector represents container
+                                      resources (cpu, memory) and their output format
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for volumes,
+                                          optional for env vars'
+                                        type: string
+                                      divisor: {}
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                  secretKeyRef:
+                                    description: SecretKeySelector selects a key of a Secret.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must
+                                          be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or it's
+                                          key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                            required:
+                            - name
+                          type: array
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must be a
+                            C_IDENTIFIER. All invalid keys will be reported as an event
+                            when the container is starting. When a key exists in multiple
+                            sources, the value associated with the last source will take
+                            precedence. Values defined by an Env with a duplicate key will
+                            take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a set of
+                              ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: |-
+                                  ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+      
+                                  The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must be defined
+                                    type: boolean
+                              prefix:
+                                description: An optional identifier to prepend to each key
+                                  in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: |-
+                                  SecretEnvSource selects a Secret to populate the environment variables with.
+      
+                                  The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be defined
+                                    type: boolean
+                          type: array
+                        image:
+                          description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management
+                            to default or override container images in workload controllers
+                            like Deployments and StatefulSets.'
+                          type: string
+                        imagePullPolicy:
+                          description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                            Defaults to Always if :latest tag is specified, or IfNotPresent
+                            otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                          type: string
+                        lifecycle:
+                          description: Lifecycle describes actions that the management system
+                            should take in response to container lifecycle events. For the
+                            PostStart and PreStop lifecycle handlers, management of the
+                            container blocks until the action is complete, unless the container
+                            process fails, in which case the handler is aborted.
+                          properties:
+                            postStart:
+                              description: Handler defines a specific action that should
+                                be taken
+                              properties:
+                                exec:
+                                  description: ExecAction describes a "run in container"
+                                    action.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to execute
+                                        inside the container, the working directory for
+                                        the command  is root ('/') in the container's filesystem.
+                                        The command is simply exec'd, it is not run inside
+                                        a shell, so traditional shell instructions ('|',
+                                        etc) won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is treated
+                                        as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                httpGet:
+                                  description: HTTPGetAction describes an action based on
+                                    HTTP Get requests.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults to
+                                        the pod IP. You probably want to set "Host" in httpHeaders
+                                        instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom header
+                                          to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                    scheme:
+                                      description: Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                tcpSocket:
+                                  description: TCPSocketAction describes an action based
+                                    on opening a socket
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect to, defaults
+                                        to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                  required:
+                                  - port
+                            preStop:
+                              description: Handler defines a specific action that should
+                                be taken
+                              properties:
+                                exec:
+                                  description: ExecAction describes a "run in container"
+                                    action.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to execute
+                                        inside the container, the working directory for
+                                        the command  is root ('/') in the container's filesystem.
+                                        The command is simply exec'd, it is not run inside
+                                        a shell, so traditional shell instructions ('|',
+                                        etc) won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is treated
+                                        as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                httpGet:
+                                  description: HTTPGetAction describes an action based on
+                                    HTTP Get requests.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults to
+                                        the pod IP. You probably want to set "Host" in httpHeaders
+                                        instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom header
+                                          to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                    scheme:
+                                      description: Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                tcpSocket:
+                                  description: TCPSocketAction describes an action based
+                                    on opening a socket
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect to, defaults
+                                        to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                  required:
+                                  - port
+                        livenessProbe:
+                          description: Probe describes a health check to be performed against
+                            a container to determine whether it is alive or ready to receive
+                            traffic.
+                          properties:
+                            exec:
+                              description: ExecAction describes a "run in container" action.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute inside
+                                    the container, the working directory for the command  is
+                                    root ('/') in the container's filesystem. The command
+                                    is simply exec'd, it is not run inside a shell, so traditional
+                                    shell instructions ('|', etc) won't work. To use a shell,
+                                    you need to explicitly call out to that shell. Exit
+                                    status of 0 is treated as live/healthy and non-zero
+                                    is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe to
+                                be considered failed after having succeeded. Defaults to
+                                3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGetAction describes an action based on HTTP
+                                Get requests.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to the
+                                    pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request. HTTP
+                                    allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header to
+                                      be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: string
+                                  - type: integer
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has started
+                                before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe to
+                                be considered successful after having failed. Defaults to
+                                1. Must be 1 for liveness. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocketAction describes an action based on
+                                opening a socket
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: string
+                                  - type: integer
+                              required:
+                              - port
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe times
+                                out. Defaults to 1 second. Minimum value is 1. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                        name:
+                          description: Name of the container specified as a DNS_LABEL. Each
+                            container in a pod must have a unique name (DNS_LABEL). Cannot
+                            be updated.
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container. Exposing
+                            a port here gives the system additional information about the
+                            network connections a container uses, but is primarily informational.
+                            Not specifying a port here DOES NOT prevent that port from being
+                            exposed. Any port which is listening on the default "0.0.0.0"
+                            address inside a container will be accessible from the network.
+                            Cannot be updated.
+                          items:
+                            description: ContainerPort represents a network port in a single
+                              container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's IP address.
+                                  This must be a valid port number, 0 < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host. If specified,
+                                  this must be a valid port number, 0 < x < 65536. If HostNetwork
+                                  is specified, this must match ContainerPort. Most containers
+                                  do not need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a pod must
+                                  have a unique name. Name for the port that can be referred
+                                  to by services.
+                                type: string
+                              protocol:
+                                description: Protocol for port. Must be UDP or TCP. Defaults
+                                  to "TCP".
+                                type: string
+                            required:
+                            - containerPort
+                          type: array
+                        readinessProbe:
+                          description: Probe describes a health check to be performed against
+                            a container to determine whether it is alive or ready to receive
+                            traffic.
+                          properties:
+                            exec:
+                              description: ExecAction describes a "run in container" action.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute inside
+                                    the container, the working directory for the command  is
+                                    root ('/') in the container's filesystem. The command
+                                    is simply exec'd, it is not run inside a shell, so traditional
+                                    shell instructions ('|', etc) won't work. To use a shell,
+                                    you need to explicitly call out to that shell. Exit
+                                    status of 0 is treated as live/healthy and non-zero
+                                    is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe to
+                                be considered failed after having succeeded. Defaults to
+                                3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGetAction describes an action based on HTTP
+                                Get requests.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to the
+                                    pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request. HTTP
+                                    allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header to
+                                      be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: string
+                                  - type: integer
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has started
+                                before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe to
+                                be considered successful after having failed. Defaults to
+                                1. Must be 1 for liveness. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocketAction describes an action based on
+                                opening a socket
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: string
+                                  - type: integer
+                              required:
+                              - port
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe times
+                                out. Defaults to 1 second. Minimum value is 1. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                        resources:
+                          description: ResourceRequirements describes the compute resource
+                            requirements.
+                          properties:
+                            limits:
+                              description: 'Limits describes the maximum amount of compute
+                                resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              description: 'Requests describes the minimum amount of compute
+                                resources required. If Requests is omitted for a container,
+                                it defaults to Limits if that is explicitly specified, otherwise
+                                to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                        securityContext:
+                          description: SecurityContext holds security configuration that
+                            will be applied to a container. Some fields are present in both
+                            SecurityContext and PodSecurityContext.  When both are set,
+                            the values in SecurityContext take precedence.
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether a
+                                process can gain more privileges than its parent process.
+                                This bool directly controls if the no_new_privs flag will
+                                be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN'
+                              type: boolean
+                            capabilities:
+                              description: Adds and removes POSIX capabilities from running
+                                containers.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                            privileged:
+                              description: Run container in privileged mode. Processes in
+                                privileged containers are essentially equivalent to root
+                                on the host. Defaults to false.
+                              type: boolean
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only root filesystem.
+                                Default is false.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be set
+                                in PodSecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as a non-root
+                                user. If true, the Kubelet will validate the image at runtime
+                                to ensure that it does not run as UID 0 (root) and fail
+                                to start the container if it does. If unset or false, no
+                                such validation will be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext, the
+                                value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata if
+                                unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext, the
+                                value specified in SecurityContext takes precedence.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: SELinuxOptions are the labels to be applied to
+                                the container
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                        stdin:
+                          description: Whether this container should allocate a buffer for
+                            stdin in the container runtime. If this is not set, reads from
+                            stdin in the container will always result in EOF. Default is
+                            false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close the stdin
+                            channel after it has been opened by a single attach. When stdin
+                            is true the stdin stream will remain open across multiple attach
+                            sessions. If stdinOnce is set to true, stdin is opened on container
+                            start, is empty until the first client attaches to stdin, and
+                            then remains open and accepts data until the client disconnects,
+                            at which time stdin is closed and remains closed until the container
+                            is restarted. If this flag is false, a container processes that
+                            reads from stdin will never receive an EOF. Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which the container''s
+                            termination message will be written is mounted into the container''s
+                            filesystem. Message written is intended to be brief final status,
+                            such as an assertion failure message. Will be truncated by the
+                            node if greater than 4096 bytes. The total message length across
+                            all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: Indicate how the termination message should be populated.
+                            File will use the contents of terminationMessagePath to populate
+                            the container status message on both success and failure. FallbackToLogsOnError
+                            will use the last chunk of container log output if the termination
+                            message file is empty and the container exited with an error.
+                            The log output is limited to 2048 bytes or 80 lines, whichever
+                            is smaller. Defaults to File. Cannot be updated.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY for
+                            itself, also requires 'stdin' to be true. Default is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices to be
+                            used by the container. This is an alpha feature and may change
+                            in the future.
+                          items:
+                            description: volumeDevice describes a mapping of a raw block
+                              device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the container
+                                  that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - name
+                            - devicePath
+                          type: array
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume within
+                              a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the volume
+                                  should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts are
+                                  propagated from the host to container and the other way
+                                  around. When not set, MountPropagationHostToContainer
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write otherwise
+                                  (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the container's
+                                  volume should be mounted. Defaults to "" (volume's root).
+                                type: string
+                            required:
+                            - name
+                            - mountPath
+                          type: array
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might be
+                            configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                    type: array
+                  externalUrl:
+                    description: The external URL the Alertmanager instances will be available
+                      under. This is necessary to generate correct URLs. This is necessary
+                      if Alertmanager is not served from root of a DNS name.
+                    type: string
+                  imagePullSecrets:
+                    description: An optional list of references to secrets in the same namespace
+                      to use for pulling prometheus and alertmanager images from registries
+                      see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
+                    items:
+                      description: LocalObjectReference contains enough information to let
+                        you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                    type: array
+                  listenLocal:
+                    description: ListenLocal makes the Alertmanager server listen on loopback,
+                      so that it does not bind against the Pod IP. Note this is only for
+                      the Alertmanager UI, not the gossip communication.
+                    type: boolean
+                  logLevel:
+                    description: Log level for Alertmanager to be configured with.
+                    type: string
+                  nodeSelector:
+                    description: Define which Nodes the Pods are scheduled on.
+                    type: object
+                  paused:
+                    description: If set to true all actions on the underlaying managed objects
+                      are not goint to be performed, except for delete actions.
+                    type: boolean
+                  podMetadata:
+                    description: ObjectMeta is metadata that all persisted resources must
+                      have, which includes all objects users must create.
+                    properties:
+                      annotations:
+                        description: 'Annotations is an unstructured key value map stored
+                          with a resource that may be set by external tools to store and
+                          retrieve arbitrary metadata. They are not queryable and should
+                          be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      clusterName:
+                        description: The name of the cluster which the object belongs to.
+                          This is used to distinguish resources with same name and namespace
+                          in different clusters. This field is not set anywhere right now
+                          and apiserver is going to ignore it if set in create or update
+                          request.
+                        type: string
+                      creationTimestamp:
+                        description: Time is a wrapper around time.Time which supports correct
+                          marshaling to YAML and JSON.  Wrappers are provided for many of
+                          the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                      deletionGracePeriodSeconds:
+                        description: Number of seconds allowed for this object to gracefully
+                          terminate before it will be removed from the system. Only set
+                          when deletionTimestamp is also set. May only be shortened. Read-only.
+                        format: int64
+                        type: integer
+                      deletionTimestamp:
+                        description: Time is a wrapper around time.Time which supports correct
+                          marshaling to YAML and JSON.  Wrappers are provided for many of
+                          the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                      finalizers:
+                        description: Must be empty before the object is deleted from the
+                          registry. Each entry is an identifier for the responsible component
+                          that will remove the entry from the list. If the deletionTimestamp
+                          of the object is non-nil, entries in this list can only be removed.
+                        items:
+                          type: string
+                        type: array
+                      generateName:
+                        description: |-
+                          GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+      
+                          If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+      
+                          Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                        type: string
+                      generation:
+                        description: A sequence number representing a specific generation
+                          of the desired state. Populated by the system. Read-only.
+                        format: int64
+                        type: integer
+                      initializers:
+                        description: Initializers tracks the progress of initialization.
+                        properties:
+                          pending:
+                            description: Pending is a list of initializers that must execute
+                              in order before this object is visible. When the last pending
+                              initializer is removed, and no failing result is set, the
+                              initializers struct will be set to nil and the object is considered
+                              as initialized and visible to all clients.
+                            items:
+                              description: Initializer is information about an initializer
+                                that has not yet completed.
+                              properties:
+                                name:
+                                  description: name of the process that is responsible for
+                                    initializing this object.
+                                  type: string
+                              required:
+                              - name
+                            type: array
+                          result:
+                            description: Status is a return value for calls that don't return
+                              other objects.
+                            properties:
+                              apiVersion:
+                                description: 'APIVersion defines the versioned schema of
+                                  this representation of an object. Servers should convert
+                                  recognized schemas to the latest internal value, and may
+                                  reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                                type: string
+                              code:
+                                description: Suggested HTTP return code for this status,
+                                  0 if not set.
+                                format: int32
+                                type: integer
+                              details:
+                                description: StatusDetails is a set of additional properties
+                                  that MAY be set by the server to provide additional information
+                                  about a response. The Reason field of a Status object
+                                  defines what attributes will be set. Clients must ignore
+                                  fields that do not match the defined type of each attribute,
+                                  and should assume that any attribute may be empty, invalid,
+                                  or under defined.
+                                properties:
+                                  causes:
+                                    description: The Causes array includes more details
+                                      associated with the StatusReason failure. Not all
+                                      StatusReasons may provide detailed causes.
+                                    items:
+                                      description: StatusCause provides more information
+                                        about an api.Status failure, including cases when
+                                        multiple errors are encountered.
+                                      properties:
+                                        field:
+                                          description: |-
+                                            The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+      
+                                            Examples:
+                                              "name" - the field "name" on the current resource
+                                              "items[0].name" - the field "name" on the first array entry in "items"
+                                          type: string
+                                        message:
+                                          description: A human-readable description of the
+                                            cause of the error.  This field may be presented
+                                            as-is to a reader.
+                                          type: string
+                                        reason:
+                                          description: A machine-readable description of
+                                            the cause of the error. If this value is empty
+                                            there is no information available.
+                                          type: string
+                                    type: array
+                                  group:
+                                    description: The group attribute of the resource associated
+                                      with the status StatusReason.
+                                    type: string
+                                  kind:
+                                    description: 'The kind attribute of the resource associated
+                                      with the status StatusReason. On some operations may
+                                      differ from the requested resource Kind. More info:
+                                      https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                    type: string
+                                  name:
+                                    description: The name attribute of the resource associated
+                                      with the status StatusReason (when there is a single
+                                      name which can be described).
+                                    type: string
+                                  retryAfterSeconds:
+                                    description: If specified, the time in seconds before
+                                      the operation should be retried. Some errors may indicate
+                                      the client must take an alternate action - for those
+                                      errors this field may indicate how long to wait before
+                                      taking the alternate action.
+                                    format: int32
+                                    type: integer
+                                  uid:
+                                    description: 'UID of the resource. (when there is a
+                                      single resource which can be described). More info:
+                                      http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                    type: string
+                              kind:
+                                description: 'Kind is a string value representing the REST
+                                  resource this object represents. Servers may infer this
+                                  from the endpoint the client submits requests to. Cannot
+                                  be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                type: string
+                              message:
+                                description: A human-readable description of the status
+                                  of this operation.
+                                type: string
+                              metadata:
+                                description: ListMeta describes metadata that synthetic
+                                  resources must have, including lists and various status
+                                  objects. A resource may have only one of {ObjectMeta,
+                                  ListMeta}.
+                                properties:
+                                  continue:
+                                    description: continue may be set if the user set a limit
+                                      on the number of items returned, and indicates that
+                                      the server has more data available. The value is opaque
+                                      and may be used to issue another request to the endpoint
+                                      that served this list to retrieve the next set of
+                                      available objects. Continuing a list may not be possible
+                                      if the server configuration has changed or more than
+                                      a few minutes have passed. The resourceVersion field
+                                      returned when using this continue value will be identical
+                                      to the value in the first response.
+                                    type: string
+                                  resourceVersion:
+                                    description: 'String that identifies the server''s internal
+                                      version of this object that can be used by clients
+                                      to determine when objects have changed. Value must
+                                      be treated as opaque by clients and passed unmodified
+                                      back to the server. Populated by the system. Read-only.
+                                      More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                                    type: string
+                                  selfLink:
+                                    description: selfLink is a URL representing this object.
+                                      Populated by the system. Read-only.
+                                    type: string
+                              reason:
+                                description: A machine-readable description of why this
+                                  operation is in the "Failure" status. If this value is
+                                  empty there is no information available. A Reason clarifies
+                                  an HTTP status code but does not override it.
+                                type: string
+                              status:
+                                description: 'Status of the operation. One of: "Success"
+                                  or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                                type: string
+                        required:
+                        - pending
+                      labels:
+                        description: 'Map of string keys and values that can be used to
+                          organize and categorize (scope and select) objects. May match
+                          selectors of replication controllers and services. More info:
+                          http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                      name:
+                        description: 'Name must be unique within a namespace. Is required
+                          when creating resources, although some resources may allow a client
+                          to request the generation of an appropriate name automatically.
+                          Name is primarily intended for creation idempotence and configuration
+                          definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+      
+                          Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                        type: string
+                      ownerReferences:
+                        description: List of objects depended by this object. If ALL objects
+                          in the list have been deleted, this object will be garbage collected.
+                          If this object is managed by a controller, then an entry in this
+                          list will point to this controller, with the controller field
+                          set to true. There cannot be more than one managing controller.
+                        items:
+                          description: OwnerReference contains enough information to let
+                            you identify an owning object. Currently, an owning object must
+                            be in the same namespace, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: If true, AND if the owner has the "foregroundDeletion"
+                                finalizer, then the owner cannot be deleted from the key-value
+                                store until this reference is removed. Defaults to false.
+                                To set this field, a user needs "delete" permission of the
+                                owner, otherwise 422 (Unprocessable Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing
+                                controller.
+                              type: boolean
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                        type: array
+                      resourceVersion:
+                        description: |-
+                          An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+      
+                          Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      selfLink:
+                        description: SelfLink is a URL representing this object. Populated
+                          by the system. Read-only.
+                        type: string
+                      uid:
+                        description: |-
+                          UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+      
+                          Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                        type: string
+                  replicas:
+                    description: Size is the expected size of the alertmanager cluster.
+                      The controller will eventually make the size of the running cluster
+                      equal to the expected size.
+                    format: int32
+                    type: integer
+                  resources:
+                    description: ResourceRequirements describes the compute resource requirements.
+                    properties:
+                      limits:
+                        description: 'Limits describes the maximum amount of compute resources
+                          allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        description: 'Requests describes the minimum amount of compute resources
+                          required. If Requests is omitted for a container, it defaults
+                          to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                  routePrefix:
+                    description: The route prefix Alertmanager registers HTTP handlers for.
+                      This is useful, if using ExternalURL and a proxy is rewriting HTTP
+                      routes of a request, and the actual ExternalURL is still true, but
+                      the server serves requests under a different route prefix. For example
+                      for use with `kubectl proxy`.
+                    type: string
+                  secrets:
+                    description: Secrets is a list of Secrets in the same namespace as the
+                      Alertmanager object, which shall be mounted into the Alertmanager
+                      Pods. The Secrets are mounted into /etc/alertmanager/secrets/<secret-name>.
+                    items:
+                      type: string
+                    type: array
+                  securityContext:
+                    description: PodSecurityContext holds pod-level security attributes
+                      and common container settings. Some fields are also present in container.securityContext.  Field
+                      values of container.securityContext take precedence over field values
+                      of PodSecurityContext.
+                    properties:
+                      fsGroup:
+                        description: |-
+                          A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+      
+                          1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+      
+                          If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                        format: int64
+                        type: integer
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail to start
+                          the container if it does. If unset or false, no such validation
+                          will be performed. May also be set in SecurityContext.  If set
+                          in both SecurityContext and PodSecurityContext, the value specified
+                          in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified. May
+                          also be set in SecurityContext.  If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: SELinuxOptions are the labels to be applied to the
+                          container
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies to the
+                              container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies to the
+                              container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies to the
+                              container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies to the
+                              container.
+                            type: string
+                      supplementalGroups:
+                        description: A list of groups applied to the first process run in
+                          each container, in addition to the container's primary GID.  If
+                          unspecified, no groups will be added to any container.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used for
+                          the pod. Pods with unsupported sysctls (by the container runtime)
+                          might fail to launch.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                        type: array
+                  serviceAccountName:
+                    description: ServiceAccountName is the name of the ServiceAccount to
+                      use to run the Prometheus Pods.
+                    type: string
+                  storage:
+                    description: StorageSpec defines the configured storage for a group
+                      Prometheus servers.
+                    properties:
+                      class:
+                        description: 'Name of the StorageClass to use when requesting storage
+                          provisioning. More info: https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses
+                          DEPRECATED'
+                        type: string
+                      emptyDir:
+                        description: Represents an empty directory for a pod. Empty directory
+                          volumes support ownership management and SELinux relabeling.
+                        properties:
+                          medium:
+                            description: 'What type of storage medium should back this directory.
+                              The default is "" which means to use the node''s default medium.
+                              Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            type: string
+                          sizeLimit: {}
+                      resources:
+                        description: ResourceRequirements describes the compute resource
+                          requirements.
+                        properties:
+                          limits:
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            description: 'Requests describes the minimum amount of compute
+                              resources required. If Requests is omitted for a container,
+                              it defaults to Limits if that is explicitly specified, otherwise
+                              to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                      selector:
+                        description: A label selector is a label query over a set of resources.
+                          The result of matchLabels and matchExpressions are ANDed. An empty
+                          label selector matches all objects. A null label selector matches
+                          no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements.
+                              The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector that
+                                contains values, a key, and an operator that relates the
+                                key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies
+                                    to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn, Exists
+                                    and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the
+                                    operator is In or NotIn, the values array must be non-empty.
+                                    If the operator is Exists or DoesNotExist, the values
+                                    array must be empty. This array is replaced during a
+                                    strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                            type: array
+                          matchLabels:
+                            description: matchLabels is a map of {key,value} pairs. A single
+                              {key,value} in the matchLabels map is equivalent to an element
+                                           of matchExpressions, whose key field is "key", the operator
+                                           is "In", and the values array contains only "value". The requirements
+                                           are ANDed.
+                            type: object
+                      volumeClaimTemplate:
+                        description: PersistentVolumeClaim is a user's request for and claim
+                          to a persistent volume
+                        properties:
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema of this
+                              representation of an object. Servers should convert recognized
+                              schemas to the latest internal value, and may reject unrecognized
+                              values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                            type: string
+                          kind:
+                            description: 'Kind is a string value representing the REST resource
+                              this object represents. Servers may infer this from the endpoint
+                              the client submits requests to. Cannot be updated. In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                            type: string
+                          metadata:
+                            description: ObjectMeta is metadata that all persisted resources
+                              must have, which includes all objects users must create.
+                            properties:
+                              annotations:
+                                description: 'Annotations is an unstructured key value map
+                                  stored with a resource that may be set by external tools
+                                  to store and retrieve arbitrary metadata. They are not
+                                  queryable and should be preserved when modifying objects.
+                                  More info: http://kubernetes.io/docs/user-guide/annotations'
+                                type: object
+                              clusterName:
+                                description: The name of the cluster which the object belongs
+                                  to. This is used to distinguish resources with same name
+                                  and namespace in different clusters. This field is not
+                                  set anywhere right now and apiserver is going to ignore
+                                  it if set in create or update request.
+                                type: string
+                              creationTimestamp:
+                                description: Time is a wrapper around time.Time which supports
+                                  correct marshaling to YAML and JSON.  Wrappers are provided
+                                  for many of the factory methods that the time package
+                                  offers.
+                                format: date-time
+                                type: string
+                              deletionGracePeriodSeconds:
+                                description: Number of seconds allowed for this object to
+                                  gracefully terminate before it will be removed from the
+                                  system. Only set when deletionTimestamp is also set. May
+                                  only be shortened. Read-only.
+                                format: int64
+                                type: integer
+                              deletionTimestamp:
+                                description: Time is a wrapper around time.Time which supports
+                                  correct marshaling to YAML and JSON.  Wrappers are provided
+                                  for many of the factory methods that the time package
+                                  offers.
+                                format: date-time
+                                type: string
+                              finalizers:
+                                description: Must be empty before the object is deleted
+                                  from the registry. Each entry is an identifier for the
+                                  responsible component that will remove the entry from
+                                  the list. If the deletionTimestamp of the object is non-nil,
+                                  entries in this list can only be removed.
+                                items:
+                                  type: string
+                                type: array
+                              generateName:
+                                description: |-
+                                  GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+      
+                                  If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+      
+                                  Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                                type: string
+                              generation:
+                                description: A sequence number representing a specific generation
+                                  of the desired state. Populated by the system. Read-only.
+                                format: int64
+                                type: integer
+                              initializers:
+                                description: Initializers tracks the progress of initialization.
+                                properties:
+                                  pending:
+                                    description: Pending is a list of initializers that
+                                      must execute in order before this object is visible.
+                                      When the last pending initializer is removed, and
+                                      no failing result is set, the initializers struct
+                                      will be set to nil and the object is considered as
+                                      initialized and visible to all clients.
+                                    items:
+                                      description: Initializer is information about an initializer
+                                        that has not yet completed.
+                                      properties:
+                                        name:
+                                          description: name of the process that is responsible
+                                            for initializing this object.
+                                          type: string
+                                      required:
+                                      - name
+                                    type: array
+                                  result:
+                                    description: Status is a return value for calls that
+                                      don't return other objects.
+                                    properties:
+                                      apiVersion:
+                                        description: 'APIVersion defines the versioned schema
+                                          of this representation of an object. Servers should
+                                          convert recognized schemas to the latest internal
+                                          value, and may reject unrecognized values. More
+                                          info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                                        type: string
+                                      code:
+                                        description: Suggested HTTP return code for this
+                                          status, 0 if not set.
+                                        format: int32
+                                        type: integer
+                                      details:
+                                        description: StatusDetails is a set of additional
+                                          properties that MAY be set by the server to provide
+                                          additional information about a response. The Reason
+                                          field of a Status object defines what attributes
+                                          will be set. Clients must ignore fields that do
+                                          not match the defined type of each attribute,
+                                          and should assume that any attribute may be empty,
+                                          invalid, or under defined.
+                                        properties:
+                                          causes:
+                                            description: The Causes array includes more
+                                              details associated with the StatusReason failure.
+                                              Not all StatusReasons may provide detailed
+                                              causes.
+                                            items:
+                                              description: StatusCause provides more information
+                                                about an api.Status failure, including cases
+                                                when multiple errors are encountered.
+                                              properties:
+                                                field:
+                                                  description: |-
+                                                    The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+      
+                                                    Examples:
+                                                      "name" - the field "name" on the current resource
+                                                      "items[0].name" - the field "name" on the first array entry in "items"
+                                                  type: string
+                                                message:
+                                                  description: A human-readable description
+                                                    of the cause of the error.  This field
+                                                    may be presented as-is to a reader.
+                                                  type: string
+                                                reason:
+                                                  description: A machine-readable description
+                                                    of the cause of the error. If this value
+                                                    is empty there is no information available.
+                                                  type: string
+                                            type: array
+                                          group:
+                                            description: The group attribute of the resource
+                                              associated with the status StatusReason.
+                                            type: string
+                                          kind:
+                                            description: 'The kind attribute of the resource
+                                              associated with the status StatusReason. On
+                                              some operations may differ from the requested
+                                              resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                            type: string
+                                          name:
+                                            description: The name attribute of the resource
+                                              associated with the status StatusReason (when
+                                              there is a single name which can be described).
+                                            type: string
+                                          retryAfterSeconds:
+                                            description: If specified, the time in seconds
+                                              before the operation should be retried. Some
+                                              errors may indicate the client must take an
+                                              alternate action - for those errors this field
+                                              may indicate how long to wait before taking
+                                              the alternate action.
+                                            format: int32
+                                            type: integer
+                                          uid:
+                                            description: 'UID of the resource. (when there
+                                              is a single resource which can be described).
+                                              More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                            type: string
+                                      kind:
+                                        description: 'Kind is a string value representing
+                                          the REST resource this object represents. Servers
+                                          may infer this from the endpoint the client submits
+                                          requests to. Cannot be updated. In CamelCase.
+                                          More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                        type: string
+                                      message:
+                                        description: A human-readable description of the
+                                          status of this operation.
+                                        type: string
+                                      metadata:
+                                        description: ListMeta describes metadata that synthetic
+                                                       resources must have, including lists and various
+                                                       status objects. A resource may have only one of
+                                          {ObjectMeta, ListMeta}.
+                                        properties:
+                                          continue:
+                                            description: continue may be set if the user
+                                              set a limit on the number of items returned,
+                                              and indicates that the server has more data
+                                              available. The value is opaque and may be
+                                              used to issue another request to the endpoint
+                                              that served this list to retrieve the next
+                                              set of available objects. Continuing a list
+                                              may not be possible if the server configuration
+                                              has changed or more than a few minutes have
+                                              passed. The resourceVersion field returned
+                                              when using this continue value will be identical
+                                              to the value in the first response.
+                                            type: string
+                                          resourceVersion:
+                                            description: 'String that identifies the server''s
+                                              internal version of this object that can be
+                                              used by clients to determine when objects
+                                              have changed. Value must be treated as opaque
+                                              by clients and passed unmodified back to the
+                                              server. Populated by the system. Read-only.
+                                              More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                                            type: string
+                                          selfLink:
+                                            description: selfLink is a URL representing
+                                              this object. Populated by the system. Read-only.
+                                            type: string
+                                      reason:
+                                        description: A machine-readable description of why
+                                          this operation is in the "Failure" status. If
+                                          this value is empty there is no information available.
+                                          A Reason clarifies an HTTP status code but does
+                                          not override it.
+                                        type: string
+                                      status:
+                                        description: 'Status of the operation. One of: "Success"
+                                          or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                                        type: string
+                                required:
+                                - pending
+                              labels:
+                                description: 'Map of string keys and values that can be
+                                  used to organize and categorize (scope and select) objects.
+                                  May match selectors of replication controllers and services.
+                                  More info: http://kubernetes.io/docs/user-guide/labels'
+                                type: object
+                              name:
+                                description: 'Name must be unique within a namespace. Is
+                                  required when creating resources, although some resources
+                                  may allow a client to request the generation of an appropriate
+                                  name automatically. Name is primarily intended for creation
+                                  idempotence and configuration definition. Cannot be updated.
+                                  More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+      
+                                  Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                                type: string
+                              ownerReferences:
+                                description: List of objects depended by this object. If
+                                  ALL objects in the list have been deleted, this object
+                                  will be garbage collected. If this object is managed by
+                                  a controller, then an entry in this list will point to
+                                  this controller, with the controller field set to true.
+                                  There cannot be more than one managing controller.
+                                items:
+                                  description: OwnerReference contains enough information
+                                    to let you identify an owning object. Currently, an
+                                    owning object must be in the same namespace, so there
+                                    is no namespace field.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    blockOwnerDeletion:
+                                      description: If true, AND if the owner has the "foregroundDeletion"
+                                                     finalizer, then the owner cannot be deleted from
+                                                     the key-value store until this reference is removed.
+                                                     Defaults to false. To set this field, a user needs
+                                                     "delete" permission of the owner, otherwise 422
+                                                     (Unprocessable Entity) will be returned.
+                                      type: boolean
+                                    controller:
+                                      description: If true, this reference points to the
+                                        managing controller.
+                                      type: boolean
+                                    kind:
+                                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                      type: string
+                                    uid:
+                                      description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                      type: string
+                                  required:
+                                  - apiVersion
+                                  - kind
+                                  - name
+                                  - uid
+                                type: array
+                              resourceVersion:
+                                description: |-
+                                  An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+      
+                                  Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              selfLink:
+                                description: SelfLink is a URL representing this object.
+                                  Populated by the system. Read-only.
+                                type: string
+                              uid:
+                                description: |-
+                                  UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+      
+                                  Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                                type: string
+                          spec:
+                            description: PersistentVolumeClaimSpec describes the common
+                              attributes of storage devices and allows a Source for provider-specific
+                              attributes
+                            properties:
+                              accessModes:
+                                description: 'AccessModes contains the desired access modes
+                                  the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceRequirements describes the compute
+                                  resource requirements.
+                                properties:
+                                  limits:
+                                    description: 'Limits describes the maximum amount of
+                                      compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                  requests:
+                                    description: 'Requests describes the minimum amount
+                                      of compute resources required. If Requests is omitted
+                                      for a container, it defaults to Limits if that is
+                                      explicitly specified, otherwise to an implementation-defined
+                                      value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                              selector:
+                                description: A label selector is a label query over a set
+                                  of resources. The result of matchLabels and matchExpressions
+                                  are ANDed. An empty label selector matches all objects.
+                                  A null label selector matches no objects.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector
+                                      requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a selector
+                                        that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship
+                                            to a set of values. Valid operators are In,
+                                            NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string values.
+                                            If the operator is In or NotIn, the values array
+                                            must be non-empty. If the operator is Exists
+                                            or DoesNotExist, the values array must be empty.
+                                            This array is replaced during a strategic merge
+                                            patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                    type: array
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value} pairs.
+                                      A single {key,value} in the matchLabels map is equivalent
+                                      to an element of matchExpressions, whose key field
+                                      is "key", the operator is "In", and the values array
+                                      contains only "value". The requirements are ANDed.
+                                    type: object
+                              storageClassName:
+                                description: 'Name of the StorageClass required by the claim.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                type: string
+                              volumeMode:
+                                description: volumeMode defines what type of volume is required
+                                  by the claim. Value of Filesystem is implied when not
+                                  included in claim spec. This is an alpha feature and may
+                                  change in the future.
+                                type: string
+                              volumeName:
+                                description: VolumeName is the binding reference to the
+                                  PersistentVolume backing this claim.
+                                type: string
+                          status:
+                            description: PersistentVolumeClaimStatus is the current status
+                              of a persistent volume claim.
+                            properties:
+                              accessModes:
+                                description: 'AccessModes contains the actual access modes
+                                  the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                items:
+                                  type: string
+                                type: array
+                              capacity:
+                                description: Represents the actual resources of the underlying
+                                  volume.
+                                type: object
+                              conditions:
+                                description: Current Condition of persistent volume claim.
+                                  If underlying persistent volume is being resized then
+                                  the Condition will be set to 'ResizeStarted'.
+                                items:
+                                  description: PersistentVolumeClaimCondition contails details
+                                    about state of pvc
+                                  properties:
+                                    lastProbeTime:
+                                      description: Time is a wrapper around time.Time which
+                                        supports correct marshaling to YAML and JSON.  Wrappers
+                                        are provided for many of the factory methods that
+                                        the time package offers.
+                                      format: date-time
+                                      type: string
+                                    lastTransitionTime:
+                                      description: Time is a wrapper around time.Time which
+                                        supports correct marshaling to YAML and JSON.  Wrappers
+                                        are provided for many of the factory methods that
+                                        the time package offers.
+                                      format: date-time
+                                      type: string
+                                    message:
+                                      description: Human-readable message indicating details
+                                        about last transition.
+                                      type: string
+                                    reason:
+                                      description: Unique, this should be a short, machine
+                                        understandable string that gives the reason for
+                                        condition's last transition. If it reports "ResizeStarted"
+                                        that means the underlying persistent volume is being
+                                        resized.
+                                      type: string
+                                    status:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
+                                  - status
+                                type: array
+                              phase:
+                                description: Phase represents the current phase of PersistentVolumeClaim.
+                                type: string
+                  tag:
+                    description: Tag of Alertmanager container image to be deployed. Defaults
+                      to the value of `version`.
+                    type: string
+                  tolerations:
+                    description: If specified, the pod's tolerations.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any
+                        taint that matches the triple <key,value,effect> using the matching
+                        operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty
+                            means match all taint effects. When specified, allowed values
+                            are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty, operator
+                            must be Exists; this combination means to match all values and
+                            all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal. Exists
+                            is equivalent to wildcard for value, so that a pod can tolerate
+                            all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the
+                            toleration (which must be of effect NoExecute, otherwise this
+                            field is ignored) tolerates the taint. By default, it is not
+                            set, which means tolerate the taint forever (do not evict).
+                            Zero and negative values will be treated as 0 (evict immediately)
+                            by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise
+                            just a regular string.
+                          type: string
+                    type: array
+                  version:
+                    description: Version the cluster should be on.
+                    type: string
+              status:
+                description: 'Most recent observed status of the Alertmanager cluster. Read-only.
+                  Not included when requesting from the apiserver, only from the Prometheus
+                  Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+                properties:
+                  availableReplicas:
+                    description: Total number of available pods (ready for at least minReadySeconds)
+                      targeted by this Alertmanager cluster.
+                    format: int32
+                    type: integer
+                  paused:
+                    description: Represents whether any actions on the underlaying managed
+                      objects are being performed. Only delete actions will be performed.
+                    type: boolean
+                  replicas:
+                    description: Total number of non-terminated pods targeted by this Alertmanager
+                      cluster (their labels match the selector).
+                    format: int32
+                    type: integer
+                  unavailableReplicas:
+                    description: Total number of unavailable pods targeted by this Alertmanager
+                      cluster.
+                    format: int32
+                    type: integer
+                  updatedReplicas:
+                    description: Total number of non-terminated pods targeted by this Alertmanager
+                      cluster that have the desired version spec.
+                    format: int32
+                    type: integer
+                required:
+                - paused
+                - replicas
+                - updatedReplicas
+                - availableReplicas
+                - unavailableReplicas
+        version: v1
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: etcdbackups.etcd.database.coreos.com
+      spec:
+        group: etcd.database.coreos.com
+        version: v1beta2
+        scope: Namespaced
+        names:
+          kind: EtcdBackup
+          listKind: EtcdBackupList
+          plural: etcdbackups
+          singular: etcdbackup
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: etcdclusters.etcd.database.coreos.com
+      spec:
+        group: etcd.database.coreos.com
+        version: v1beta2
+        scope: Namespaced
+        names:
+          plural: etcdclusters
+          singular: etcdcluster
+          kind: EtcdCluster
+          listKind: EtcdClusterList
+          shortNames:
+            - etcdclus
+            - etcd
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: etcdrestores.etcd.database.coreos.com
+      spec:
+        group: etcd.database.coreos.com
+        version: v1beta2
+        scope: Namespaced
+        names:
+          kind: EtcdRestore
+          listKind: EtcdRestoreList
+          plural: etcdrestores
+          singular: etcdrestore
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: prometheuses.monitoring.coreos.com
+      spec:
+        group: monitoring.coreos.com
+        names:
+          kind: Prometheus
+          plural: prometheuses
+        scope: Namespaced
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                description: 'Specification of the desired behavior of the Prometheus cluster.
+                  More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+                properties:
+                  additionalAlertManagerConfigs:
+                    description: SecretKeySelector selects a key of a Secret.
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be a valid
+                          secret key.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or it's key must be defined
+                        type: boolean
+                    required:
+                    - key
+                  additionalScrapeConfigs:
+                    description: SecretKeySelector selects a key of a Secret.
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be a valid
+                          secret key.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or it's key must be defined
+                        type: boolean
+                    required:
+                    - key
+                  affinity:
+                    description: Affinity is a group of affinity scheduling rules.
+                    properties:
+                      nodeAffinity:
+                        description: Node affinity is a group of node affinity scheduling
+                          rules.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes
+                              that satisfy the affinity expressions specified by this field,
+                              but it may choose a node that violates one or more of the
+                              expressions. The node that is most preferred is the one with
+                              the greatest sum of weights, i.e. for each node that meets
+                              all of the scheduling requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating through
+                              the elements of this field and adding "weight" to the sum
+                              if the node matches the corresponding matchExpressions; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all
+                                objects with implicit weight 0 (i.e. it's a no-op). A null
+                                preferred scheduling term matches no objects (i.e. is also
+                                a no-op).
+                              properties:
+                                preference:
+                                  description: A null or empty node selector term matches
+                                    no objects. The requirements of them are ANDed. The
+                                    TopologySelectorTerm type implements a subset of the
+                                    NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the
+                                              operator is In or NotIn, the values array
+                                              must be non-empty. If the operator is Exists
+                                              or DoesNotExist, the values array must be
+                                              empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will
+                                              be interpreted as an integer. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the
+                                              operator is In or NotIn, the values array
+                                              must be non-empty. If the operator is Exists
+                                              or DoesNotExist, the values array must be
+                                              empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will
+                                              be interpreted as an integer. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                weight:
+                                  description: Weight associated with matching the corresponding
+                                    nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - preference
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: A node selector represents the union of the results
+                              of one or more label queries over a set of nodes; that is,
+                              it represents the OR of the selectors represented by the node
+                              selector terms.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The
+                                  terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches
+                                    no objects. The requirements of them are ANDed. The
+                                    TopologySelectorTerm type implements a subset of the
+                                    NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the
+                                              operator is In or NotIn, the values array
+                                              must be non-empty. If the operator is Exists
+                                              or DoesNotExist, the values array must be
+                                              empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will
+                                              be interpreted as an integer. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the
+                                              operator is In or NotIn, the values array
+                                              must be non-empty. If the operator is Exists
+                                              or DoesNotExist, the values array must be
+                                              empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will
+                                              be interpreted as an integer. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                      podAffinity:
+                        description: Pod affinity is a group of inter pod affinity scheduling
+                          rules.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes
+                              that satisfy the affinity expressions specified by this field,
+                              but it may choose a node that violates one or more of the
+                              expressions. The node that is most preferred is the one with
+                              the greatest sum of weights, i.e. for each node that meets
+                              all of the scheduling requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating through
+                              the elements of this field and adding "weight" to the sum
+                              if the node has pods which matches the corresponding podAffinityTerm;
+                              the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Defines a set of pods (namely those matching
+                                    the labelSelector relative to the given namespace(s))
+                                    that this pod should be co-located (affinity) or not
+                                    co-located (anti-affinity) with, where co-located is
+                                    defined as running on a node whose value of the label
+                                    with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label selector is a label query over
+                                        a set of resources. The result of matchLabels and
+                                        matchExpressions are ANDed. An empty label selector
+                                        matches all objects. A null label selector matches
+                                        no objects.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label
+                                            selector requirements. The requirements are
+                                            ANDed.
+                                          items:
+                                            description: A label selector requirement is
+                                              a selector that contains values, a key, and
+                                              an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If
+                                                  the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array
+                                                  is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                          type: array
+                                        matchLabels:
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is "In",
+                                            and the values array contains only "value".
+                                            The requirements are ANDed.
+                                          type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified namespaces,
+                                        where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches
+                                        that of any node on which any of the selected pods
+                                        is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                weight:
+                                  description: weight associated with matching the corresponding
+                                    podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - podAffinityTerm
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this
+                              field are not met at scheduling time, the pod will not be
+                              scheduled onto the node. If the affinity requirements specified
+                              by this field cease to be met at some point during pod execution
+                              (e.g. due to a pod label update), the system may or may not
+                              try to eventually evict the pod from its node. When there
+                              are multiple elements, the lists of nodes corresponding to
+                              each podAffinityTerm are intersected, i.e. all terms must
+                              be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s)) that
+                                this pod should be co-located (affinity) or not co-located
+                                (anti-affinity) with, where co-located is defined as running
+                                on a node whose value of the label with key <topologyKey>
+                                matches that of any node on which a pod of the set of pods
+                                is running
+                              properties:
+                                labelSelector:
+                                  description: A label selector is a label query over a
+                                    set of resources. The result of matchLabels and matchExpressions
+                                    are ANDed. An empty label selector matches all objects.
+                                    A null label selector matches no objects.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector
+                                        requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator is
+                                              Exists or DoesNotExist, the values array must
+                                              be empty. This array is replaced during a
+                                              strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                    matchLabels:
+                                      description: matchLabels is a map of {key,value} pairs.
+                                        A single {key,value} in the matchLabels map is equivalent
+                                        to an element of matchExpressions, whose key field
+                                        is "key", the operator is "In", and the values array
+                                        contains only "value". The requirements are ANDed.
+                                      type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the
+                                    labelSelector applies to (matches against); null or
+                                    empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where
+                                    co-located is defined as running on a node whose value
+                                    of the label with key topologyKey matches that of any
+                                    node on which any of the selected pods is running. Empty
+                                    topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                            type: array
+                      podAntiAffinity:
+                        description: Pod anti affinity is a group of inter pod anti affinity
+                          scheduling rules.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes
+                              that satisfy the anti-affinity expressions specified by this
+                              field, but it may choose a node that violates one or more
+                              of the expressions. The node that is most preferred is the
+                              one with the greatest sum of weights, i.e. for each node that
+                              meets all of the scheduling requirements (resource request,
+                              requiredDuringScheduling anti-affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field
+                              and adding "weight" to the sum if the node has pods which
+                              matches the corresponding podAffinityTerm; the node(s) with
+                              the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Defines a set of pods (namely those matching
+                                    the labelSelector relative to the given namespace(s))
+                                    that this pod should be co-located (affinity) or not
+                                    co-located (anti-affinity) with, where co-located is
+                                    defined as running on a node whose value of the label
+                                    with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label selector is a label query over
+                                        a set of resources. The result of matchLabels and
+                                        matchExpressions are ANDed. An empty label selector
+                                        matches all objects. A null label selector matches
+                                        no objects.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label
+                                            selector requirements. The requirements are
+                                            ANDed.
+                                          items:
+                                            description: A label selector requirement is
+                                              a selector that contains values, a key, and
+                                              an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If
+                                                  the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array
+                                                  is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                          type: array
+                                        matchLabels:
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is "In",
+                                            and the values array contains only "value".
+                                            The requirements are ANDed.
+                                          type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified namespaces,
+                                        where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches
+                                        that of any node on which any of the selected pods
+                                        is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                weight:
+                                  description: weight associated with matching the corresponding
+                                    podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - podAffinityTerm
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by
+                              this field are not met at scheduling time, the pod will not
+                              be scheduled onto the node. If the anti-affinity requirements
+                              specified by this field cease to be met at some point during
+                              pod execution (e.g. due to a pod label update), the system
+                              may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding
+                              to each podAffinityTerm are intersected, i.e. all terms must
+                              be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s)) that
+                                this pod should be co-located (affinity) or not co-located
+                                (anti-affinity) with, where co-located is defined as running
+                                on a node whose value of the label with key <topologyKey>
+                                matches that of any node on which a pod of the set of pods
+                                is running
+                              properties:
+                                labelSelector:
+                                  description: A label selector is a label query over a
+                                    set of resources. The result of matchLabels and matchExpressions
+                                    are ANDed. An empty label selector matches all objects.
+                                    A null label selector matches no objects.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector
+                                        requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator is
+                                              Exists or DoesNotExist, the values array must
+                                              be empty. This array is replaced during a
+                                              strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                    matchLabels:
+                                      description: matchLabels is a map of {key,value} pairs.
+                                        A single {key,value} in the matchLabels map is equivalent
+                                        to an element of matchExpressions, whose key field
+                                        is "key", the operator is "In", and the values array
+                                        contains only "value". The requirements are ANDed.
+                                      type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the
+                                    labelSelector applies to (matches against); null or
+                                    empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where
+                                    co-located is defined as running on a node whose value
+                                    of the label with key topologyKey matches that of any
+                                    node on which any of the selected pods is running. Empty
+                                    topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                            type: array
+                  alerting:
+                    description: AlertingSpec defines parameters for alerting configuration
+                      of Prometheus servers.
+                    properties:
+                      alertmanagers:
+                        description: AlertmanagerEndpoints Prometheus should fire alerts
+                          against.
+                        items:
+                          description: AlertmanagerEndpoints defines a selection of a single
+                            Endpoints object containing alertmanager IPs to fire alerts
+                            against.
+                          properties:
+                            bearerTokenFile:
+                              description: BearerTokenFile to read from filesystem to use
+                                when authenticating to Alertmanager.
+                              type: string
+                            name:
+                              description: Name of Endpoints object in Namespace.
+                              type: string
+                            namespace:
+                              description: Namespace of Endpoints object.
+                              type: string
+                            pathPrefix:
+                              description: Prefix for the HTTP path alerts are pushed to.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: string
+                              - type: integer
+                            scheme:
+                              description: Scheme to use when firing alerts.
+                              type: string
+                            tlsConfig:
+                              description: TLSConfig specifies TLS configuration parameters.
+                              properties:
+                                caFile:
+                                  description: The CA cert to use for the targets.
+                                  type: string
+                                certFile:
+                                  description: The client cert file for the targets.
+                                  type: string
+                                insecureSkipVerify:
+                                  description: Disable target certificate validation.
+                                  type: boolean
+                                keyFile:
+                                  description: The client key file for the targets.
+                                  type: string
+                                serverName:
+                                  description: Used to verify the hostname for the targets.
+                                  type: string
+                          required:
+                          - namespace
+                          - name
+                          - port
+                        type: array
+                    required:
+                    - alertmanagers
+                  baseImage:
+                    description: Base image to use for a Prometheus deployment.
+                    type: string
+                  containers:
+                    description: Containers allows injecting additional containers. This
+                      is meant to allow adding an authentication proxy to a Prometheus pod.
+                    items:
+                      description: A single application container that you want to run within
+                        a pod.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The docker image''s
+                            CMD is used if this is not provided. Variable references $(VAR_NAME)
+                            are expanded using the container''s environment. If a variable
+                            cannot be resolved, the reference in the input string will be
+                            unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                            $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot be
+                            updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell. The
+                            docker image''s ENTRYPOINT is used if this is not provided.
+                            Variable references $(VAR_NAME) are expanded using the container''s
+                            environment. If a variable cannot be resolved, the reference
+                            in the input string will be unchanged. The $(VAR_NAME) syntax
+                            can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable exists
+                            or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the container.
+                            Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable present
+                              in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must be a
+                                  C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are expanded
+                                  using the previous defined environment variables in the
+                                  container and any service environment variables. If a
+                                  variable cannot be resolved, the reference in the input
+                                  string will be unchanged. The $(VAR_NAME) syntax can be
+                                  escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                                  will never be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
+                                type: string
+                              valueFrom:
+                                description: EnvVarSource represents a source for the value
+                                  of an EnvVar.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key from a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or it's
+                                          key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                  fieldRef:
+                                    description: ObjectFieldSelector selects an APIVersioned
+                                      field of an object.
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in the
+                                          specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                  resourceFieldRef:
+                                    description: ResourceFieldSelector represents container
+                                      resources (cpu, memory) and their output format
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for volumes,
+                                          optional for env vars'
+                                        type: string
+                                      divisor: {}
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                  secretKeyRef:
+                                    description: SecretKeySelector selects a key of a Secret.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must
+                                          be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or it's
+                                          key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                            required:
+                            - name
+                          type: array
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must be a
+                            C_IDENTIFIER. All invalid keys will be reported as an event
+                            when the container is starting. When a key exists in multiple
+                            sources, the value associated with the last source will take
+                            precedence. Values defined by an Env with a duplicate key will
+                            take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a set of
+                              ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: |-
+                                  ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+                                  The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must be defined
+                                    type: boolean
+                              prefix:
+                                description: An optional identifier to prepend to each key
+                                  in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: |-
+                                  SecretEnvSource selects a Secret to populate the environment variables with.
+                                  The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be defined
+                                    type: boolean
+                          type: array
+                        image:
+                          description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management
+                            to default or override container images in workload controllers
+                            like Deployments and StatefulSets.'
+                          type: string
+                        imagePullPolicy:
+                          description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                            Defaults to Always if :latest tag is specified, or IfNotPresent
+                            otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                          type: string
+                        lifecycle:
+                          description: Lifecycle describes actions that the management system
+                            should take in response to container lifecycle events. For the
+                            PostStart and PreStop lifecycle handlers, management of the
+                            container blocks until the action is complete, unless the container
+                            process fails, in which case the handler is aborted.
+                          properties:
+                            postStart:
+                              description: Handler defines a specific action that should
+                                be taken
+                              properties:
+                                exec:
+                                  description: ExecAction describes a "run in container"
+                                    action.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to execute
+                                        inside the container, the working directory for
+                                        the command  is root ('/') in the container's filesystem.
+                                        The command is simply exec'd, it is not run inside
+                                        a shell, so traditional shell instructions ('|',
+                                        etc) won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is treated
+                                        as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                httpGet:
+                                  description: HTTPGetAction describes an action based on
+                                    HTTP Get requests.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults to
+                                        the pod IP. You probably want to set "Host" in httpHeaders
+                                        instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom header
+                                          to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                    scheme:
+                                      description: Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                tcpSocket:
+                                  description: TCPSocketAction describes an action based
+                                    on opening a socket
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect to, defaults
+                                        to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                  required:
+                                  - port
+                            preStop:
+                              description: Handler defines a specific action that should
+                                be taken
+                              properties:
+                                exec:
+                                  description: ExecAction describes a "run in container"
+                                    action.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to execute
+                                        inside the container, the working directory for
+                                        the command  is root ('/') in the container's filesystem.
+                                        The command is simply exec'd, it is not run inside
+                                        a shell, so traditional shell instructions ('|',
+                                        etc) won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is treated
+                                        as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                httpGet:
+                                  description: HTTPGetAction describes an action based on
+                                    HTTP Get requests.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults to
+                                        the pod IP. You probably want to set "Host" in httpHeaders
+                                        instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom header
+                                          to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                    scheme:
+                                      description: Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                tcpSocket:
+                                  description: TCPSocketAction describes an action based
+                                    on opening a socket
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect to, defaults
+                                        to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                  required:
+                                  - port
+                        livenessProbe:
+                          description: Probe describes a health check to be performed against
+                            a container to determine whether it is alive or ready to receive
+                            traffic.
+                          properties:
+                            exec:
+                              description: ExecAction describes a "run in container" action.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute inside
+                                    the container, the working directory for the command  is
+                                    root ('/') in the container's filesystem. The command
+                                    is simply exec'd, it is not run inside a shell, so traditional
+                                    shell instructions ('|', etc) won't work. To use a shell,
+                                    you need to explicitly call out to that shell. Exit
+                                    status of 0 is treated as live/healthy and non-zero
+                                    is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe to
+                                be considered failed after having succeeded. Defaults to
+                                3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGetAction describes an action based on HTTP
+                                Get requests.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to the
+                                    pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request. HTTP
+                                    allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header to
+                                      be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: string
+                                  - type: integer
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has started
+                                before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe to
+                                be considered successful after having failed. Defaults to
+                                1. Must be 1 for liveness. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocketAction describes an action based on
+                                opening a socket
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: string
+                                  - type: integer
+                              required:
+                              - port
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe times
+                                out. Defaults to 1 second. Minimum value is 1. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                        name:
+                          description: Name of the container specified as a DNS_LABEL. Each
+                            container in a pod must have a unique name (DNS_LABEL). Cannot
+                            be updated.
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container. Exposing
+                            a port here gives the system additional information about the
+                            network connections a container uses, but is primarily informational.
+                            Not specifying a port here DOES NOT prevent that port from being
+                            exposed. Any port which is listening on the default "0.0.0.0"
+                            address inside a container will be accessible from the network.
+                            Cannot be updated.
+                          items:
+                            description: ContainerPort represents a network port in a single
+                              container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's IP address.
+                                  This must be a valid port number, 0 < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host. If specified,
+                                  this must be a valid port number, 0 < x < 65536. If HostNetwork
+                                  is specified, this must match ContainerPort. Most containers
+                                  do not need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a pod must
+                                  have a unique name. Name for the port that can be referred
+                                  to by services.
+                                type: string
+                              protocol:
+                                description: Protocol for port. Must be UDP or TCP. Defaults
+                                  to "TCP".
+                                type: string
+                            required:
+                            - containerPort
+                          type: array
+                        readinessProbe:
+                          description: Probe describes a health check to be performed against
+                            a container to determine whether it is alive or ready to receive
+                            traffic.
+                          properties:
+                            exec:
+                              description: ExecAction describes a "run in container" action.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute inside
+                                    the container, the working directory for the command  is
+                                    root ('/') in the container's filesystem. The command
+                                    is simply exec'd, it is not run inside a shell, so traditional
+                                    shell instructions ('|', etc) won't work. To use a shell,
+                                    you need to explicitly call out to that shell. Exit
+                                    status of 0 is treated as live/healthy and non-zero
+                                    is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe to
+                                be considered failed after having succeeded. Defaults to
+                                3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGetAction describes an action based on HTTP
+                                Get requests.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to the
+                                    pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request. HTTP
+                                    allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header to
+                                      be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: string
+                                  - type: integer
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has started
+                                before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe to
+                                be considered successful after having failed. Defaults to
+                                1. Must be 1 for liveness. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocketAction describes an action based on
+                                opening a socket
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: string
+                                  - type: integer
+                              required:
+                              - port
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe times
+                                out. Defaults to 1 second. Minimum value is 1. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                        resources:
+                          description: ResourceRequirements describes the compute resource
+                            requirements.
+                          properties:
+                            limits:
+                              description: 'Limits describes the maximum amount of compute
+                                resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              description: 'Requests describes the minimum amount of compute
+                                resources required. If Requests is omitted for a container,
+                                it defaults to Limits if that is explicitly specified, otherwise
+                                to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                        securityContext:
+                          description: SecurityContext holds security configuration that
+                            will be applied to a container. Some fields are present in both
+                            SecurityContext and PodSecurityContext.  When both are set,
+                            the values in SecurityContext take precedence.
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether a
+                                process can gain more privileges than its parent process.
+                                This bool directly controls if the no_new_privs flag will
+                                be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN'
+                              type: boolean
+                            capabilities:
+                              description: Adds and removes POSIX capabilities from running
+                                containers.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                            privileged:
+                              description: Run container in privileged mode. Processes in
+                                privileged containers are essentially equivalent to root
+                                on the host. Defaults to false.
+                              type: boolean
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only root filesystem.
+                                Default is false.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be set
+                                in PodSecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as a non-root
+                                user. If true, the Kubelet will validate the image at runtime
+                                to ensure that it does not run as UID 0 (root) and fail
+                                to start the container if it does. If unset or false, no
+                                such validation will be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext, the
+                                value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata if
+                                unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext, the
+                                value specified in SecurityContext takes precedence.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: SELinuxOptions are the labels to be applied to
+                                the container
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                        stdin:
+                          description: Whether this container should allocate a buffer for
+                            stdin in the container runtime. If this is not set, reads from
+                            stdin in the container will always result in EOF. Default is
+                            false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close the stdin
+                            channel after it has been opened by a single attach. When stdin
+                            is true the stdin stream will remain open across multiple attach
+                            sessions. If stdinOnce is set to true, stdin is opened on container
+                            start, is empty until the first client attaches to stdin, and
+                            then remains open and accepts data until the client disconnects,
+                            at which time stdin is closed and remains closed until the container
+                            is restarted. If this flag is false, a container processes that
+                            reads from stdin will never receive an EOF. Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which the container''s
+                            termination message will be written is mounted into the container''s
+                            filesystem. Message written is intended to be brief final status,
+                            such as an assertion failure message. Will be truncated by the
+                            node if greater than 4096 bytes. The total message length across
+                            all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: Indicate how the termination message should be populated.
+                            File will use the contents of terminationMessagePath to populate
+                            the container status message on both success and failure. FallbackToLogsOnError
+                            will use the last chunk of container log output if the termination
+                            message file is empty and the container exited with an error.
+                            The log output is limited to 2048 bytes or 80 lines, whichever
+                            is smaller. Defaults to File. Cannot be updated.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY for
+                            itself, also requires 'stdin' to be true. Default is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices to be
+                            used by the container. This is an alpha feature and may change
+                            in the future.
+                          items:
+                            description: volumeDevice describes a mapping of a raw block
+                              device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the container
+                                  that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - name
+                            - devicePath
+                          type: array
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume within
+                              a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the volume
+                                  should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts are
+                                  propagated from the host to container and the other way
+                                  around. When not set, MountPropagationHostToContainer
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write otherwise
+                                  (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the container's
+                                  volume should be mounted. Defaults to "" (volume's root).
+                                type: string
+                            required:
+                            - name
+                            - mountPath
+                          type: array
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might be
+                            configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                    type: array
+                  evaluationInterval:
+                    description: Interval between consecutive evaluations.
+                    type: string
+                  externalLabels:
+                    description: The labels to add to any time series or alerts when communicating
+                      with external systems (federation, remote storage, Alertmanager).
+                    type: object
+                  externalUrl:
+                    description: The external URL the Prometheus instances will be available
+                      under. This is necessary to generate correct URLs. This is necessary
+                      if Prometheus is not served from root of a DNS name.
+                    type: string
+                  imagePullSecrets:
+                    description: An optional list of references to secrets in the same namespace
+                      to use for pulling prometheus and alertmanager images from registries
+                      see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
+                    items:
+                      description: LocalObjectReference contains enough information to let
+                        you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                    type: array
+                  listenLocal:
+                    description: ListenLocal makes the Prometheus server listen on loopback,
+                      so that it does not bind against the Pod IP.
+                    type: boolean
+                  logLevel:
+                    description: Log level for Prometheus to be configured with.
+                    type: string
+                  nodeSelector:
+                    description: Define which Nodes the Pods are scheduled on.
+                    type: object
+                  paused:
+                    description: When a Prometheus deployment is paused, no actions except
+                      for deletion will be performed on the underlying objects.
+                    type: boolean
+                  podMetadata:
+                    description: ObjectMeta is metadata that all persisted resources must
+                      have, which includes all objects users must create.
+                    properties:
+                      annotations:
+                        description: 'Annotations is an unstructured key value map stored
+                          with a resource that may be set by external tools to store and
+                          retrieve arbitrary metadata. They are not queryable and should
+                          be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      clusterName:
+                        description: The name of the cluster which the object belongs to.
+                          This is used to distinguish resources with same name and namespace
+                          in different clusters. This field is not set anywhere right now
+                          and apiserver is going to ignore it if set in create or update
+                          request.
+                        type: string
+                      creationTimestamp:
+                        description: Time is a wrapper around time.Time which supports correct
+                          marshaling to YAML and JSON.  Wrappers are provided for many of
+                          the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                      deletionGracePeriodSeconds:
+                        description: Number of seconds allowed for this object to gracefully
+                          terminate before it will be removed from the system. Only set
+                          when deletionTimestamp is also set. May only be shortened. Read-only.
+                        format: int64
+                        type: integer
+                      deletionTimestamp:
+                        description: Time is a wrapper around time.Time which supports correct
+                          marshaling to YAML and JSON.  Wrappers are provided for many of
+                          the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                      finalizers:
+                        description: Must be empty before the object is deleted from the
+                          registry. Each entry is an identifier for the responsible component
+                          that will remove the entry from the list. If the deletionTimestamp
+                          of the object is non-nil, entries in this list can only be removed.
+                        items:
+                          type: string
+                        type: array
+                      generateName:
+                        description: |-
+                          GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+                          If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+                          Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                        type: string
+                      generation:
+                        description: A sequence number representing a specific generation
+                          of the desired state. Populated by the system. Read-only.
+                        format: int64
+                        type: integer
+                      initializers:
+                        description: Initializers tracks the progress of initialization.
+                        properties:
+                          pending:
+                            description: Pending is a list of initializers that must execute
+                              in order before this object is visible. When the last pending
+                              initializer is removed, and no failing result is set, the
+                              initializers struct will be set to nil and the object is considered
+                              as initialized and visible to all clients.
+                            items:
+                              description: Initializer is information about an initializer
+                                that has not yet completed.
+                              properties:
+                                name:
+                                  description: name of the process that is responsible for
+                                    initializing this object.
+                                  type: string
+                              required:
+                              - name
+                            type: array
+                          result:
+                            description: Status is a return value for calls that don't return
+                              other objects.
+                            properties:
+                              apiVersion:
+                                description: 'APIVersion defines the versioned schema of
+                                  this representation of an object. Servers should convert
+                                  recognized schemas to the latest internal value, and may
+                                  reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                                type: string
+                              code:
+                                description: Suggested HTTP return code for this status,
+                                  0 if not set.
+                                format: int32
+                                type: integer
+                              details:
+                                description: StatusDetails is a set of additional properties
+                                  that MAY be set by the server to provide additional information
+                                  about a response. The Reason field of a Status object
+                                  defines what attributes will be set. Clients must ignore
+                                  fields that do not match the defined type of each attribute,
+                                  and should assume that any attribute may be empty, invalid,
+                                  or under defined.
+                                properties:
+                                  causes:
+                                    description: The Causes array includes more details
+                                      associated with the StatusReason failure. Not all
+                                      StatusReasons may provide detailed causes.
+                                    items:
+                                      description: StatusCause provides more information
+                                        about an api.Status failure, including cases when
+                                        multiple errors are encountered.
+                                      properties:
+                                        field:
+                                          description: |-
+                                            The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+                                            Examples:
+                                              "name" - the field "name" on the current resource
+                                              "items[0].name" - the field "name" on the first array entry in "items"
+                                          type: string
+                                        message:
+                                          description: A human-readable description of the
+                                            cause of the error.  This field may be presented
+                                            as-is to a reader.
+                                          type: string
+                                        reason:
+                                          description: A machine-readable description of
+                                            the cause of the error. If this value is empty
+                                            there is no information available.
+                                          type: string
+                                    type: array
+                                  group:
+                                    description: The group attribute of the resource associated
+                                      with the status StatusReason.
+                                    type: string
+                                  kind:
+                                    description: 'The kind attribute of the resource associated
+                                      with the status StatusReason. On some operations may
+                                      differ from the requested resource Kind. More info:
+                                      https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                    type: string
+                                  name:
+                                    description: The name attribute of the resource associated
+                                      with the status StatusReason (when there is a single
+                                      name which can be described).
+                                    type: string
+                                  retryAfterSeconds:
+                                    description: If specified, the time in seconds before
+                                      the operation should be retried. Some errors may indicate
+                                      the client must take an alternate action - for those
+                                      errors this field may indicate how long to wait before
+                                      taking the alternate action.
+                                    format: int32
+                                    type: integer
+                                  uid:
+                                    description: 'UID of the resource. (when there is a
+                                      single resource which can be described). More info:
+                                      http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                    type: string
+                              kind:
+                                description: 'Kind is a string value representing the REST
+                                  resource this object represents. Servers may infer this
+                                  from the endpoint the client submits requests to. Cannot
+                                  be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                type: string
+                              message:
+                                description: A human-readable description of the status
+                                  of this operation.
+                                type: string
+                              metadata:
+                                description: ListMeta describes metadata that synthetic
+                                  resources must have, including lists and various status
+                                  objects. A resource may have only one of {ObjectMeta,
+                                  ListMeta}.
+                                properties:
+                                  continue:
+                                    description: continue may be set if the user set a limit
+                                      on the number of items returned, and indicates that
+                                      the server has more data available. The value is opaque
+                                      and may be used to issue another request to the endpoint
+                                      that served this list to retrieve the next set of
+                                      available objects. Continuing a list may not be possible
+                                      if the server configuration has changed or more than
+                                      a few minutes have passed. The resourceVersion field
+                                      returned when using this continue value will be identical
+                                      to the value in the first response.
+                                    type: string
+                                  resourceVersion:
+                                    description: 'String that identifies the server''s internal
+                                      version of this object that can be used by clients
+                                      to determine when objects have changed. Value must
+                                      be treated as opaque by clients and passed unmodified
+                                      back to the server. Populated by the system. Read-only.
+                                      More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                                    type: string
+                                  selfLink:
+                                    description: selfLink is a URL representing this object.
+                                      Populated by the system. Read-only.
+                                    type: string
+                              reason:
+                                description: A machine-readable description of why this
+                                  operation is in the "Failure" status. If this value is
+                                  empty there is no information available. A Reason clarifies
+                                  an HTTP status code but does not override it.
+                                type: string
+                              status:
+                                description: 'Status of the operation. One of: "Success"
+                                  or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                                type: string
+                        required:
+                        - pending
+                      labels:
+                        description: 'Map of string keys and values that can be used to
+                          organize and categorize (scope and select) objects. May match
+                          selectors of replication controllers and services. More info:
+                          http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                      name:
+                        description: 'Name must be unique within a namespace. Is required
+                          when creating resources, although some resources may allow a client
+                          to request the generation of an appropriate name automatically.
+                          Name is primarily intended for creation idempotence and configuration
+                          definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+                          Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                        type: string
+                      ownerReferences:
+                        description: List of objects depended by this object. If ALL objects
+                          in the list have been deleted, this object will be garbage collected.
+                          If this object is managed by a controller, then an entry in this
+                          list will point to this controller, with the controller field
+                          set to true. There cannot be more than one managing controller.
+                        items:
+                          description: OwnerReference contains enough information to let
+                            you identify an owning object. Currently, an owning object must
+                            be in the same namespace, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: If true, AND if the owner has the "foregroundDeletion"
+                                finalizer, then the owner cannot be deleted from the key-value
+                                store until this reference is removed. Defaults to false.
+                                To set this field, a user needs "delete" permission of the
+                                owner, otherwise 422 (Unprocessable Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing
+                                controller.
+                              type: boolean
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                        type: array
+                      resourceVersion:
+                        description: |-
+                          An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+                          Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      selfLink:
+                        description: SelfLink is a URL representing this object. Populated
+                          by the system. Read-only.
+                        type: string
+                      uid:
+                        description: |-
+                          UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+                          Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                        type: string
+                  remoteRead:
+                    description: If specified, the remote_read spec. This is an experimental
+                      feature, it may change in any upcoming release in a breaking way.
+                    items:
+                      description: RemoteReadSpec defines the remote_read configuration
+                        for prometheus.
+                      properties:
+                        basicAuth:
+                          description: 'BasicAuth allow an endpoint to authenticate over
+                            basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                          properties:
+                            password:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or it's key must
+                                    be defined
+                                  type: boolean
+                              required:
+                              - key
+                            username:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or it's key must
+                                    be defined
+                                  type: boolean
+                              required:
+                              - key
+                        bearerToken:
+                          description: bearer token for remote read.
+                          type: string
+                        bearerTokenFile:
+                          description: File to read bearer token for remote read.
+                          type: string
+                        proxyUrl:
+                          description: Optional ProxyURL
+                          type: string
+                        readRecent:
+                          description: Whether reads should be made for queries for time
+                            ranges that the local storage should have complete data for.
+                          type: boolean
+                        remoteTimeout:
+                          description: Timeout for requests to the remote read endpoint.
+                          type: string
+                        requiredMatchers:
+                          description: An optional list of equality matchers which have
+                            to be present in a selector to query the remote read endpoint.
+                          type: object
+                        tlsConfig:
+                          description: TLSConfig specifies TLS configuration parameters.
+                          properties:
+                            caFile:
+                              description: The CA cert to use for the targets.
+                              type: string
+                            certFile:
+                              description: The client cert file for the targets.
+                              type: string
+                            insecureSkipVerify:
+                              description: Disable target certificate validation.
+                              type: boolean
+                            keyFile:
+                              description: The client key file for the targets.
+                              type: string
+                            serverName:
+                              description: Used to verify the hostname for the targets.
+                              type: string
+                        url:
+                          description: The URL of the endpoint to send samples to.
+                          type: string
+                      required:
+                      - url
+                    type: array
+                  remoteWrite:
+                    description: If specified, the remote_write spec. This is an experimental
+                      feature, it may change in any upcoming release in a breaking way.
+                    items:
+                      description: RemoteWriteSpec defines the remote_write configuration
+                        for prometheus.
+                      properties:
+                        basicAuth:
+                          description: 'BasicAuth allow an endpoint to authenticate over
+                            basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                          properties:
+                            password:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or it's key must
+                                    be defined
+                                  type: boolean
+                              required:
+                              - key
+                            username:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or it's key must
+                                    be defined
+                                  type: boolean
+                              required:
+                              - key
+                        bearerToken:
+                          description: File to read bearer token for remote write.
+                          type: string
+                        bearerTokenFile:
+                          description: File to read bearer token for remote write.
+                          type: string
+                        proxyUrl:
+                          description: Optional ProxyURL
+                          type: string
+                        queueConfig:
+                          description: QueueConfig allows the tuning of remote_write queue_config
+                            parameters. This object is referenced in the RemoteWriteSpec
+                            object.
+                          properties:
+                            batchSendDeadline:
+                              description: BatchSendDeadline is the maximum time a sample
+                                will wait in buffer.
+                              type: string
+                            capacity:
+                              description: Capacity is the number of samples to buffer per
+                                shard before we start dropping them.
+                              format: int32
+                              type: integer
+                            maxBackoff:
+                              description: MaxBackoff is the maximum retry delay.
+                              type: string
+                            maxRetries:
+                              description: MaxRetries is the maximum number of times to
+                                retry a batch on recoverable errors.
+                              format: int32
+                              type: integer
+                            maxSamplesPerSend:
+                              description: MaxSamplesPerSend is the maximum number of samples
+                                per send.
+                              format: int32
+                              type: integer
+                            maxShards:
+                              description: MaxShards is the maximum number of shards, i.e.
+                                amount of concurrency.
+                              format: int32
+                              type: integer
+                            minBackoff:
+                              description: MinBackoff is the initial retry delay. Gets doubled
+                                for every retry.
+                              type: string
+                        remoteTimeout:
+                          description: Timeout for requests to the remote write endpoint.
+                          type: string
+                        tlsConfig:
+                          description: TLSConfig specifies TLS configuration parameters.
+                          properties:
+                            caFile:
+                              description: The CA cert to use for the targets.
+                              type: string
+                            certFile:
+                              description: The client cert file for the targets.
+                              type: string
+                            insecureSkipVerify:
+                              description: Disable target certificate validation.
+                              type: boolean
+                            keyFile:
+                              description: The client key file for the targets.
+                              type: string
+                            serverName:
+                              description: Used to verify the hostname for the targets.
+                              type: string
+                        url:
+                          description: The URL of the endpoint to send samples to.
+                          type: string
+                        writeRelabelConfigs:
+                          description: The list of remote write relabel configurations.
+                          items:
+                            description: 'RelabelConfig allows dynamic rewriting of the
+                              label set, being applied to samples before ingestion. It defines
+                              `<metric_relabel_configs>`-section of Prometheus configuration.
+                              More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                            properties:
+                              action:
+                                description: Action to perform based on regex matching.
+                                  Default is 'replace'
+                                type: string
+                              modulus:
+                                description: Modulus to take of the hash of the source label
+                                  values.
+                                format: int64
+                                type: integer
+                              regex:
+                                description: Regular expression against which the extracted
+                                  value is matched. defailt is '(.*)'
+                                type: string
+                              replacement:
+                                description: Replacement value against which a regex replace
+                                  is performed if the regular expression matches. Regex
+                                  capture groups are available. Default is '$1'
+                                type: string
+                              separator:
+                                description: Separator placed between concatenated source
+                                  label values. default is ';'.
+                                type: string
+                              sourceLabels:
+                                description: The source labels select values from existing
+                                  labels. Their content is concatenated using the configured
+                                  separator and matched against the configured regular expression
+                                  for the replace, keep, and drop actions.
+                                items:
+                                  type: string
+                                type: array
+                              targetLabel:
+                                description: Label to which the resulting value is written
+                                  in a replace action. It is mandatory for replace actions.
+                                  Regex capture groups are available.
+                                type: string
+                          type: array
+                      required:
+                      - url
+                    type: array
+                  replicas:
+                    description: Number of instances to deploy for a Prometheus deployment.
+                    format: int32
+                    type: integer
+                  resources:
+                    description: ResourceRequirements describes the compute resource requirements.
+                    properties:
+                      limits:
+                        description: 'Limits describes the maximum amount of compute resources
+                          allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        description: 'Requests describes the minimum amount of compute resources
+                          required. If Requests is omitted for a container, it defaults
+                          to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                  retention:
+                    description: Time duration Prometheus shall retain data for.
+                    type: string
+                  routePrefix:
+                    description: The route prefix Prometheus registers HTTP handlers for.
+                      This is useful, if using ExternalURL and a proxy is rewriting HTTP
+                      routes of a request, and the actual ExternalURL is still true, but
+                      the server serves requests under a different route prefix. For example
+                      for use with `kubectl proxy`.
+                    type: string
+                  ruleNamespaceSelector:
+                    description: A label selector is a label query over a set of resources.
+                      The result of matchLabels and matchExpressions are ANDed. An empty
+                      label selector matches all objects. A null label selector matches
+                      no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements.
+                          The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector that contains
+                            values, a key, and an operator that relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies
+                                to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a
+                                set of values. Valid operators are In, NotIn, Exists and
+                                DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator
+                                is In or NotIn, the values array must be non-empty. If the
+                                operator is Exists or DoesNotExist, the values array must
+                                be empty. This array is replaced during a strategic merge
+                                patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                        type: array
+                      matchLabels:
+                        description: matchLabels is a map of {key,value} pairs. A single
+                          {key,value} in the matchLabels map is equivalent to an element
+                                       of matchExpressions, whose key field is "key", the operator is
+                                       "In", and the values array contains only "value". The requirements
+                                       are ANDed.
+                        type: object
+                  ruleSelector:
+                    description: A label selector is a label query over a set of resources.
+                      The result of matchLabels and matchExpressions are ANDed. An empty
+                      label selector matches all objects. A null label selector matches
+                      no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements.
+                          The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector that contains
+                            values, a key, and an operator that relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies
+                                to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a
+                                set of values. Valid operators are In, NotIn, Exists and
+                                DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator
+                                is In or NotIn, the values array must be non-empty. If the
+                                operator is Exists or DoesNotExist, the values array must
+                                be empty. This array is replaced during a strategic merge
+                                patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                        type: array
+                      matchLabels:
+                        description: matchLabels is a map of {key,value} pairs. A single
+                          {key,value} in the matchLabels map is equivalent to an element
+                                       of matchExpressions, whose key field is "key", the operator is
+                                       "In", and the values array contains only "value". The requirements
+                                       are ANDed.
+                        type: object
+                  scrapeInterval:
+                    description: Interval between consecutive scrapes.
+                    type: string
+                  secrets:
+                    description: Secrets is a list of Secrets in the same namespace as the
+                      Prometheus object, which shall be mounted into the Prometheus Pods.
+                      The Secrets are mounted into /etc/prometheus/secrets/<secret-name>.
+                      Secrets changes after initial creation of a Prometheus object are
+                      not reflected in the running Pods. To change the secrets mounted into
+                      the Prometheus Pods, the object must be deleted and recreated with
+                      the new list of secrets.
+                    items:
+                      type: string
+                    type: array
+                  securityContext:
+                    description: PodSecurityContext holds pod-level security attributes
+                      and common container settings. Some fields are also present in container.securityContext.  Field
+                      values of container.securityContext take precedence over field values
+                      of PodSecurityContext.
+                    properties:
+                      fsGroup:
+                        description: |-
+                          A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+                          1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                          If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                        format: int64
+                        type: integer
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail to start
+                          the container if it does. If unset or false, no such validation
+                          will be performed. May also be set in SecurityContext.  If set
+                          in both SecurityContext and PodSecurityContext, the value specified
+                          in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified. May
+                          also be set in SecurityContext.  If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: SELinuxOptions are the labels to be applied to the
+                          container
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies to the
+                              container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies to the
+                              container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies to the
+                              container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies to the
+                              container.
+                            type: string
+                      supplementalGroups:
+                        description: A list of groups applied to the first process run in
+                          each container, in addition to the container's primary GID.  If
+                          unspecified, no groups will be added to any container.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used for
+                          the pod. Pods with unsupported sysctls (by the container runtime)
+                          might fail to launch.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                        type: array
+                  serviceAccountName:
+                    description: ServiceAccountName is the name of the ServiceAccount to
+                      use to run the Prometheus Pods.
+                    type: string
+                  serviceMonitorNamespaceSelector:
+                    description: A label selector is a label query over a set of resources.
+                      The result of matchLabels and matchExpressions are ANDed. An empty
+                      label selector matches all objects. A null label selector matches
+                      no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements.
+                          The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector that contains
+                            values, a key, and an operator that relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies
+                                to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a
+                                set of values. Valid operators are In, NotIn, Exists and
+                                DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator
+                                is In or NotIn, the values array must be non-empty. If the
+                                operator is Exists or DoesNotExist, the values array must
+                                be empty. This array is replaced during a strategic merge
+                                patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                        type: array
+                      matchLabels:
+                        description: matchLabels is a map of {key,value} pairs. A single
+                          {key,value} in the matchLabels map is equivalent to an element
+                                       of matchExpressions, whose key field is "key", the operator is
+                                       "In", and the values array contains only "value". The requirements
+                                       are ANDed.
+                        type: object
+                  serviceMonitorSelector:
+                    description: A label selector is a label query over a set of resources.
+                      The result of matchLabels and matchExpressions are ANDed. An empty
+                      label selector matches all objects. A null label selector matches
+                      no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements.
+                          The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector that contains
+                            values, a key, and an operator that relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies
+                                to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a
+                                set of values. Valid operators are In, NotIn, Exists and
+                                DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator
+                                is In or NotIn, the values array must be non-empty. If the
+                                operator is Exists or DoesNotExist, the values array must
+                                be empty. This array is replaced during a strategic merge
+                                patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                        type: array
+                      matchLabels:
+                        description: matchLabels is a map of {key,value} pairs. A single
+                          {key,value} in the matchLabels map is equivalent to an element
+                                       of matchExpressions, whose key field is "key", the operator is
+                                       "In", and the values array contains only "value". The requirements
+                                       are ANDed.
+                        type: object
+                  storage:
+                    description: StorageSpec defines the configured storage for a group
+                      Prometheus servers.
+                    properties:
+                      class:
+                        description: 'Name of the StorageClass to use when requesting storage
+                          provisioning. More info: https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses
+                          DEPRECATED'
+                        type: string
+                      emptyDir:
+                        description: Represents an empty directory for a pod. Empty directory
+                          volumes support ownership management and SELinux relabeling.
+                        properties:
+                          medium:
+                            description: 'What type of storage medium should back this directory.
+                              The default is "" which means to use the node''s default medium.
+                              Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            type: string
+                          sizeLimit: {}
+                      resources:
+                        description: ResourceRequirements describes the compute resource
+                          requirements.
+                        properties:
+                          limits:
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            description: 'Requests describes the minimum amount of compute
+                              resources required. If Requests is omitted for a container,
+                              it defaults to Limits if that is explicitly specified, otherwise
+                              to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                      selector:
+                        description: A label selector is a label query over a set of resources.
+                          The result of matchLabels and matchExpressions are ANDed. An empty
+                          label selector matches all objects. A null label selector matches
+                          no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements.
+                              The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector that
+                                contains values, a key, and an operator that relates the
+                                key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies
+                                    to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn, Exists
+                                    and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the
+                                    operator is In or NotIn, the values array must be non-empty.
+                                    If the operator is Exists or DoesNotExist, the values
+                                    array must be empty. This array is replaced during a
+                                    strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                            type: array
+                          matchLabels:
+                            description: matchLabels is a map of {key,value} pairs. A single
+                              {key,value} in the matchLabels map is equivalent to an element
+                                           of matchExpressions, whose key field is "key", the operator
+                                           is "In", and the values array contains only "value". The requirements
+                                           are ANDed.
+                            type: object
+                      volumeClaimTemplate:
+                        description: PersistentVolumeClaim is a user's request for and claim
+                          to a persistent volume
+                        properties:
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema of this
+                              representation of an object. Servers should convert recognized
+                              schemas to the latest internal value, and may reject unrecognized
+                              values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                            type: string
+                          kind:
+                            description: 'Kind is a string value representing the REST resource
+                              this object represents. Servers may infer this from the endpoint
+                              the client submits requests to. Cannot be updated. In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                            type: string
+                          metadata:
+                            description: ObjectMeta is metadata that all persisted resources
+                              must have, which includes all objects users must create.
+                            properties:
+                              annotations:
+                                description: 'Annotations is an unstructured key value map
+                                  stored with a resource that may be set by external tools
+                                  to store and retrieve arbitrary metadata. They are not
+                                  queryable and should be preserved when modifying objects.
+                                  More info: http://kubernetes.io/docs/user-guide/annotations'
+                                type: object
+                              clusterName:
+                                description: The name of the cluster which the object belongs
+                                  to. This is used to distinguish resources with same name
+                                  and namespace in different clusters. This field is not
+                                  set anywhere right now and apiserver is going to ignore
+                                  it if set in create or update request.
+                                type: string
+                              creationTimestamp:
+                                description: Time is a wrapper around time.Time which supports
+                                  correct marshaling to YAML and JSON.  Wrappers are provided
+                                  for many of the factory methods that the time package
+                                  offers.
+                                format: date-time
+                                type: string
+                              deletionGracePeriodSeconds:
+                                description: Number of seconds allowed for this object to
+                                  gracefully terminate before it will be removed from the
+                                  system. Only set when deletionTimestamp is also set. May
+                                  only be shortened. Read-only.
+                                format: int64
+                                type: integer
+                              deletionTimestamp:
+                                description: Time is a wrapper around time.Time which supports
+                                  correct marshaling to YAML and JSON.  Wrappers are provided
+                                  for many of the factory methods that the time package
+                                  offers.
+                                format: date-time
+                                type: string
+                              finalizers:
+                                description: Must be empty before the object is deleted
+                                  from the registry. Each entry is an identifier for the
+                                  responsible component that will remove the entry from
+                                  the list. If the deletionTimestamp of the object is non-nil,
+                                  entries in this list can only be removed.
+                                items:
+                                  type: string
+                                type: array
+                              generateName:
+                                description: |-
+                                  GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+                                  If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+                                  Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                                type: string
+                              generation:
+                                description: A sequence number representing a specific generation
+                                  of the desired state. Populated by the system. Read-only.
+                                format: int64
+                                type: integer
+                              initializers:
+                                description: Initializers tracks the progress of initialization.
+                                properties:
+                                  pending:
+                                    description: Pending is a list of initializers that
+                                      must execute in order before this object is visible.
+                                      When the last pending initializer is removed, and
+                                      no failing result is set, the initializers struct
+                                      will be set to nil and the object is considered as
+                                      initialized and visible to all clients.
+                                    items:
+                                      description: Initializer is information about an initializer
+                                        that has not yet completed.
+                                      properties:
+                                        name:
+                                          description: name of the process that is responsible
+                                            for initializing this object.
+                                          type: string
+                                      required:
+                                      - name
+                                    type: array
+                                  result:
+                                    description: Status is a return value for calls that
+                                      don't return other objects.
+                                    properties:
+                                      apiVersion:
+                                        description: 'APIVersion defines the versioned schema
+                                          of this representation of an object. Servers should
+                                          convert recognized schemas to the latest internal
+                                          value, and may reject unrecognized values. More
+                                          info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                                        type: string
+                                      code:
+                                        description: Suggested HTTP return code for this
+                                          status, 0 if not set.
+                                        format: int32
+                                        type: integer
+                                      details:
+                                        description: StatusDetails is a set of additional
+                                          properties that MAY be set by the server to provide
+                                          additional information about a response. The Reason
+                                          field of a Status object defines what attributes
+                                          will be set. Clients must ignore fields that do
+                                          not match the defined type of each attribute,
+                                          and should assume that any attribute may be empty,
+                                          invalid, or under defined.
+                                        properties:
+                                          causes:
+                                            description: The Causes array includes more
+                                              details associated with the StatusReason failure.
+                                              Not all StatusReasons may provide detailed
+                                              causes.
+                                            items:
+                                              description: StatusCause provides more information
+                                                about an api.Status failure, including cases
+                                                when multiple errors are encountered.
+                                              properties:
+                                                field:
+                                                  description: |-
+                                                    The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+                                                    Examples:
+                                                      "name" - the field "name" on the current resource
+                                                      "items[0].name" - the field "name" on the first array entry in "items"
+                                                  type: string
+                                                message:
+                                                  description: A human-readable description
+                                                    of the cause of the error.  This field
+                                                    may be presented as-is to a reader.
+                                                  type: string
+                                                reason:
+                                                  description: A machine-readable description
+                                                    of the cause of the error. If this value
+                                                    is empty there is no information available.
+                                                  type: string
+                                            type: array
+                                          group:
+                                            description: The group attribute of the resource
+                                              associated with the status StatusReason.
+                                            type: string
+                                          kind:
+                                            description: 'The kind attribute of the resource
+                                              associated with the status StatusReason. On
+                                              some operations may differ from the requested
+                                              resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                            type: string
+                                          name:
+                                            description: The name attribute of the resource
+                                              associated with the status StatusReason (when
+                                              there is a single name which can be described).
+                                            type: string
+                                          retryAfterSeconds:
+                                            description: If specified, the time in seconds
+                                              before the operation should be retried. Some
+                                              errors may indicate the client must take an
+                                              alternate action - for those errors this field
+                                              may indicate how long to wait before taking
+                                              the alternate action.
+                                            format: int32
+                                            type: integer
+                                          uid:
+                                            description: 'UID of the resource. (when there
+                                              is a single resource which can be described).
+                                              More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                            type: string
+                                      kind:
+                                        description: 'Kind is a string value representing
+                                          the REST resource this object represents. Servers
+                                          may infer this from the endpoint the client submits
+                                          requests to. Cannot be updated. In CamelCase.
+                                          More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                        type: string
+                                      message:
+                                        description: A human-readable description of the
+                                          status of this operation.
+                                        type: string
+                                      metadata:
+                                        description: ListMeta describes metadata that synthetic
+                                                       resources must have, including lists and various
+                                                       status objects. A resource may have only one of
+                                          {ObjectMeta, ListMeta}.
+                                        properties:
+                                          continue:
+                                            description: continue may be set if the user
+                                              set a limit on the number of items returned,
+                                              and indicates that the server has more data
+                                              available. The value is opaque and may be
+                                              used to issue another request to the endpoint
+                                              that served this list to retrieve the next
+                                              set of available objects. Continuing a list
+                                              may not be possible if the server configuration
+                                              has changed or more than a few minutes have
+                                              passed. The resourceVersion field returned
+                                              when using this continue value will be identical
+                                              to the value in the first response.
+                                            type: string
+                                          resourceVersion:
+                                            description: 'String that identifies the server''s
+                                              internal version of this object that can be
+                                              used by clients to determine when objects
+                                              have changed. Value must be treated as opaque
+                                              by clients and passed unmodified back to the
+                                              server. Populated by the system. Read-only.
+                                              More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                                            type: string
+                                          selfLink:
+                                            description: selfLink is a URL representing
+                                              this object. Populated by the system. Read-only.
+                                            type: string
+                                      reason:
+                                        description: A machine-readable description of why
+                                          this operation is in the "Failure" status. If
+                                          this value is empty there is no information available.
+                                          A Reason clarifies an HTTP status code but does
+                                          not override it.
+                                        type: string
+                                      status:
+                                        description: 'Status of the operation. One of: "Success"
+                                          or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                                        type: string
+                                required:
+                                - pending
+                              labels:
+                                description: 'Map of string keys and values that can be
+                                  used to organize and categorize (scope and select) objects.
+                                  May match selectors of replication controllers and services.
+                                  More info: http://kubernetes.io/docs/user-guide/labels'
+                                type: object
+                              name:
+                                description: 'Name must be unique within a namespace. Is
+                                  required when creating resources, although some resources
+                                  may allow a client to request the generation of an appropriate
+                                  name automatically. Name is primarily intended for creation
+                                  idempotence and configuration definition. Cannot be updated.
+                                  More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+                                  Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                                type: string
+                              ownerReferences:
+                                description: List of objects depended by this object. If
+                                  ALL objects in the list have been deleted, this object
+                                  will be garbage collected. If this object is managed by
+                                  a controller, then an entry in this list will point to
+                                  this controller, with the controller field set to true.
+                                  There cannot be more than one managing controller.
+                                items:
+                                  description: OwnerReference contains enough information
+                                    to let you identify an owning object. Currently, an
+                                    owning object must be in the same namespace, so there
+                                    is no namespace field.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    blockOwnerDeletion:
+                                      description: If true, AND if the owner has the "foregroundDeletion"
+                                                     finalizer, then the owner cannot be deleted from
+                                                     the key-value store until this reference is removed.
+                                                     Defaults to false. To set this field, a user needs
+                                                     "delete" permission of the owner, otherwise 422
+                                                     (Unprocessable Entity) will be returned.
+                                      type: boolean
+                                    controller:
+                                      description: If true, this reference points to the
+                                        managing controller.
+                                      type: boolean
+                                    kind:
+                                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                      type: string
+                                    uid:
+                                      description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                      type: string
+                                  required:
+                                  - apiVersion
+                                  - kind
+                                  - name
+                                  - uid
+                                type: array
+                              resourceVersion:
+                                description: |-
+                                  An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+                                  Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              selfLink:
+                                description: SelfLink is a URL representing this object.
+                                  Populated by the system. Read-only.
+                                type: string
+                              uid:
+                                description: |-
+                                  UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+                                  Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                                type: string
+                          spec:
+                            description: PersistentVolumeClaimSpec describes the common
+                              attributes of storage devices and allows a Source for provider-specific
+                              attributes
+                            properties:
+                              accessModes:
+                                description: 'AccessModes contains the desired access modes
+                                  the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceRequirements describes the compute
+                                  resource requirements.
+                                properties:
+                                  limits:
+                                    description: 'Limits describes the maximum amount of
+                                      compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                  requests:
+                                    description: 'Requests describes the minimum amount
+                                      of compute resources required. If Requests is omitted
+                                      for a container, it defaults to Limits if that is
+                                      explicitly specified, otherwise to an implementation-defined
+                                      value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                              selector:
+                                description: A label selector is a label query over a set
+                                  of resources. The result of matchLabels and matchExpressions
+                                  are ANDed. An empty label selector matches all objects.
+                                  A null label selector matches no objects.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector
+                                      requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a selector
+                                        that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship
+                                            to a set of values. Valid operators are In,
+                                            NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string values.
+                                            If the operator is In or NotIn, the values array
+                                            must be non-empty. If the operator is Exists
+                                            or DoesNotExist, the values array must be empty.
+                                            This array is replaced during a strategic merge
+                                            patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                    type: array
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value} pairs.
+                                      A single {key,value} in the matchLabels map is equivalent
+                                      to an element of matchExpressions, whose key field
+                                      is "key", the operator is "In", and the values array
+                                      contains only "value". The requirements are ANDed.
+                                    type: object
+                              storageClassName:
+                                description: 'Name of the StorageClass required by the claim.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                type: string
+                              volumeMode:
+                                description: volumeMode defines what type of volume is required
+                                  by the claim. Value of Filesystem is implied when not
+                                  included in claim spec. This is an alpha feature and may
+                                  change in the future.
+                                type: string
+                              volumeName:
+                                description: VolumeName is the binding reference to the
+                                  PersistentVolume backing this claim.
+                                type: string
+                          status:
+                            description: PersistentVolumeClaimStatus is the current status
+                              of a persistent volume claim.
+                            properties:
+                              accessModes:
+                                description: 'AccessModes contains the actual access modes
+                                  the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                items:
+                                  type: string
+                                type: array
+                              capacity:
+                                description: Represents the actual resources of the underlying
+                                  volume.
+                                type: object
+                              conditions:
+                                description: Current Condition of persistent volume claim.
+                                  If underlying persistent volume is being resized then
+                                  the Condition will be set to 'ResizeStarted'.
+                                items:
+                                  description: PersistentVolumeClaimCondition contails details
+                                    about state of pvc
+                                  properties:
+                                    lastProbeTime:
+                                      description: Time is a wrapper around time.Time which
+                                        supports correct marshaling to YAML and JSON.  Wrappers
+                                        are provided for many of the factory methods that
+                                        the time package offers.
+                                      format: date-time
+                                      type: string
+                                    lastTransitionTime:
+                                      description: Time is a wrapper around time.Time which
+                                        supports correct marshaling to YAML and JSON.  Wrappers
+                                        are provided for many of the factory methods that
+                                        the time package offers.
+                                      format: date-time
+                                      type: string
+                                    message:
+                                      description: Human-readable message indicating details
+                                        about last transition.
+                                      type: string
+                                    reason:
+                                      description: Unique, this should be a short, machine
+                                        understandable string that gives the reason for
+                                        condition's last transition. If it reports "ResizeStarted"
+                                        that means the underlying persistent volume is being
+                                        resized.
+                                      type: string
+                                    status:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
+                                  - status
+                                type: array
+                              phase:
+                                description: Phase represents the current phase of PersistentVolumeClaim.
+                                type: string
+                  tag:
+                    description: Tag of Prometheus container image to be deployed. Defaults
+                      to the value of `version`.
+                    type: string
+                  thanos:
+                    description: ThanosSpec defines parameters for a Prometheus server within
+                      a Thanos deployment.
+                    properties:
+                      baseImage:
+                        description: Thanos base image if other than default.
+                        type: string
+                      gcs:
+                        description: ThanosGCSSpec defines parameters for use of Google
+                          Cloud Storage (GCS) with Thanos.
+                        properties:
+                          bucket:
+                            description: Google Cloud Storage bucket name for stored blocks.
+                              If empty it won't store any block inside Google Cloud Storage.
+                            type: string
+                      peers:
+                        description: Peers is a DNS name for Thanos to discover peers through.
+                        type: string
+                      s3:
+                        description: ThanosSpec defines parameters for of AWS Simple Storage
+                          Service (S3) with Thanos. (S3 compatible services apply as well)
+                        properties:
+                          accessKey:
+                            description: SecretKeySelector selects a key of a Secret.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or it's key must
+                                  be defined
+                                type: boolean
+                            required:
+                            - key
+                          bucket:
+                            description: S3-Compatible API bucket name for stored blocks.
+                            type: string
+                          endpoint:
+                            description: S3-Compatible API endpoint for stored blocks.
+                            type: string
+                          insecure:
+                            description: Whether to use an insecure connection with an S3-Compatible
+                              API.
+                            type: boolean
+                          secretKey:
+                            description: SecretKeySelector selects a key of a Secret.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or it's key must
+                                  be defined
+                                type: boolean
+                            required:
+                            - key
+                          signatureVersion2:
+                            description: Whether to use S3 Signature Version 2; otherwise
+                              Signature Version 4 will be used.
+                            type: boolean
+                      tag:
+                        description: Tag of Thanos sidecar container image to be deployed.
+                          Defaults to the value of `version`.
+                        type: string
+                      version:
+                        description: Version describes the version of Thanos to use.
+                        type: string
+                  tolerations:
+                    description: If specified, the pod's tolerations.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any
+                        taint that matches the triple <key,value,effect> using the matching
+                        operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty
+                            means match all taint effects. When specified, allowed values
+                            are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty, operator
+                            must be Exists; this combination means to match all values and
+                            all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal. Exists
+                            is equivalent to wildcard for value, so that a pod can tolerate
+                            all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the
+                            toleration (which must be of effect NoExecute, otherwise this
+                            field is ignored) tolerates the taint. By default, it is not
+                            set, which means tolerate the taint forever (do not evict).
+                            Zero and negative values will be treated as 0 (evict immediately)
+                            by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise
+                            just a regular string.
+                          type: string
+                    type: array
+                  version:
+                    description: Version of Prometheus to be deployed.
+                    type: string
+              status:
+                description: 'Most recent observed status of the Prometheus cluster. Read-only.
+                  Not included when requesting from the apiserver, only from the Prometheus
+                  Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+                properties:
+                  availableReplicas:
+                    description: Total number of available pods (ready for at least minReadySeconds)
+                      targeted by this Prometheus deployment.
+                    format: int32
+                    type: integer
+                  paused:
+                    description: Represents whether any actions on the underlaying managed
+                      objects are being performed. Only delete actions will be performed.
+                    type: boolean
+                  replicas:
+                    description: Total number of non-terminated pods targeted by this Prometheus
+                      deployment (their labels match the selector).
+                    format: int32
+                    type: integer
+                  unavailableReplicas:
+                    description: Total number of unavailable pods targeted by this Prometheus
+                      deployment.
+                    format: int32
+                    type: integer
+                  updatedReplicas:
+                    description: Total number of non-terminated pods targeted by this Prometheus
+                      deployment that have the desired version spec.
+                    format: int32
+                    type: integer
+                required:
+                - paused
+                - replicas
+                - updatedReplicas
+                - availableReplicas
+                - unavailableReplicas
+        version: v1
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: prometheusrules.monitoring.coreos.com
+      spec:
+        group: monitoring.coreos.com
+        names:
+          kind: PrometheusRule
+          plural: prometheusrules
+        scope: Namespaced
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                description: PrometheusRuleSpec contains specification parameters for a
+                  Rule.
+                properties:
+                  groups:
+                    description: Content of Prometheus rule file
+                    items:
+                      description: RuleGroup is a list of sequentially evaluated recording
+                        and alerting rules.
+                      properties:
+                        interval:
+                          type: string
+                        name:
+                          type: string
+                        rules:
+                          items:
+                            description: Rule describes an alerting or recording rule.
+                            properties:
+                              alert:
+                                type: string
+                              annotations:
+                                type: object
+                              expr:
+                                type: string
+                              for:
+                                type: string
+                              labels:
+                                type: object
+                              record:
+                                type: string
+                            required:
+                            - expr
+                          type: array
+                      required:
+                      - name
+                      - rules
+                    type: array
+        version: v1
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: servicemonitors.monitoring.coreos.com
+      spec:
+        group: monitoring.coreos.com
+        names:
+          kind: ServiceMonitor
+          plural: servicemonitors
+        scope: Namespaced
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                description: ServiceMonitorSpec contains specification parameters for a
+                  ServiceMonitor.
+                properties:
+                  endpoints:
+                    description: A list of endpoints allowed as part of this ServiceMonitor.
+                    items:
+                      description: Endpoint defines a scrapeable endpoint serving Prometheus
+                        metrics.
+                      properties:
+                        basicAuth:
+                          description: 'BasicAuth allow an endpoint to authenticate over
+                            basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                          properties:
+                            password:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or it's key must
+                                    be defined
+                                  type: boolean
+                              required:
+                              - key
+                            username:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or it's key must
+                                    be defined
+                                  type: boolean
+                              required:
+                              - key
+                        bearerTokenFile:
+                          description: File to read bearer token for scraping targets.
+                          type: string
+                        honorLabels:
+                          description: HonorLabels chooses the metric's labels on collisions
+                            with target labels.
+                          type: boolean
+                        interval:
+                          description: Interval at which metrics should be scraped
+                          type: string
+                        metricRelabelings:
+                          description: MetricRelabelConfigs to apply to samples before ingestion.
+                          items:
+                            description: 'RelabelConfig allows dynamic rewriting of the
+                              label set, being applied to samples before ingestion. It defines
+                              `<metric_relabel_configs>`-section of Prometheus configuration.
+                              More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                            properties:
+                              action:
+                                description: Action to perform based on regex matching.
+                                  Default is 'replace'
+                                type: string
+                              modulus:
+                                description: Modulus to take of the hash of the source label
+                                  values.
+                                format: int64
+                                type: integer
+                              regex:
+                                description: Regular expression against which the extracted
+                                  value is matched. defailt is '(.*)'
+                                type: string
+                              replacement:
+                                description: Replacement value against which a regex replace
+                                  is performed if the regular expression matches. Regex
+                                  capture groups are available. Default is '$1'
+                                type: string
+                              separator:
+                                description: Separator placed between concatenated source
+                                  label values. default is ';'.
+                                type: string
+                              sourceLabels:
+                                description: The source labels select values from existing
+                                  labels. Their content is concatenated using the configured
+                                  separator and matched against the configured regular expression
+                                  for the replace, keep, and drop actions.
+                                items:
+                                  type: string
+                                type: array
+                              targetLabel:
+                                description: Label to which the resulting value is written
+                                  in a replace action. It is mandatory for replace actions.
+                                  Regex capture groups are available.
+                                type: string
+                          type: array
+                        params:
+                          description: Optional HTTP URL parameters
+                          type: object
+                        path:
+                          description: HTTP path to scrape for metrics.
+                          type: string
+                        port:
+                          description: Name of the service port this endpoint refers to.
+                            Mutually exclusive with targetPort.
+                          type: string
+                        proxyUrl:
+                          description: ProxyURL eg http://proxyserver:2195 Directs scrapes
+                            to proxy through this endpoint.
+                          type: string
+                        scheme:
+                          description: HTTP scheme to use for scraping.
+                          type: string
+                        scrapeTimeout:
+                          description: Timeout after which the scrape is ended
+                          type: string
+                        targetPort:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                        tlsConfig:
+                          description: TLSConfig specifies TLS configuration parameters.
+                          properties:
+                            caFile:
+                              description: The CA cert to use for the targets.
+                              type: string
+                            certFile:
+                              description: The client cert file for the targets.
+                              type: string
+                            insecureSkipVerify:
+                              description: Disable target certificate validation.
+                              type: boolean
+                            keyFile:
+                              description: The client key file for the targets.
+                              type: string
+                            serverName:
+                              description: Used to verify the hostname for the targets.
+                              type: string
+                    type: array
+                  jobLabel:
+                    description: The label to use to retrieve the job name from.
+                    type: string
+                  namespaceSelector:
+                    description: A selector for selecting namespaces either selecting all
+                      namespaces or a list of namespaces.
+                    properties:
+                      any:
+                        description: Boolean describing whether all namespaces are selected
+                          in contrast to a list restricting them.
+                        type: boolean
+                      matchNames:
+                        description: List of namespace names.
+                        items:
+                          type: string
+                        type: array
+                  selector:
+                    description: A label selector is a label query over a set of resources.
+                      The result of matchLabels and matchExpressions are ANDed. An empty
+                      label selector matches all objects. A null label selector matches
+                      no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements.
+                          The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector that contains
+                            values, a key, and an operator that relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies
+                                to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a
+                                set of values. Valid operators are In, NotIn, Exists and
+                                DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator
+                                is In or NotIn, the values array must be non-empty. If the
+                                operator is Exists or DoesNotExist, the values array must
+                                be empty. This array is replaced during a strategic merge
+                                patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                        type: array
+                      matchLabels:
+                        description: matchLabels is a map of {key,value} pairs. A single
+                          {key,value} in the matchLabels map is equivalent to an element
+                                       of matchExpressions, whose key field is "key", the operator is
+                                       "In", and the values array contains only "value". The requirements
+                                       are ANDed.
+                        type: object
+                  targetLabels:
+                    description: TargetLabels transfers labels on the Kubernetes Service
+                      onto the target.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - endpoints
+                - selector
+        version: v1
+      
+  clusterServiceVersions: |-
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        name: etcdoperator.v0.6.1
+        namespace: placeholder
+        annotations:		
+          tectonic-visibility: ocs		
+      spec:
+        displayName: etcd
+        description: |
+          etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. It’s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader. Your applications can read and write data into etcd.
+          A simple use-case is to store database connection details or feature flags within etcd as key value pairs. These values can be watched, allowing your app to reconfigure itself when they change. Advanced uses take advantage of the consistency guarantees to implement database leader elections or do distributed locking across a cluster of workers.
+      
+          _The etcd Open Cloud Service is Public Alpha. The goal before Beta is to fully implement backup features._
+      
+          ### Reading and writing to etcd
+      
+          Communicate with etcd though its command line utility `etcdctl` or with the API using the automatically generated Kubernetes Service.
+      
+          [Read the complete guide to using the etcd Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/etcd-ocs.html)
+      
+          ### Supported Features
+          **High availability**
+          Multiple instances of etcd are networked together and secured. Individual failures or networking issues are transparently handled to keep your cluster up and running.
+          **Automated updates**
+          Rolling out a new etcd version works like all Kubernetes rolling updates. Simply declare the desired version, and the etcd service starts a safe rolling update to the new version automatically.
+          **Backups included**
+          Coming soon, the ability to schedule backups to happen on or off cluster.
+        keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
+        version: 0.6.1
+        maturity: alpha
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+        labels:
+          alm-status-descriptors: etcdoperator.v0.6.1
+          alm-owner-etcd: etcdoperator
+          operated-by: etcdoperator
+        selector:
+          matchLabels:
+            alm-owner-etcd: etcdoperator
+            operated-by: etcdoperator
+        links:
+        - name: Blog
+          url: https://coreos.com/etcd
+        - name: Documentation
+          url: https://coreos.com/operators/etcd/docs/latest/
+        - name: etcd Operator Source Code
+          url: https://github.com/coreos/etcd-operator
+      
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAOEAAADZCAYAAADWmle6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAEKlJREFUeNrsndt1GzkShmEev4sTgeiHfRYdgVqbgOgITEVgOgLTEQydwIiKwFQCayoCU6+7DyYjsBiBFyVVz7RkXvqCSxXw/+f04XjGQ6IL+FBVuL769euXgZ7r39f/G9iP0X+u/jWDNZzZdGI/Ftama1jjuV4BwmcNpbAf1Fgu+V/9YRvNAyzT2a59+/GT/3hnn5m16wKWedJrmOCxkYztx9Q+py/+E0GJxtJdReWfz+mxNt+QzS2Mc0AI+HbBBwj9QViKbH5t64DsP2fvmGXUkWU4WgO+Uve2YQzBUGd7r+zH2ZG/tiUQc4QxKwgbwFfVGwwmdLL5wH78aPC/ZBem9jJpCAX3xtcNASSNgJLzUPSQyjB1zQNl8IQJ9MIU4lx2+Jo72ysXYKl1HSzN02BMa/vbZ5xyNJIshJzwf3L0dQhJw4Sih/SFw9Tk8sVeghVPoefaIYCkMZCKbrcP9lnZuk0uPUjGE/KE8JQry7W2tgfuC3vXgvNV+qSQbyFtAtyWk7zWiYevvuUQ9QEQCvJ+5mmu6dTjz1zFHLFj8Eb87MtxaZh/IQFIHom+9vgTWwZxAQjT9X4vtbEVPojwjiV471s00mhAckpwGuCn1HtFtRDaSh6y9zsL+LNBvCG/24ThcxHObdlWc1v+VQJe8LcO0jwtuF8BwnAAUgP9M8JPU2Me+Oh12auPGT6fHuTePE3bLDy+x9pTLnhMn+07TQGh//Bz1iI0c6kvtqInjvPZcYR3KsPVmUsPYt9nFig9SCY8VQNhpPBzn952bbgcsk2EvM89wzh3UEffBbyPqvBUBYQ8ODGPFOLsa7RF096WJ69L+E4EmnpjWu5o4ChlKaRTKT39RMMaVPEQRsz/nIWlDN80chjdJlSd1l0pJCAMVZsniobQVuxceMM9OFoaMd9zqZtjMEYYDW38Drb8Y0DYPLShxn0pvIFuOSxd7YCPet9zk452wsh54FJoeN05hcgSQoG5RR0Qh9Q4E4VvL4wcZq8UACgaRFEQKgSwWrkr5WFnGxiHSutqJGlXjBgIOayhwYBTA0ER0oisIVSUV0AAMT0IASCUO4hRIQSAEECMCCEPwqyQA0JCQBzEGjWNAqHiUVAoXUWbvggOIQCEAOJzxTjoaQ4AIaE64/aZridUsBYUgkhB15oGg1DBIl8IqirYwV6hPSGBSFteMCUBSVXwfYixBmamRubeMyjzMJQBDDowE3OesDD+zwqFoDqiEwXoXJpljB+PvWJGy75BKF1FPxhKygJuqUdYQGlLxNEXkrYyjQ0GbaAwEnUIlLRNvVjQDYUAsJB0HKLE4y0AIpQNgCIhBIhQTgCKhZBBpAN/v6LtQI50JfUgYOnnjmLUFHKhjxbAmdTCaTiBm3ovLPqG2urWAij6im0Nd9aTN9ygLUEt9LgSRnohxUPIKxlGaE+/6Y7znFf0yX+GnkvFFWmarkab2o9PmTeq8sbd2a7DaysXz7i64VeznN4jCQhN9gdDbRiuWrfrsq0mHIrlaq+hlotCtd3Um9u0BYWY8y5D67wccJoZjFca7iUs9VqZcfsZwTd1sbWGG+OcYaTnPAP7rTQVVlM4Sg3oGvB1tmNh0t/HKXZ1jFoIMwCQjtqbhNxUmkGYqgZEDZP11HN/S3gAYRozf0l8C5kKEKUvW0t1IfeWG/5MwgheZTT1E0AEhDkAePQO+Ig2H3DncAkQM4cwUQCD530dU4B5Yvmi2LlDqXfWrxMCcMth51RToRMNUXFnfc2KJ0+Ryl0VNOUwlhh6NoxK5gnViTgQpUG4SqSyt5z3zRJpuKmt3Q1614QaCBPaN6je+2XiFcWAKOXcUfIYKRyL/1lb7pe5VxSxxjQ6hImshqGRt5GWZVKO6q2wHwujfwDtIvaIdexj8Cm8+a68EqMfox6x/voMouZF4dHnEGNeCDMwT6vdNfekH1MafMk4PI06YtqLVGl95aEM9Z5vAeCTOA++YLtoVJRrsqNCaJ6WRmkdYaNec5BT/lcTRMqrhmwfjbpkj55+OKp8IEbU/JLgPJE6Wa3TTe9sHS+ShVD5QIyqIxMEwKh12olC6mHIed5ewEop80CNlfIOADYOT2nd6ZXCop+Ebqchc0JqxKcKASxChycJgUh1rnHA5ow9eTrhqNI7JWiAYYwBGGdpyNLoGw0Pkh96h1BpHihyywtATDM/7Hk2fN9EnH8BgKJCU4ooBkbXFMZJiPbrOyecGl3zgQDQL4hk10IZiOe+5w99Q/gBAEIJgPhJM4QAEEoFREAIAAEiIASAkD8Qt4AQAEIAERAGFlX4CACKAXGVM4ivMwWwCLFAlyeoaa70QePKm5Dlp+/n+ye/5dYgva6YsUaVeMa+tzNFeJtWwc+udbJ0Fg399kLielQJ5Ze61c2+7ytA6EZetiPxZC6tj22yJCv6jUwOyj/zcbqAxOMyAKEbfeHtNa7DtYXptjsk2kJxR+eIeim/tHNofUKYy8DMrQcAKWz6brpvzyIAlpwPhQ49l6b7skJf5Z+YTOYQc4FwLDxvoTDwaygQK+U/kVr+ytSFBG01Q3gnJJR4cNiAhx4HDub8/b5DULXlj6SVZghFiE+LdvE9vo/o8Lp1RmH5hzm0T6wdbZ6n+D6i44zDRc3ln6CpAEJfXiRU45oqLz8gFAThWsh7ughrRibc0QynHgZpNJa/ENJ+loCwu/qOGnFIjYR/n7TfgycULhcQhu6VC+HfF+L3BoAQ4WiZTw1M+FPCnA2gKC6/FAhXgDC+ojQGh3NuWsvfF1L/D5ohlCKtl1j2ldu9a/nPAKFwN56Bst10zCG0CPleXN/zXPgHQZXaZaBgrbzyY5V/mUA+6F0hwtGN9rwu5DVZPuwWqfxdFz1LWbJ2lwKEa+0Qsm4Dl3fp+Pu0lV97PgwIPfSsS+UQhj5Oo+vvFULazRIQyvGEcxPuNLCth2MvFsrKn8UOilAQShkh7TTczYNMoS6OdP47msrPi82lXKGWhCdMZYS0bFy+vcnGAjP1CIfvgbKNA9glecEH9RD6Ol4wRuWyN/G9MHnksS6o/GPf5XcwNSUlHzQhDuAKtWJmkwKElU7lylP5rgIcsquh/FI8YZCDpkJBuE4FQm7Icw8N+SrUGaQKyi8FwiDt1ve5o+Vu7qYHy/psgK8cvh+FTYuO77bhEC7GuaPiys/L1X4IgXDL+e3M5+ovLxBy5VLuIebw1oqcHoPfoaMJUsHays878r8KbDc3xtPx/84gZPBG/JwaufrsY/SRG/OY3//8QMNdsvdZCFtbW6f8pFuf5bflILAlX7O+4fdfugKyFYS8T2zAsXthdG0VurPGKwI06oF5vkBgHWkNp6ry29+lsPZMU3vijnXFNmoclr+6+Ou/FIb8yb30sS8YGjmTqCLyQsi5N/6ZwKs0Yenj68pfPjF6N782Dp2FzV9CTyoSeY8mLK16qGxIkLI8oa1n8tz9juP40DlK0epxYEbojbq+9QfurBeVIlCO9D2396bxiV4lkYQ3hOAFw2pbhqMGISkkQOMcQ9EqhDmGZZdo92JC0YHRNTfoSg+5e0IT+opqCKHoIU+4ztQIgBD1EFNrQAgIpYSil9lDmPHqkROPt+JC6AgPquSuumJmg0YARVCuneDfvPVeJokZ6pIXDkNxQtGzTF9/BQjRG0tQznfb74RwCQghpALBtIQnfK4zhxdyQvVCUeknMIT3hLyY+T5jo0yABqKPQNpUNw/09tGZod5jgCaYFxyYvJcNPkv9eof+I3pnCFEHIETjSM8L9tHZHYCQT9PaZGycU6yg8S4akDnJ+P03L0+t23XGzCLzRgII/Wqa+fv/xlfvmKvMUOcOrlCDdoei1MGdZm6G5VEIfRzzjd4aQs69n699Rx7ewhvCGzr2gmTPs8zNsJOrXt24FbkhhOjCfT4ICA/rPbyhUy94Dks0gJCX1NzCZui9YUd3oei+c257TalFbgg19ILHrlrL2gvWgXAL26EX76gZTNASQnad8Ibwhl284NhgXpB0c+jKhWO3Ms1hP9ihJYB9eMF6qd1BCPk0qA1s+LimFIu7m4nsdQIzPK4VbQ8hYvrnuSH2G9b2ggP78QmWqBdF9Vx8SSY6QYdUW7BTA1schZATyhvY8lHvcRbNUS9YGFy2U+qmzh2YPVc0I7yAOFyHfRpyUwtCSzOdPXMHmz7qDIM0e0V2wZTEk+6Ym6N63eBLp/b5Bts+2cKCSJ/LuoZO3ANSiE5hKAZjnvNSS4931jcw9jpwT0feV/qSJ1pVtCyfHKDkvK8Ejx7pUxGh2xFNSwx8QTi2H9ceC0/nni64MS/5N5dG39pDqvRV+WgGk71c9VFXF9b+xYvOw/d61iv7m3MvEHryhvecwC52jSSx4VIIgwnMNT/UsTxIgpPt3K/ARj15CptwL3Zd/ceDSATj2DGQjbxgWwhdeMMte7zpy5On9vymRm/YxBYljGVjKWF9VJf7I1+sex3wY8w/V1QPTborW/72gkdsRDaZMJBdbdHIC7aCkAu9atlLbtnrzerMnyToDaGwelOnk3/hHSem/ZK7e/t7jeeR20LYBgqa8J80gS8jbwi5F02Uj1u2NYJxap8PLkJfLxA2hIJyvnHX/AfeEPLpBfe0uSFHbnXaea3Qd5d6HcpYZ8L6M7lnFwMQ3MNg+RxUR1+6AshtbsVgfXTEg1sIGax9UND2p7f270wdG3eK9gXVGHdw2k5sOyZv+Nbs39Z308XR9DqWb2J+PwKDhuKHPobfuXf7gnYGHdCs7bhDDadD4entDug7LWNsnRNW4mYqwJ9dk+GGSTPBiA2j0G8RWNM5upZtcG4/3vMfP7KnbK2egx6CCnDPhRn7NgD3cghLIad5WcM2SO38iqHvvMOosyeMpQ5zlVCaaj06GVs9xUbHdiKoqrHWgquFEFMWUEWfXUxJAML23hAHFOctmjZQffKD2pywkhtSGHKNtpitLroscAeE7kCkSsC60vxEl6yMtL9EL5HKGCMszU5bk8gdkklAyEn5FO0yK419rIxBOIqwFMooDE0tHEVYijAUECIshRCGIhxFWIowFJ5QkEYIS5PTJrUwNGlPyN6QQPyKtpuM1E/K5+YJDV/MiA3AaehzqgAm7QnZG9IGYKo8bHnSK7VblLL3hOwNHziPuEGOqE5brrdR6i+atCfckyeWD47HkAkepRGLY/e8A8J0gCwYSNypF08bBm+e6zVz2UL4AshhBUjML/rXLefqC82bcQFhGC9JDwZ1uuu+At0S5gCETYHsV4DUeD9fDN2Zfy5OXaW2zAwQygCzBLJ8cvaW5OXKC1FxfTggFAHmoAJnSiOw2wps9KwRWgJCLaEswaj5NqkLwAYIU4BxqTSXbHXpJdRMPZgAOiAMqABCNGYIEEJutEK5IUAIwYMDQgiCACEEAcJs1Vda7gGqDhCmoiEghAAhBAHCrKXVo2C1DCBMRlp37uMIEECoX7xrX3P5C9QiINSuIcoPAUI0YkAICLNWgfJDh4T9hH7zqYH9+JHAq7zBqWjwhPAicTVCVQJCNF50JghHocahKK0X/ZnQKyEkhSdUpzG8OgQI42qC94EQjsYLRSmH+pbgq73L6bYkeEJ4DYTYmeg1TOBFc/usTTp3V9DdEuXJ2xDCUbXhaXk0/kAYmBvuMB4qkC35E5e5AMKkwSQgyxufyuPy6fMMgAFCSI73LFXU/N8AmEL9X4ABACNSKMHAgb34AAAAAElFTkSuQmCC
+          mediatype: image/png
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: etcd-operator
+              rules:
+              - apiGroups:
+                - etcd.database.coreos.com
+                resources:
+                - etcdclusters
+                verbs:
+                - "*"
+              - apiGroups:
+                - storage.k8s.io
+                resources:
+                - storageclasses
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - secrets
+                verbs:
+                - get
+            deployments:
+            - name: etcd-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: etcd-operator-alm-owned
+                template:
+                  metadata:
+                    name: etcd-operator-alm-owned
+                    labels:
+                      name: etcd-operator-alm-owned
+                  spec:
+                    serviceAccountName: etcd-operator
+                    containers:
+                    - name: etcd-operator
+                      command:
+                      - etcd-operator
+                      - --create-crd=false
+                      image: quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+        customresourcedefinitions:
+          owned:
+          - name: etcdclusters.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdCluster
+            displayName: etcd Cluster
+            description: Represents a cluster of etcd nodes.
+            resources:
+              - kind: Service
+                version: v1
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of member Pods for the etcd cluster.
+                displayName: Size
+                path: size
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            statusDescriptors:
+              - description: The status of each of the member Pods for the etcd cluster.
+                displayName: Member Status
+                path: members
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+              - description: The service at which the running etcd cluster can be accessed.
+                displayName: Service
+                path: service
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The current size of the etcd cluster.
+                displayName: Cluster Size
+                path: size
+              - description: The current version of the etcd cluster.
+                displayName: Current Version
+                path: currentVersion
+              - description: 'The target version of the etcd cluster, after upgrading.'
+                displayName: Target Version
+                path: targetVersion
+              - description: The current status of the etcd cluster.
+                displayName: Status
+                path: phase
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase'
+              - description: Explanation for the current status of the cluster.
+                displayName: Status Details
+                path: reason
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        name: etcdoperator.v0.9.0
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
+      spec:
+        displayName: etcd
+        description: |
+          etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. It’s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader. Your applications can read and write data into etcd.
+          A simple use-case is to store database connection details or feature flags within etcd as key value pairs. These values can be watched, allowing your app to reconfigure itself when they change. Advanced uses take advantage of the consistency guarantees to implement database leader elections or do distributed locking across a cluster of workers.
+      
+          _The etcd Open Cloud Service is Public Alpha. The goal before Beta is to fully implement backup features._
+      
+          ### Reading and writing to etcd
+      
+          Communicate with etcd though its command line utility `etcdctl` or with the API using the automatically generated Kubernetes Service.
+      
+          [Read the complete guide to using the etcd Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/etcd-ocs.html)
+      
+          ### Supported Features
+      
+      
+          **High availability**
+      
+      
+          Multiple instances of etcd are networked together and secured. Individual failures or networking issues are transparently handled to keep your cluster up and running.
+      
+      
+          **Automated updates**
+      
+      
+          Rolling out a new etcd version works like all Kubernetes rolling updates. Simply declare the desired version, and the etcd service starts a safe rolling update to the new version automatically.
+      
+      
+          **Backups included**
+      
+      
+          Coming soon, the ability to schedule backups to happen on or off cluster.
+        keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
+        version: 0.9.0
+        maturity: alpha
+        replaces: etcdoperator.v0.6.1
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+        labels:
+          alm-owner-etcd: etcdoperator
+          operated-by: etcdoperator
+        selector:
+          matchLabels:
+            alm-owner-etcd: etcdoperator
+            operated-by: etcdoperator
+        links:
+        - name: Blog
+          url: https://coreos.com/etcd
+        - name: Documentation
+          url: https://coreos.com/operators/etcd/docs/latest/
+        - name: etcd Operator Source Code
+          url: https://github.com/coreos/etcd-operator
+      
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAOEAAADZCAYAAADWmle6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAEKlJREFUeNrsndt1GzkShmEev4sTgeiHfRYdgVqbgOgITEVgOgLTEQydwIiKwFQCayoCU6+7DyYjsBiBFyVVz7RkXvqCSxXw/+f04XjGQ6IL+FBVuL769euXgZ7r39f/G9iP0X+u/jWDNZzZdGI/Ftama1jjuV4BwmcNpbAf1Fgu+V/9YRvNAyzT2a59+/GT/3hnn5m16wKWedJrmOCxkYztx9Q+py/+E0GJxtJdReWfz+mxNt+QzS2Mc0AI+HbBBwj9QViKbH5t64DsP2fvmGXUkWU4WgO+Uve2YQzBUGd7r+zH2ZG/tiUQc4QxKwgbwFfVGwwmdLL5wH78aPC/ZBem9jJpCAX3xtcNASSNgJLzUPSQyjB1zQNl8IQJ9MIU4lx2+Jo72ysXYKl1HSzN02BMa/vbZ5xyNJIshJzwf3L0dQhJw4Sih/SFw9Tk8sVeghVPoefaIYCkMZCKbrcP9lnZuk0uPUjGE/KE8JQry7W2tgfuC3vXgvNV+qSQbyFtAtyWk7zWiYevvuUQ9QEQCvJ+5mmu6dTjz1zFHLFj8Eb87MtxaZh/IQFIHom+9vgTWwZxAQjT9X4vtbEVPojwjiV471s00mhAckpwGuCn1HtFtRDaSh6y9zsL+LNBvCG/24ThcxHObdlWc1v+VQJe8LcO0jwtuF8BwnAAUgP9M8JPU2Me+Oh12auPGT6fHuTePE3bLDy+x9pTLnhMn+07TQGh//Bz1iI0c6kvtqInjvPZcYR3KsPVmUsPYt9nFig9SCY8VQNhpPBzn952bbgcsk2EvM89wzh3UEffBbyPqvBUBYQ8ODGPFOLsa7RF096WJ69L+E4EmnpjWu5o4ChlKaRTKT39RMMaVPEQRsz/nIWlDN80chjdJlSd1l0pJCAMVZsniobQVuxceMM9OFoaMd9zqZtjMEYYDW38Drb8Y0DYPLShxn0pvIFuOSxd7YCPet9zk452wsh54FJoeN05hcgSQoG5RR0Qh9Q4E4VvL4wcZq8UACgaRFEQKgSwWrkr5WFnGxiHSutqJGlXjBgIOayhwYBTA0ER0oisIVSUV0AAMT0IASCUO4hRIQSAEECMCCEPwqyQA0JCQBzEGjWNAqHiUVAoXUWbvggOIQCEAOJzxTjoaQ4AIaE64/aZridUsBYUgkhB15oGg1DBIl8IqirYwV6hPSGBSFteMCUBSVXwfYixBmamRubeMyjzMJQBDDowE3OesDD+zwqFoDqiEwXoXJpljB+PvWJGy75BKF1FPxhKygJuqUdYQGlLxNEXkrYyjQ0GbaAwEnUIlLRNvVjQDYUAsJB0HKLE4y0AIpQNgCIhBIhQTgCKhZBBpAN/v6LtQI50JfUgYOnnjmLUFHKhjxbAmdTCaTiBm3ovLPqG2urWAij6im0Nd9aTN9ygLUEt9LgSRnohxUPIKxlGaE+/6Y7znFf0yX+GnkvFFWmarkab2o9PmTeq8sbd2a7DaysXz7i64VeznN4jCQhN9gdDbRiuWrfrsq0mHIrlaq+hlotCtd3Um9u0BYWY8y5D67wccJoZjFca7iUs9VqZcfsZwTd1sbWGG+OcYaTnPAP7rTQVVlM4Sg3oGvB1tmNh0t/HKXZ1jFoIMwCQjtqbhNxUmkGYqgZEDZP11HN/S3gAYRozf0l8C5kKEKUvW0t1IfeWG/5MwgheZTT1E0AEhDkAePQO+Ig2H3DncAkQM4cwUQCD530dU4B5Yvmi2LlDqXfWrxMCcMth51RToRMNUXFnfc2KJ0+Ryl0VNOUwlhh6NoxK5gnViTgQpUG4SqSyt5z3zRJpuKmt3Q1614QaCBPaN6je+2XiFcWAKOXcUfIYKRyL/1lb7pe5VxSxxjQ6hImshqGRt5GWZVKO6q2wHwujfwDtIvaIdexj8Cm8+a68EqMfox6x/voMouZF4dHnEGNeCDMwT6vdNfekH1MafMk4PI06YtqLVGl95aEM9Z5vAeCTOA++YLtoVJRrsqNCaJ6WRmkdYaNec5BT/lcTRMqrhmwfjbpkj55+OKp8IEbU/JLgPJE6Wa3TTe9sHS+ShVD5QIyqIxMEwKh12olC6mHIed5ewEop80CNlfIOADYOT2nd6ZXCop+Ebqchc0JqxKcKASxChycJgUh1rnHA5ow9eTrhqNI7JWiAYYwBGGdpyNLoGw0Pkh96h1BpHihyywtATDM/7Hk2fN9EnH8BgKJCU4ooBkbXFMZJiPbrOyecGl3zgQDQL4hk10IZiOe+5w99Q/gBAEIJgPhJM4QAEEoFREAIAAEiIASAkD8Qt4AQAEIAERAGFlX4CACKAXGVM4ivMwWwCLFAlyeoaa70QePKm5Dlp+/n+ye/5dYgva6YsUaVeMa+tzNFeJtWwc+udbJ0Fg399kLielQJ5Ze61c2+7ytA6EZetiPxZC6tj22yJCv6jUwOyj/zcbqAxOMyAKEbfeHtNa7DtYXptjsk2kJxR+eIeim/tHNofUKYy8DMrQcAKWz6brpvzyIAlpwPhQ49l6b7skJf5Z+YTOYQc4FwLDxvoTDwaygQK+U/kVr+ytSFBG01Q3gnJJR4cNiAhx4HDub8/b5DULXlj6SVZghFiE+LdvE9vo/o8Lp1RmH5hzm0T6wdbZ6n+D6i44zDRc3ln6CpAEJfXiRU45oqLz8gFAThWsh7ughrRibc0QynHgZpNJa/ENJ+loCwu/qOGnFIjYR/n7TfgycULhcQhu6VC+HfF+L3BoAQ4WiZTw1M+FPCnA2gKC6/FAhXgDC+ojQGh3NuWsvfF1L/D5ohlCKtl1j2ldu9a/nPAKFwN56Bst10zCG0CPleXN/zXPgHQZXaZaBgrbzyY5V/mUA+6F0hwtGN9rwu5DVZPuwWqfxdFz1LWbJ2lwKEa+0Qsm4Dl3fp+Pu0lV97PgwIPfSsS+UQhj5Oo+vvFULazRIQyvGEcxPuNLCth2MvFsrKn8UOilAQShkh7TTczYNMoS6OdP47msrPi82lXKGWhCdMZYS0bFy+vcnGAjP1CIfvgbKNA9glecEH9RD6Ol4wRuWyN/G9MHnksS6o/GPf5XcwNSUlHzQhDuAKtWJmkwKElU7lylP5rgIcsquh/FI8YZCDpkJBuE4FQm7Icw8N+SrUGaQKyi8FwiDt1ve5o+Vu7qYHy/psgK8cvh+FTYuO77bhEC7GuaPiys/L1X4IgXDL+e3M5+ovLxBy5VLuIebw1oqcHoPfoaMJUsHays878r8KbDc3xtPx/84gZPBG/JwaufrsY/SRG/OY3//8QMNdsvdZCFtbW6f8pFuf5bflILAlX7O+4fdfugKyFYS8T2zAsXthdG0VurPGKwI06oF5vkBgHWkNp6ry29+lsPZMU3vijnXFNmoclr+6+Ou/FIb8yb30sS8YGjmTqCLyQsi5N/6ZwKs0Yenj68pfPjF6N782Dp2FzV9CTyoSeY8mLK16qGxIkLI8oa1n8tz9juP40DlK0epxYEbojbq+9QfurBeVIlCO9D2396bxiV4lkYQ3hOAFw2pbhqMGISkkQOMcQ9EqhDmGZZdo92JC0YHRNTfoSg+5e0IT+opqCKHoIU+4ztQIgBD1EFNrQAgIpYSil9lDmPHqkROPt+JC6AgPquSuumJmg0YARVCuneDfvPVeJokZ6pIXDkNxQtGzTF9/BQjRG0tQznfb74RwCQghpALBtIQnfK4zhxdyQvVCUeknMIT3hLyY+T5jo0yABqKPQNpUNw/09tGZod5jgCaYFxyYvJcNPkv9eof+I3pnCFEHIETjSM8L9tHZHYCQT9PaZGycU6yg8S4akDnJ+P03L0+t23XGzCLzRgII/Wqa+fv/xlfvmKvMUOcOrlCDdoei1MGdZm6G5VEIfRzzjd4aQs69n699Rx7ewhvCGzr2gmTPs8zNsJOrXt24FbkhhOjCfT4ICA/rPbyhUy94Dks0gJCX1NzCZui9YUd3oei+c257TalFbgg19ILHrlrL2gvWgXAL26EX76gZTNASQnad8Ibwhl284NhgXpB0c+jKhWO3Ms1hP9ihJYB9eMF6qd1BCPk0qA1s+LimFIu7m4nsdQIzPK4VbQ8hYvrnuSH2G9b2ggP78QmWqBdF9Vx8SSY6QYdUW7BTA1schZATyhvY8lHvcRbNUS9YGFy2U+qmzh2YPVc0I7yAOFyHfRpyUwtCSzOdPXMHmz7qDIM0e0V2wZTEk+6Ym6N63eBLp/b5Bts+2cKCSJ/LuoZO3ANSiE5hKAZjnvNSS4931jcw9jpwT0feV/qSJ1pVtCyfHKDkvK8Ejx7pUxGh2xFNSwx8QTi2H9ceC0/nni64MS/5N5dG39pDqvRV+WgGk71c9VFXF9b+xYvOw/d61iv7m3MvEHryhvecwC52jSSx4VIIgwnMNT/UsTxIgpPt3K/ARj15CptwL3Zd/ceDSATj2DGQjbxgWwhdeMMte7zpy5On9vymRm/YxBYljGVjKWF9VJf7I1+sex3wY8w/V1QPTborW/72gkdsRDaZMJBdbdHIC7aCkAu9atlLbtnrzerMnyToDaGwelOnk3/hHSem/ZK7e/t7jeeR20LYBgqa8J80gS8jbwi5F02Uj1u2NYJxap8PLkJfLxA2hIJyvnHX/AfeEPLpBfe0uSFHbnXaea3Qd5d6HcpYZ8L6M7lnFwMQ3MNg+RxUR1+6AshtbsVgfXTEg1sIGax9UND2p7f270wdG3eK9gXVGHdw2k5sOyZv+Nbs39Z308XR9DqWb2J+PwKDhuKHPobfuXf7gnYGHdCs7bhDDadD4entDug7LWNsnRNW4mYqwJ9dk+GGSTPBiA2j0G8RWNM5upZtcG4/3vMfP7KnbK2egx6CCnDPhRn7NgD3cghLIad5WcM2SO38iqHvvMOosyeMpQ5zlVCaaj06GVs9xUbHdiKoqrHWgquFEFMWUEWfXUxJAML23hAHFOctmjZQffKD2pywkhtSGHKNtpitLroscAeE7kCkSsC60vxEl6yMtL9EL5HKGCMszU5bk8gdkklAyEn5FO0yK419rIxBOIqwFMooDE0tHEVYijAUECIshRCGIhxFWIowFJ5QkEYIS5PTJrUwNGlPyN6QQPyKtpuM1E/K5+YJDV/MiA3AaehzqgAm7QnZG9IGYKo8bHnSK7VblLL3hOwNHziPuEGOqE5brrdR6i+atCfckyeWD47HkAkepRGLY/e8A8J0gCwYSNypF08bBm+e6zVz2UL4AshhBUjML/rXLefqC82bcQFhGC9JDwZ1uuu+At0S5gCETYHsV4DUeD9fDN2Zfy5OXaW2zAwQygCzBLJ8cvaW5OXKC1FxfTggFAHmoAJnSiOw2wps9KwRWgJCLaEswaj5NqkLwAYIU4BxqTSXbHXpJdRMPZgAOiAMqABCNGYIEEJutEK5IUAIwYMDQgiCACEEAcJs1Vda7gGqDhCmoiEghAAhBAHCrKXVo2C1DCBMRlp37uMIEECoX7xrX3P5C9QiINSuIcoPAUI0YkAICLNWgfJDh4T9hH7zqYH9+JHAq7zBqWjwhPAicTVCVQJCNF50JghHocahKK0X/ZnQKyEkhSdUpzG8OgQI42qC94EQjsYLRSmH+pbgq73L6bYkeEJ4DYTYmeg1TOBFc/usTTp3V9DdEuXJ2xDCUbXhaXk0/kAYmBvuMB4qkC35E5e5AMKkwSQgyxufyuPy6fMMgAFCSI73LFXU/N8AmEL9X4ABACNSKMHAgb34AAAAAElFTkSuQmCC
+          mediatype: image/png
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: etcd-operator
+              rules:
+              - apiGroups:
+                - etcd.database.coreos.com
+                resources:
+                - etcdclusters
+                - etcdbackups
+                - etcdrestores
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - secrets
+                verbs:
+                - get
+            deployments:
+            - name: etcd-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: etcd-operator-alm-owned
+                template:
+                  metadata:
+                    name: etcd-operator-alm-owned
+                    labels:
+                      name: etcd-operator-alm-owned
+                  spec:
+                    serviceAccountName: etcd-operator
+                    containers:
+                    - name: etcd-operator
+                      command:
+                      - etcd-operator
+                      - --create-crd=false
+                      image: quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                    - name: etcd-backup-operator
+                      image: quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8
+                      command:
+                      - etcd-backup-operator
+                      - --create-crd=false
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                    - name: etcd-restore-operator
+                      image: quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8
+                      command:
+                      - etcd-restore-operator
+                      - --create-crd=false
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+        customresourcedefinitions:
+          owned:
+          - name: etcdclusters.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdCluster
+            displayName: etcd Cluster
+            description: Represents a cluster of etcd nodes.
+            resources:
+              - kind: Service
+                version: v1
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of member Pods for the etcd cluster.
+                displayName: Size
+                path: size
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+              - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+                displayName: Resource Requirements
+                path: pod.resources
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+            statusDescriptors:
+              - description: The status of each of the member Pods for the etcd cluster.
+                displayName: Member Status
+                path: members
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+              - description: The service at which the running etcd cluster can be accessed.
+                displayName: Service
+                path: serviceName
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The current size of the etcd cluster.
+                displayName: Cluster Size
+                path: size
+              - description: The current version of the etcd cluster.
+                displayName: Current Version
+                path: currentVersion
+              - description: 'The target version of the etcd cluster, after upgrading.'
+                displayName: Target Version
+                path: targetVersion
+              - description: The current status of the etcd cluster.
+                displayName: Status
+                path: phase
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase'
+              - description: Explanation for the current status of the cluster.
+                displayName: Status Details
+                path: reason
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+          - name: etcdbackups.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdBackup
+            displayName: etcd Backup
+            description: Represents the intent to backup an etcd cluster.
+            specDescriptors:
+              - description: Specifies the endpoints of an etcd cluster.
+                displayName: etcd Endpoint(s)
+                path: etcdEndpoints
+                x-descriptors: 
+                  - 'urn:alm:descriptor:etcd:endpoint'
+              - description: The full AWS S3 path where the backup is saved.
+                displayName: S3 Path
+                path: s3.path
+                x-descriptors: 
+                  - 'urn:alm:descriptor:aws:s3:path'
+              - description: The name of the secret object that stores the AWS credential and config files.
+                displayName: AWS Secret
+                path: s3.awsSecret
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:Secret'
+            statusDescriptors:
+              - description: Indicates if the backup was successful.
+                displayName: Succeeded
+                path: succeeded
+                x-descriptors: 
+                  - 'urn:alm:descriptor:text'
+              - description: Indicates the reason for any backup related failures.
+                displayName: Reason
+                path: reason
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+          - name: etcdrestores.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdRestore
+            displayName: etcd Restore
+            description: Represents the intent to restore an etcd cluster from a backup.
+            specDescriptors:
+              - description: References the EtcdCluster which should be restored,
+                displayName: etcd Cluster
+                path: etcdCluster.name
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:EtcdCluster'
+                  - 'urn:alm:descriptor:text'
+              - description: The full AWS S3 path where the backup is saved.
+                displayName: S3 Path
+                path: s3.path
+                x-descriptors: 
+                  - 'urn:alm:descriptor:aws:s3:path'
+              - description: The name of the secret object that stores the AWS credential and config files.
+                displayName: AWS Secret
+                path: s3.awsSecret
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:Secret'
+            statusDescriptors:
+              - description: Indicates if the restore was successful.
+                displayName: Succeeded
+                path: succeeded
+                x-descriptors: 
+                  - 'urn:alm:descriptor:text'
+              - description: Indicates the reason for any restore related failures.
+                displayName: Reason
+                path: reason
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        name: etcdoperator.v0.9.2
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
+      spec:
+        displayName: etcd
+        description: |
+          etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. It’s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader. Your applications can read and write data into etcd.
+          A simple use-case is to store database connection details or feature flags within etcd as key value pairs. These values can be watched, allowing your app to reconfigure itself when they change. Advanced uses take advantage of the consistency guarantees to implement database leader elections or do distributed locking across a cluster of workers.
+      
+          _The etcd Open Cloud Service is Public Alpha. The goal before Beta is to fully implement backup features._
+      
+          ### Reading and writing to etcd
+      
+          Communicate with etcd though its command line utility `etcdctl` or with the API using the automatically generated Kubernetes Service.
+      
+          [Read the complete guide to using the etcd Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/etcd-ocs.html)
+      
+          ### Supported Features
+      
+      
+          **High availability**
+      
+      
+          Multiple instances of etcd are networked together and secured. Individual failures or networking issues are transparently handled to keep your cluster up and running.
+      
+      
+          **Automated updates**
+      
+      
+          Rolling out a new etcd version works like all Kubernetes rolling updates. Simply declare the desired version, and the etcd service starts a safe rolling update to the new version automatically.
+      
+      
+          **Backups included**
+      
+      
+          Coming soon, the ability to schedule backups to happen on or off cluster.
+        keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
+        version: 0.9.2
+        maturity: alpha
+        replaces: etcdoperator.v0.9.0
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+        labels:
+          alm-owner-etcd: etcdoperator
+          operated-by: etcdoperator
+        selector:
+          matchLabels:
+            alm-owner-etcd: etcdoperator
+            operated-by: etcdoperator
+        links:
+        - name: Blog
+          url: https://coreos.com/etcd
+        - name: Documentation
+          url: https://coreos.com/operators/etcd/docs/latest/
+        - name: etcd Operator Source Code
+          url: https://github.com/coreos/etcd-operator
+      
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAOEAAADZCAYAAADWmle6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAEKlJREFUeNrsndt1GzkShmEev4sTgeiHfRYdgVqbgOgITEVgOgLTEQydwIiKwFQCayoCU6+7DyYjsBiBFyVVz7RkXvqCSxXw/+f04XjGQ6IL+FBVuL769euXgZ7r39f/G9iP0X+u/jWDNZzZdGI/Ftama1jjuV4BwmcNpbAf1Fgu+V/9YRvNAyzT2a59+/GT/3hnn5m16wKWedJrmOCxkYztx9Q+py/+E0GJxtJdReWfz+mxNt+QzS2Mc0AI+HbBBwj9QViKbH5t64DsP2fvmGXUkWU4WgO+Uve2YQzBUGd7r+zH2ZG/tiUQc4QxKwgbwFfVGwwmdLL5wH78aPC/ZBem9jJpCAX3xtcNASSNgJLzUPSQyjB1zQNl8IQJ9MIU4lx2+Jo72ysXYKl1HSzN02BMa/vbZ5xyNJIshJzwf3L0dQhJw4Sih/SFw9Tk8sVeghVPoefaIYCkMZCKbrcP9lnZuk0uPUjGE/KE8JQry7W2tgfuC3vXgvNV+qSQbyFtAtyWk7zWiYevvuUQ9QEQCvJ+5mmu6dTjz1zFHLFj8Eb87MtxaZh/IQFIHom+9vgTWwZxAQjT9X4vtbEVPojwjiV471s00mhAckpwGuCn1HtFtRDaSh6y9zsL+LNBvCG/24ThcxHObdlWc1v+VQJe8LcO0jwtuF8BwnAAUgP9M8JPU2Me+Oh12auPGT6fHuTePE3bLDy+x9pTLnhMn+07TQGh//Bz1iI0c6kvtqInjvPZcYR3KsPVmUsPYt9nFig9SCY8VQNhpPBzn952bbgcsk2EvM89wzh3UEffBbyPqvBUBYQ8ODGPFOLsa7RF096WJ69L+E4EmnpjWu5o4ChlKaRTKT39RMMaVPEQRsz/nIWlDN80chjdJlSd1l0pJCAMVZsniobQVuxceMM9OFoaMd9zqZtjMEYYDW38Drb8Y0DYPLShxn0pvIFuOSxd7YCPet9zk452wsh54FJoeN05hcgSQoG5RR0Qh9Q4E4VvL4wcZq8UACgaRFEQKgSwWrkr5WFnGxiHSutqJGlXjBgIOayhwYBTA0ER0oisIVSUV0AAMT0IASCUO4hRIQSAEECMCCEPwqyQA0JCQBzEGjWNAqHiUVAoXUWbvggOIQCEAOJzxTjoaQ4AIaE64/aZridUsBYUgkhB15oGg1DBIl8IqirYwV6hPSGBSFteMCUBSVXwfYixBmamRubeMyjzMJQBDDowE3OesDD+zwqFoDqiEwXoXJpljB+PvWJGy75BKF1FPxhKygJuqUdYQGlLxNEXkrYyjQ0GbaAwEnUIlLRNvVjQDYUAsJB0HKLE4y0AIpQNgCIhBIhQTgCKhZBBpAN/v6LtQI50JfUgYOnnjmLUFHKhjxbAmdTCaTiBm3ovLPqG2urWAij6im0Nd9aTN9ygLUEt9LgSRnohxUPIKxlGaE+/6Y7znFf0yX+GnkvFFWmarkab2o9PmTeq8sbd2a7DaysXz7i64VeznN4jCQhN9gdDbRiuWrfrsq0mHIrlaq+hlotCtd3Um9u0BYWY8y5D67wccJoZjFca7iUs9VqZcfsZwTd1sbWGG+OcYaTnPAP7rTQVVlM4Sg3oGvB1tmNh0t/HKXZ1jFoIMwCQjtqbhNxUmkGYqgZEDZP11HN/S3gAYRozf0l8C5kKEKUvW0t1IfeWG/5MwgheZTT1E0AEhDkAePQO+Ig2H3DncAkQM4cwUQCD530dU4B5Yvmi2LlDqXfWrxMCcMth51RToRMNUXFnfc2KJ0+Ryl0VNOUwlhh6NoxK5gnViTgQpUG4SqSyt5z3zRJpuKmt3Q1614QaCBPaN6je+2XiFcWAKOXcUfIYKRyL/1lb7pe5VxSxxjQ6hImshqGRt5GWZVKO6q2wHwujfwDtIvaIdexj8Cm8+a68EqMfox6x/voMouZF4dHnEGNeCDMwT6vdNfekH1MafMk4PI06YtqLVGl95aEM9Z5vAeCTOA++YLtoVJRrsqNCaJ6WRmkdYaNec5BT/lcTRMqrhmwfjbpkj55+OKp8IEbU/JLgPJE6Wa3TTe9sHS+ShVD5QIyqIxMEwKh12olC6mHIed5ewEop80CNlfIOADYOT2nd6ZXCop+Ebqchc0JqxKcKASxChycJgUh1rnHA5ow9eTrhqNI7JWiAYYwBGGdpyNLoGw0Pkh96h1BpHihyywtATDM/7Hk2fN9EnH8BgKJCU4ooBkbXFMZJiPbrOyecGl3zgQDQL4hk10IZiOe+5w99Q/gBAEIJgPhJM4QAEEoFREAIAAEiIASAkD8Qt4AQAEIAERAGFlX4CACKAXGVM4ivMwWwCLFAlyeoaa70QePKm5Dlp+/n+ye/5dYgva6YsUaVeMa+tzNFeJtWwc+udbJ0Fg399kLielQJ5Ze61c2+7ytA6EZetiPxZC6tj22yJCv6jUwOyj/zcbqAxOMyAKEbfeHtNa7DtYXptjsk2kJxR+eIeim/tHNofUKYy8DMrQcAKWz6brpvzyIAlpwPhQ49l6b7skJf5Z+YTOYQc4FwLDxvoTDwaygQK+U/kVr+ytSFBG01Q3gnJJR4cNiAhx4HDub8/b5DULXlj6SVZghFiE+LdvE9vo/o8Lp1RmH5hzm0T6wdbZ6n+D6i44zDRc3ln6CpAEJfXiRU45oqLz8gFAThWsh7ughrRibc0QynHgZpNJa/ENJ+loCwu/qOGnFIjYR/n7TfgycULhcQhu6VC+HfF+L3BoAQ4WiZTw1M+FPCnA2gKC6/FAhXgDC+ojQGh3NuWsvfF1L/D5ohlCKtl1j2ldu9a/nPAKFwN56Bst10zCG0CPleXN/zXPgHQZXaZaBgrbzyY5V/mUA+6F0hwtGN9rwu5DVZPuwWqfxdFz1LWbJ2lwKEa+0Qsm4Dl3fp+Pu0lV97PgwIPfSsS+UQhj5Oo+vvFULazRIQyvGEcxPuNLCth2MvFsrKn8UOilAQShkh7TTczYNMoS6OdP47msrPi82lXKGWhCdMZYS0bFy+vcnGAjP1CIfvgbKNA9glecEH9RD6Ol4wRuWyN/G9MHnksS6o/GPf5XcwNSUlHzQhDuAKtWJmkwKElU7lylP5rgIcsquh/FI8YZCDpkJBuE4FQm7Icw8N+SrUGaQKyi8FwiDt1ve5o+Vu7qYHy/psgK8cvh+FTYuO77bhEC7GuaPiys/L1X4IgXDL+e3M5+ovLxBy5VLuIebw1oqcHoPfoaMJUsHays878r8KbDc3xtPx/84gZPBG/JwaufrsY/SRG/OY3//8QMNdsvdZCFtbW6f8pFuf5bflILAlX7O+4fdfugKyFYS8T2zAsXthdG0VurPGKwI06oF5vkBgHWkNp6ry29+lsPZMU3vijnXFNmoclr+6+Ou/FIb8yb30sS8YGjmTqCLyQsi5N/6ZwKs0Yenj68pfPjF6N782Dp2FzV9CTyoSeY8mLK16qGxIkLI8oa1n8tz9juP40DlK0epxYEbojbq+9QfurBeVIlCO9D2396bxiV4lkYQ3hOAFw2pbhqMGISkkQOMcQ9EqhDmGZZdo92JC0YHRNTfoSg+5e0IT+opqCKHoIU+4ztQIgBD1EFNrQAgIpYSil9lDmPHqkROPt+JC6AgPquSuumJmg0YARVCuneDfvPVeJokZ6pIXDkNxQtGzTF9/BQjRG0tQznfb74RwCQghpALBtIQnfK4zhxdyQvVCUeknMIT3hLyY+T5jo0yABqKPQNpUNw/09tGZod5jgCaYFxyYvJcNPkv9eof+I3pnCFEHIETjSM8L9tHZHYCQT9PaZGycU6yg8S4akDnJ+P03L0+t23XGzCLzRgII/Wqa+fv/xlfvmKvMUOcOrlCDdoei1MGdZm6G5VEIfRzzjd4aQs69n699Rx7ewhvCGzr2gmTPs8zNsJOrXt24FbkhhOjCfT4ICA/rPbyhUy94Dks0gJCX1NzCZui9YUd3oei+c257TalFbgg19ILHrlrL2gvWgXAL26EX76gZTNASQnad8Ibwhl284NhgXpB0c+jKhWO3Ms1hP9ihJYB9eMF6qd1BCPk0qA1s+LimFIu7m4nsdQIzPK4VbQ8hYvrnuSH2G9b2ggP78QmWqBdF9Vx8SSY6QYdUW7BTA1schZATyhvY8lHvcRbNUS9YGFy2U+qmzh2YPVc0I7yAOFyHfRpyUwtCSzOdPXMHmz7qDIM0e0V2wZTEk+6Ym6N63eBLp/b5Bts+2cKCSJ/LuoZO3ANSiE5hKAZjnvNSS4931jcw9jpwT0feV/qSJ1pVtCyfHKDkvK8Ejx7pUxGh2xFNSwx8QTi2H9ceC0/nni64MS/5N5dG39pDqvRV+WgGk71c9VFXF9b+xYvOw/d61iv7m3MvEHryhvecwC52jSSx4VIIgwnMNT/UsTxIgpPt3K/ARj15CptwL3Zd/ceDSATj2DGQjbxgWwhdeMMte7zpy5On9vymRm/YxBYljGVjKWF9VJf7I1+sex3wY8w/V1QPTborW/72gkdsRDaZMJBdbdHIC7aCkAu9atlLbtnrzerMnyToDaGwelOnk3/hHSem/ZK7e/t7jeeR20LYBgqa8J80gS8jbwi5F02Uj1u2NYJxap8PLkJfLxA2hIJyvnHX/AfeEPLpBfe0uSFHbnXaea3Qd5d6HcpYZ8L6M7lnFwMQ3MNg+RxUR1+6AshtbsVgfXTEg1sIGax9UND2p7f270wdG3eK9gXVGHdw2k5sOyZv+Nbs39Z308XR9DqWb2J+PwKDhuKHPobfuXf7gnYGHdCs7bhDDadD4entDug7LWNsnRNW4mYqwJ9dk+GGSTPBiA2j0G8RWNM5upZtcG4/3vMfP7KnbK2egx6CCnDPhRn7NgD3cghLIad5WcM2SO38iqHvvMOosyeMpQ5zlVCaaj06GVs9xUbHdiKoqrHWgquFEFMWUEWfXUxJAML23hAHFOctmjZQffKD2pywkhtSGHKNtpitLroscAeE7kCkSsC60vxEl6yMtL9EL5HKGCMszU5bk8gdkklAyEn5FO0yK419rIxBOIqwFMooDE0tHEVYijAUECIshRCGIhxFWIowFJ5QkEYIS5PTJrUwNGlPyN6QQPyKtpuM1E/K5+YJDV/MiA3AaehzqgAm7QnZG9IGYKo8bHnSK7VblLL3hOwNHziPuEGOqE5brrdR6i+atCfckyeWD47HkAkepRGLY/e8A8J0gCwYSNypF08bBm+e6zVz2UL4AshhBUjML/rXLefqC82bcQFhGC9JDwZ1uuu+At0S5gCETYHsV4DUeD9fDN2Zfy5OXaW2zAwQygCzBLJ8cvaW5OXKC1FxfTggFAHmoAJnSiOw2wps9KwRWgJCLaEswaj5NqkLwAYIU4BxqTSXbHXpJdRMPZgAOiAMqABCNGYIEEJutEK5IUAIwYMDQgiCACEEAcJs1Vda7gGqDhCmoiEghAAhBAHCrKXVo2C1DCBMRlp37uMIEECoX7xrX3P5C9QiINSuIcoPAUI0YkAICLNWgfJDh4T9hH7zqYH9+JHAq7zBqWjwhPAicTVCVQJCNF50JghHocahKK0X/ZnQKyEkhSdUpzG8OgQI42qC94EQjsYLRSmH+pbgq73L6bYkeEJ4DYTYmeg1TOBFc/usTTp3V9DdEuXJ2xDCUbXhaXk0/kAYmBvuMB4qkC35E5e5AMKkwSQgyxufyuPy6fMMgAFCSI73LFXU/N8AmEL9X4ABACNSKMHAgb34AAAAAElFTkSuQmCC
+          mediatype: image/png
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: etcd-operator
+              rules:
+              - apiGroups:
+                - etcd.database.coreos.com
+                resources:
+                - etcdclusters
+                - etcdbackups
+                - etcdrestores
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - secrets
+                verbs:
+                - get
+            deployments:
+            - name: etcd-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: etcd-operator-alm-owned
+                template:
+                  metadata:
+                    name: etcd-operator-alm-owned
+                    labels:
+                      name: etcd-operator-alm-owned
+                  spec:
+                    serviceAccountName: etcd-operator
+                    containers:
+                    - name: etcd-operator
+                      command:
+                      - etcd-operator
+                      - --create-crd=false
+                      image: quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                    - name: etcd-backup-operator
+                      image: quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2
+                      command:
+                      - etcd-backup-operator
+                      - --create-crd=false
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                    - name: etcd-restore-operator
+                      image: quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2
+                      command:
+                      - etcd-restore-operator
+                      - --create-crd=false
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+        customresourcedefinitions:
+          owned:
+          - name: etcdclusters.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdCluster
+            displayName: etcd Cluster
+            description: Represents a cluster of etcd nodes.
+            resources:
+              - kind: Service
+                version: v1
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of member Pods for the etcd cluster.
+                displayName: Size
+                path: size
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+              - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+                displayName: Resource Requirements
+                path: pod.resources
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+            statusDescriptors:
+              - description: The status of each of the member Pods for the etcd cluster.
+                displayName: Member Status
+                path: members
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+              - description: The service at which the running etcd cluster can be accessed.
+                displayName: Service
+                path: serviceName
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The current size of the etcd cluster.
+                displayName: Cluster Size
+                path: size
+              - description: The current version of the etcd cluster.
+                displayName: Current Version
+                path: currentVersion
+              - description: 'The target version of the etcd cluster, after upgrading.'
+                displayName: Target Version
+                path: targetVersion
+              - description: The current status of the etcd cluster.
+                displayName: Status
+                path: phase
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase'
+              - description: Explanation for the current status of the cluster.
+                displayName: Status Details
+                path: reason
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+          - name: etcdbackups.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdBackup
+            displayName: etcd Backup
+            description: Represents the intent to backup an etcd cluster.
+            specDescriptors:
+              - description: Specifies the endpoints of an etcd cluster.
+                displayName: etcd Endpoint(s)
+                path: etcdEndpoints
+                x-descriptors: 
+                  - 'urn:alm:descriptor:etcd:endpoint'
+              - description: The full AWS S3 path where the backup is saved.
+                displayName: S3 Path
+                path: s3.path
+                x-descriptors: 
+                  - 'urn:alm:descriptor:aws:s3:path'
+              - description: The name of the secret object that stores the AWS credential and config files.
+                displayName: AWS Secret
+                path: s3.awsSecret
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:Secret'
+            statusDescriptors:
+              - description: Indicates if the backup was successful.
+                displayName: Succeeded
+                path: succeeded
+                x-descriptors: 
+                  - 'urn:alm:descriptor:text'
+              - description: Indicates the reason for any backup related failures.
+                displayName: Reason
+                path: reason
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+          - name: etcdrestores.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdRestore
+            displayName: etcd Restore
+            description: Represents the intent to restore an etcd cluster from a backup.
+            specDescriptors:
+              - description: References the EtcdCluster which should be restored,
+                displayName: etcd Cluster
+                path: etcdCluster.name
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:EtcdCluster'
+                  - 'urn:alm:descriptor:text'
+              - description: The full AWS S3 path where the backup is saved.
+                displayName: S3 Path
+                path: s3.path
+                x-descriptors: 
+                  - 'urn:alm:descriptor:aws:s3:path'
+              - description: The name of the secret object that stores the AWS credential and config files.
+                displayName: AWS Secret
+                path: s3.awsSecret
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:Secret'
+            statusDescriptors:
+              - description: Indicates if the restore was successful.
+                displayName: Succeeded
+                path: succeeded
+                x-descriptors: 
+                  - 'urn:alm:descriptor:text'
+              - description: Indicates the reason for any restore related failures.
+                displayName: Reason
+                path: reason
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        name: prometheusoperator.0.14.0
+        namespace: placeholder
+      spec:
+        displayName: Prometheus
+        description: |
+          An open-source monitoring system with a dimensional data model, flexible query language, efficient time series database and modern alerting approach.
+      
+          _The Prometheus Open Cloud Service is Public Alpha. The goal before Beta is for additional user testing and minor bug fixes._
+      
+          ### Monitoring applications
+      
+          Prometheus scrapes your application metrics based on targets maintained in a ServiceMonitor object. When alerts need to be sent, they are processsed by an AlertManager.
+      
+          [Read the complete guide to monitoring applications with the Prometheus Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/prometheus-ocs.html)
+      
+          ## Supported Features
+      
+          **High availability**
+          Multiple instances are run across failure zones and data is replicated. This keeps your monitoring available during an outage, when you need it most.
+          **Updates via automated operations**
+          New Prometheus versions are deployed using a rolling update with no downtime, making it easy to stay up to date.
+          **Handles the dynamic nature of containers**
+          Alerting rules are attached to groups of containers instead of individual instances, which is ideal for the highly dynamic nature of container deployment.
+      
+        keywords: ['prometheus', 'monitoring', 'tsdb', 'alerting']
+      
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+      
+        links:
+        - name: Prometheus
+          url: https://www.prometheus.io/
+        - name: Documentation
+          url: https://coreos.com/operators/prometheus/docs/latest/
+        - name: Prometheus Operator Source Code
+          url: https://github.com/coreos/prometheus-operator
+      
+        labels:
+          alm-status-descriptors: prometheusoperator.0.14.0
+          alm-owner-prometheus: prometheusoperator
+      
+        selector:
+          matchLabels:
+            alm-owner-prometheus: prometheusoperator
+      
+        icon:
+        - base64data: PHN2ZyB3aWR0aD0iMjQ5MCIgaGVpZ2h0PSIyNTAwIiB2aWV3Qm94PSIwIDAgMjU2IDI1NyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCI+PHBhdGggZD0iTTEyOC4wMDEuNjY3QzU3LjMxMS42NjcgMCA1Ny45NzEgMCAxMjguNjY0YzAgNzAuNjkgNTcuMzExIDEyNy45OTggMTI4LjAwMSAxMjcuOTk4UzI1NiAxOTkuMzU0IDI1NiAxMjguNjY0QzI1NiA1Ny45NyAxOTguNjg5LjY2NyAxMjguMDAxLjY2N3ptMCAyMzkuNTZjLTIwLjExMiAwLTM2LjQxOS0xMy40MzUtMzYuNDE5LTMwLjAwNGg3Mi44MzhjMCAxNi41NjYtMTYuMzA2IDMwLjAwNC0zNi40MTkgMzAuMDA0em02MC4xNTMtMzkuOTRINjcuODQyVjE3OC40N2gxMjAuMzE0djIxLjgxNmgtLjAwMnptLS40MzItMzMuMDQ1SDY4LjE4NWMtLjM5OC0uNDU4LS44MDQtLjkxLTEuMTg4LTEuMzc1LTEyLjMxNS0xNC45NTQtMTUuMjE2LTIyLjc2LTE4LjAzMi0zMC43MTYtLjA0OC0uMjYyIDE0LjkzMyAzLjA2IDI1LjU1NiA1LjQ1IDAgMCA1LjQ2NiAxLjI2NSAxMy40NTggMi43MjItNy42NzMtOC45OTQtMTIuMjMtMjAuNDI4LTEyLjIzLTMyLjExNiAwLTI1LjY1OCAxOS42OC00OC4wNzkgMTIuNTgtNjYuMjAxIDYuOTEuNTYyIDE0LjMgMTQuNTgzIDE0LjggMzYuNTA1IDcuMzQ2LTEwLjE1MiAxMC40Mi0yOC42OSAxMC40Mi00MC4wNTYgMC0xMS43NjkgNy43NTUtMjUuNDQgMTUuNTEyLTI1LjkwNy02LjkxNSAxMS4zOTYgMS43OSAyMS4xNjUgOS41MyA0NS40IDIuOTAyIDkuMTAzIDIuNTMyIDI0LjQyMyA0Ljc3MiAzNC4xMzguNzQ0LTIwLjE3OCA0LjIxMy00OS42MiAxNy4wMTQtNTkuNzg0LTUuNjQ3IDEyLjguODM2IDI4LjgxOCA1LjI3IDM2LjUxOCA3LjE1NCAxMi40MjQgMTEuNDkgMjEuODM2IDExLjQ5IDM5LjYzOCAwIDExLjkzNi00LjQwNyAyMy4xNzMtMTEuODQgMzEuOTU4IDguNDUyLTEuNTg2IDE0LjI4OS0zLjAxNiAxNC4yODktMy4wMTZsMjcuNDUtNS4zNTVjLjAwMi0uMDAyLTMuOTg3IDE2LjQwMS0xOS4zMTQgMzIuMTk3eiIgZmlsbD0iI0RBNEUzMSIvPjwvc3ZnPg==
+          mediatype: image/svg+xml
+      
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: prometheus-k8s
+              rules:
+              - apiGroups: [""]
+                resources:
+                - nodes
+                - services
+                - endpoints
+                - pods
+                verbs: ["get", "list", "watch"]
+              - apiGroups: [""]
+                resources:
+                - configmaps
+                verbs: ["get"]
+            - serviceAccountName: prometheus-operator-0-14-0
+              rules:
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs: ["get", "list"]
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - alertmanagers
+                - prometheuses
+                - servicemonitors
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - statefulsets
+                verbs: ["*"]
+              - apiGroups: [""]
+                resources:
+                - configmaps
+                - secrets
+                verbs: ["*"]
+              - apiGroups: [""]
+                resources:
+                - pods
+                verbs: ["list", "delete"]
+              - apiGroups: [""]
+                resources:
+                - services
+                - endpoints
+                verbs: ["get", "create", "update"]
+              - apiGroups: [""]
+                resources:
+                - nodes
+                verbs: ["list", "watch"]
+              - apiGroups: [""]
+                resources:
+                - namespaces
+                verbs: ['list']
+            deployments:
+            - name: prometheus-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    k8s-app: prometheus-operator
+                template:
+                  metadata:
+                    labels:
+                      k8s-app: prometheus-operator
+                  spec:
+                    serviceAccount: prometheus-operator-0-14-0
+                    containers:
+                    - name: prometheus-operator
+                      image: quay.io/coreos/prometheus-operator@sha256:5037b4e90dbb03ebdefaa547ddf6a1f748c8eeebeedf6b9d9f0913ad662b5731
+                      command:
+                        - sh
+                        - -c
+                        - >
+                          /bin/operator --namespace=$K8S_NAMESPACE --crd-apigroup monitoring.coreos.com
+                          --labels alm-status-descriptors=prometheusoperator.0.14.0,alm-owner-prometheus=prometheusoperator
+                          --kubelet-service=kube-system/kubelet
+                          --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+                      env:
+                        - name: K8S_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                      ports:
+                      - containerPort: 8080
+                        name: http
+                      resources:
+                        limits:
+                          cpu: 200m
+                          memory: 100Mi
+                        requests:
+                          cpu: 100m
+                          memory: 50Mi
+        maturity: alpha
+        version: 0.14.0
+        customresourcedefinitions:
+          owned:
+          - name: prometheuses.monitoring.coreos.com
+            version: v1
+            kind: Prometheus
+            displayName: Prometheus
+            description: A running Prometheus instance
+            resources:
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            - description: A selector for the ConfigMaps from which to load rule files
+              displayName: Rule Config Map Selector
+              path: ruleSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:ConfigMap'
+            - description: ServiceMonitors to be selected for target discovery
+              displayName: Service Monitor Selector
+              path: serviceMonitorSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:selector:monitoring.coreos.com:v1:ServiceMonitor'
+            - description: The ServiceAccount to use to run the Prometheus pods
+              displayName: Service Account
+              path: serviceAccountName
+              x-descriptors:
+                - 'urn:alm:descriptor:io.kubernetes:ServiceAccount'
+            - description: Define resources requests and limits for single Pods
+              displayName: Resource Request
+              path: resources.requests
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+            statusDescriptors:
+              - description: The current number of Pods for the cluster
+                displayName: Cluster Size
+                path: replicas
+              - path: prometheusSelector
+                displayName: Prometheus Service Selector
+                description: Label selector to find the service that routes to this prometheus
+                x-descriptors:
+                - 'urn:alm:descriptor:label:selector'
+          - name: servicemonitors.monitoring.coreos.com
+            version: v1
+            kind: ServiceMonitor
+            displayName: Service Monitor
+            description: Configures prometheus to monitor a particular k8s service
+            resources:
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Selector to select which namespaces the Endpoints objects are discovered from
+              displayName: Monitoring Namespaces
+              path: namespaceSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:namespaceSelector'
+            - description: The label to use to retrieve the job name from
+              displayName: Job Label
+              path: jobLabel
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:label'
+            - description: A list of endpoints allowed as part of this ServiceMonitor
+              displayName: Endpoints
+              path: endpoints
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:endpointList'
+          - name: alertmanagers.monitoring.coreos.com
+            version: v1
+            kind: Alertmanager
+            displayName: Alert Manager
+            description: Configures an Alert Manager for the namespace
+            resources:
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        name: prometheusoperator.0.15.0
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v1.7.0","serviceAccountName":"prometheus-k8s","serviceMonitorSelector":{"matchExpressions":[{"key":"k8s-app","operator":"Exists"}]},"ruleSelector":{"matchLabels":{"role":"prometheus-rulefiles","prometheus":"k8s"}},"resources":{"requests":{"memory":"400Mi"}},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus","prometheus":"k8s"}},"namespaceSelector":{"matchNames":["monitoring"]},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3}}]'
+      spec:
+        replaces: prometheusoperator.0.14.0
+        displayName: Prometheus
+        description: |
+          An open-source monitoring system with a dimensional data model, flexible query language, efficient time series database and modern alerting approach.
+      
+          _The Prometheus Open Cloud Service is Public Alpha. The goal before Beta is for additional user testing and minor bug fixes._
+      
+          ### Monitoring applications
+      
+          Prometheus scrapes your application metrics based on targets maintained in a ServiceMonitor object. When alerts need to be sent, they are processsed by an AlertManager.
+      
+          [Read the complete guide to monitoring applications with the Prometheus Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/prometheus-ocs.html)
+      
+          ### Supported Features
+      
+      
+          **High availability**
+      
+      
+          Multiple instances are run across failure zones and data is replicated. This keeps your monitoring available during an outage, when you need it most.
+      
+      
+          **Updates via automated operations**
+      
+      
+          New Prometheus versions are deployed using a rolling update with no downtime, making it easy to stay up to date.
+      
+      
+          **Handles the dynamic nature of containers**
+      
+      
+          Alerting rules are attached to groups of containers instead of individual instances, which is ideal for the highly dynamic nature of container deployment.
+      
+        keywords: ['prometheus', 'monitoring', 'tsdb', 'alerting']
+      
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+      
+        links:
+        - name: Prometheus
+          url: https://www.prometheus.io/
+        - name: Documentation
+          url: https://coreos.com/operators/prometheus/docs/latest/
+        - name: Prometheus Operator Source Code
+          url: https://github.com/coreos/prometheus-operator
+      
+        labels:
+          alm-status-descriptors: prometheusoperator.0.15.0
+          alm-owner-prometheus: prometheusoperator
+      
+        selector:
+          matchLabels:
+            alm-owner-prometheus: prometheusoperator
+      
+        icon:
+        - base64data: PHN2ZyB3aWR0aD0iMjQ5MCIgaGVpZ2h0PSIyNTAwIiB2aWV3Qm94PSIwIDAgMjU2IDI1NyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCI+PHBhdGggZD0iTTEyOC4wMDEuNjY3QzU3LjMxMS42NjcgMCA1Ny45NzEgMCAxMjguNjY0YzAgNzAuNjkgNTcuMzExIDEyNy45OTggMTI4LjAwMSAxMjcuOTk4UzI1NiAxOTkuMzU0IDI1NiAxMjguNjY0QzI1NiA1Ny45NyAxOTguNjg5LjY2NyAxMjguMDAxLjY2N3ptMCAyMzkuNTZjLTIwLjExMiAwLTM2LjQxOS0xMy40MzUtMzYuNDE5LTMwLjAwNGg3Mi44MzhjMCAxNi41NjYtMTYuMzA2IDMwLjAwNC0zNi40MTkgMzAuMDA0em02MC4xNTMtMzkuOTRINjcuODQyVjE3OC40N2gxMjAuMzE0djIxLjgxNmgtLjAwMnptLS40MzItMzMuMDQ1SDY4LjE4NWMtLjM5OC0uNDU4LS44MDQtLjkxLTEuMTg4LTEuMzc1LTEyLjMxNS0xNC45NTQtMTUuMjE2LTIyLjc2LTE4LjAzMi0zMC43MTYtLjA0OC0uMjYyIDE0LjkzMyAzLjA2IDI1LjU1NiA1LjQ1IDAgMCA1LjQ2NiAxLjI2NSAxMy40NTggMi43MjItNy42NzMtOC45OTQtMTIuMjMtMjAuNDI4LTEyLjIzLTMyLjExNiAwLTI1LjY1OCAxOS42OC00OC4wNzkgMTIuNTgtNjYuMjAxIDYuOTEuNTYyIDE0LjMgMTQuNTgzIDE0LjggMzYuNTA1IDcuMzQ2LTEwLjE1MiAxMC40Mi0yOC42OSAxMC40Mi00MC4wNTYgMC0xMS43NjkgNy43NTUtMjUuNDQgMTUuNTEyLTI1LjkwNy02LjkxNSAxMS4zOTYgMS43OSAyMS4xNjUgOS41MyA0NS40IDIuOTAyIDkuMTAzIDIuNTMyIDI0LjQyMyA0Ljc3MiAzNC4xMzguNzQ0LTIwLjE3OCA0LjIxMy00OS42MiAxNy4wMTQtNTkuNzg0LTUuNjQ3IDEyLjguODM2IDI4LjgxOCA1LjI3IDM2LjUxOCA3LjE1NCAxMi40MjQgMTEuNDkgMjEuODM2IDExLjQ5IDM5LjYzOCAwIDExLjkzNi00LjQwNyAyMy4xNzMtMTEuODQgMzEuOTU4IDguNDUyLTEuNTg2IDE0LjI4OS0zLjAxNiAxNC4yODktMy4wMTZsMjcuNDUtNS4zNTVjLjAwMi0uMDAyLTMuOTg3IDE2LjQwMS0xOS4zMTQgMzIuMTk3eiIgZmlsbD0iI0RBNEUzMSIvPjwvc3ZnPg==
+          mediatype: image/svg+xml
+      
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: prometheus-k8s
+              rules:
+              - apiGroups: [""]
+                resources:
+                - nodes
+                - services
+                - endpoints
+                - pods
+                verbs: ["get", "list", "watch"]
+              - apiGroups: [""]
+                resources:
+                - configmaps
+                verbs: ["get"]
+            - serviceAccountName: prometheus-operator-0-14-0
+              rules:
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs: ["get", "list"]
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - alertmanagers
+                - prometheuses
+                - servicemonitors
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - statefulsets
+                verbs: ["*"]
+              - apiGroups: [""]
+                resources:
+                - configmaps
+                - secrets
+                verbs: ["*"]
+              - apiGroups: [""]
+                resources:
+                - pods
+                verbs: ["list", "delete"]
+              - apiGroups: [""]
+                resources:
+                - services
+                - endpoints
+                verbs: ["get", "create", "update"]
+              - apiGroups: [""]
+                resources:
+                - nodes
+                verbs: ["list", "watch"]
+              - apiGroups: [""]
+                resources:
+                - namespaces
+                verbs: ['list']
+            deployments:
+            - name: prometheus-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    k8s-app: prometheus-operator
+                template:
+                  metadata:
+                    labels:
+                      k8s-app: prometheus-operator
+                  spec:
+                    serviceAccount: prometheus-operator-0-14-0
+                    containers:
+                    - name: prometheus-operator
+                      image: quay.io/coreos/prometheus-operator@sha256:0e92dd9b5789c4b13d53e1319d0a6375bcca4caaf0d698af61198061222a576d
+                      command:
+                        - sh
+                        - -c
+                        - >
+                          /bin/operator --namespace=$K8S_NAMESPACE --crd-apigroup monitoring.coreos.com
+                          --labels alm-status-descriptors=prometheusoperator.0.15.0,alm-owner-prometheus=prometheusoperator
+                          --kubelet-service=kube-system/kubelet
+                          --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+                      env:
+                        - name: K8S_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                      ports:
+                      - containerPort: 8080
+                        name: http
+                      resources:
+                        limits:
+                          cpu: 200m
+                          memory: 100Mi
+                        requests:
+                          cpu: 100m
+                          memory: 50Mi
+        maturity: alpha
+        version: 0.15.0
+        customresourcedefinitions:
+          owned:
+          - name: prometheuses.monitoring.coreos.com
+            version: v1
+            kind: Prometheus
+            displayName: Prometheus
+            description: A running Prometheus instance
+            resources:
+              - kind: StatefulSet
+                version: v1beta2
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            - description: A selector for the ConfigMaps from which to load rule files
+              displayName: Rule Config Map Selector
+              path: ruleSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:ConfigMap'
+            - description: ServiceMonitors to be selected for target discovery
+              displayName: Service Monitor Selector
+              path: serviceMonitorSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:selector:monitoring.coreos.com:v1:ServiceMonitor'
+            - description: The ServiceAccount to use to run the Prometheus pods
+              displayName: Service Account
+              path: serviceAccountName
+              x-descriptors:
+                - 'urn:alm:descriptor:io.kubernetes:ServiceAccount'
+            - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+              displayName: Resource Requirements
+              path: resources
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+            statusDescriptors:
+              - description: The current number of Pods for the cluster
+                displayName: Cluster Size
+                path: replicas
+              - path: prometheusSelector
+                displayName: Prometheus Service Selector
+                description: Label selector to find the service that routes to this prometheus
+                x-descriptors:
+                - 'urn:alm:descriptor:label:selector'
+          - name: servicemonitors.monitoring.coreos.com
+            version: v1
+            kind: ServiceMonitor
+            displayName: Service Monitor
+            description: Configures prometheus to monitor a particular k8s service
+            resources:
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Selector to select which namespaces the Endpoints objects are discovered from
+              displayName: Monitoring Namespaces
+              path: namespaceSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:namespaceSelector'
+            - description: The label to use to retrieve the job name from
+              displayName: Job Label
+              path: jobLabel
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:label'
+            - description: A list of endpoints allowed as part of this ServiceMonitor
+              displayName: Endpoints
+              path: endpoints
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:endpointList'
+          - name: alertmanagers.monitoring.coreos.com
+            version: v1
+            kind: Alertmanager
+            displayName: Alert Manager
+            description: Configures an Alert Manager for the namespace
+            resources:
+              - kind: StatefulSet
+                version: v1beta2
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+              displayName: Resource Requirements
+              path: resources
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        name: prometheusoperator.0.22.2
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v2.3.2","serviceAccountName":"prometheus-k8s","securityContext": {}, "serviceMonitorSelector":{"matchExpressions":[{"key":"k8s-app","operator":"Exists"}]},"ruleSelector":{"matchLabels":{"role":"prometheus-rulefiles","prometheus":"k8s"}},"resources":{"requests":{"memory":"400Mi"}},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus","prometheus":"k8s"}},"namespaceSelector":{"matchNames":["monitoring"]},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3}}]'
+      spec:
+        replaces: prometheusoperator.0.15.0
+        displayName: Prometheus
+        description: |
+          An open-source monitoring system with a dimensional data model, flexible query language, efficient time series database and modern alerting approach.
+      
+          _The Prometheus Open Cloud Service is Public Alpha. The goal before Beta is for additional user testing and minor bug fixes._
+      
+          ### Monitoring applications
+      
+          Prometheus scrapes your application metrics based on targets maintained in a ServiceMonitor object. When alerts need to be sent, they are processsed by an AlertManager.
+      
+          [Read the complete guide to monitoring applications with the Prometheus Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/prometheus-ocs.html)
+      
+          ### Supported Features
+      
+      
+          **High availability**
+      
+      
+          Multiple instances are run across failure zones and data is replicated. This keeps your monitoring available during an outage, when you need it most.
+      
+      
+          **Updates via automated operations**
+      
+      
+          New Prometheus versions are deployed using a rolling update with no downtime, making it easy to stay up to date.
+      
+      
+          **Handles the dynamic nature of containers**
+      
+      
+          Alerting rules are attached to groups of containers instead of individual instances, which is ideal for the highly dynamic nature of container deployment.
+      
+        keywords: ['prometheus', 'monitoring', 'tsdb', 'alerting']
+      
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+      
+        links:
+        - name: Prometheus
+          url: https://www.prometheus.io/
+        - name: Documentation
+          url: https://coreos.com/operators/prometheus/docs/latest/
+        - name: Prometheus Operator Source Code
+          url: https://github.com/coreos/prometheus-operator
+      
+        labels:
+          alm-status-descriptors: prometheusoperator.0.22.2
+          alm-owner-prometheus: prometheusoperator
+      
+        selector:
+          matchLabels:
+            alm-owner-prometheus: prometheusoperator
+      
+        icon:
+        - base64data: PHN2ZyB3aWR0aD0iMjQ5MCIgaGVpZ2h0PSIyNTAwIiB2aWV3Qm94PSIwIDAgMjU2IDI1NyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCI+PHBhdGggZD0iTTEyOC4wMDEuNjY3QzU3LjMxMS42NjcgMCA1Ny45NzEgMCAxMjguNjY0YzAgNzAuNjkgNTcuMzExIDEyNy45OTggMTI4LjAwMSAxMjcuOTk4UzI1NiAxOTkuMzU0IDI1NiAxMjguNjY0QzI1NiA1Ny45NyAxOTguNjg5LjY2NyAxMjguMDAxLjY2N3ptMCAyMzkuNTZjLTIwLjExMiAwLTM2LjQxOS0xMy40MzUtMzYuNDE5LTMwLjAwNGg3Mi44MzhjMCAxNi41NjYtMTYuMzA2IDMwLjAwNC0zNi40MTkgMzAuMDA0em02MC4xNTMtMzkuOTRINjcuODQyVjE3OC40N2gxMjAuMzE0djIxLjgxNmgtLjAwMnptLS40MzItMzMuMDQ1SDY4LjE4NWMtLjM5OC0uNDU4LS44MDQtLjkxLTEuMTg4LTEuMzc1LTEyLjMxNS0xNC45NTQtMTUuMjE2LTIyLjc2LTE4LjAzMi0zMC43MTYtLjA0OC0uMjYyIDE0LjkzMyAzLjA2IDI1LjU1NiA1LjQ1IDAgMCA1LjQ2NiAxLjI2NSAxMy40NTggMi43MjItNy42NzMtOC45OTQtMTIuMjMtMjAuNDI4LTEyLjIzLTMyLjExNiAwLTI1LjY1OCAxOS42OC00OC4wNzkgMTIuNTgtNjYuMjAxIDYuOTEuNTYyIDE0LjMgMTQuNTgzIDE0LjggMzYuNTA1IDcuMzQ2LTEwLjE1MiAxMC40Mi0yOC42OSAxMC40Mi00MC4wNTYgMC0xMS43NjkgNy43NTUtMjUuNDQgMTUuNTEyLTI1LjkwNy02LjkxNSAxMS4zOTYgMS43OSAyMS4xNjUgOS41MyA0NS40IDIuOTAyIDkuMTAzIDIuNTMyIDI0LjQyMyA0Ljc3MiAzNC4xMzguNzQ0LTIwLjE3OCA0LjIxMy00OS42MiAxNy4wMTQtNTkuNzg0LTUuNjQ3IDEyLjguODM2IDI4LjgxOCA1LjI3IDM2LjUxOCA3LjE1NCAxMi40MjQgMTEuNDkgMjEuODM2IDExLjQ5IDM5LjYzOCAwIDExLjkzNi00LjQwNyAyMy4xNzMtMTEuODQgMzEuOTU4IDguNDUyLTEuNTg2IDE0LjI4OS0zLjAxNiAxNC4yODktMy4wMTZsMjcuNDUtNS4zNTVjLjAwMi0uMDAyLTMuOTg3IDE2LjQwMS0xOS4zMTQgMzIuMTk3eiIgZmlsbD0iI0RBNEUzMSIvPjwvc3ZnPg==
+          mediatype: image/svg+xml
+      
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: prometheus-k8s
+              rules:
+              - apiGroups: [""]
+                resources:
+                - nodes
+                - services
+                - endpoints
+                - pods
+                verbs: ["get", "list", "watch"]
+              - apiGroups: [""]
+                resources:
+                - configmaps
+                verbs: ["get"]
+            - serviceAccountName: prometheus-operator-0-22-2
+              rules:
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs:
+                - '*'
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - alertmanagers
+                - prometheuses
+                - prometheuses/finalizers
+                - alertmanagers/finalizers
+                - servicemonitors
+                - prometheusrules
+                verbs:
+                - '*'
+              - apiGroups:
+                - apps
+                resources:
+                - statefulsets
+                verbs:
+                - '*'
+              - apiGroups:
+                - ""
+                resources:
+                - configmaps
+                - secrets
+                verbs:
+                - '*'
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                verbs:
+                - list
+                - delete
+              - apiGroups:
+                - ""
+                resources:
+                - services
+                - endpoints
+                verbs:
+                - get
+                - create
+                - update
+              - apiGroups:
+                - ""
+                resources:
+                - nodes
+                verbs:
+                - list
+                - watch
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - list
+                - watch
+            deployments:
+            - name: prometheus-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    k8s-app: prometheus-operator
+                template:
+                  metadata:
+                    labels:
+                      k8s-app: prometheus-operator
+                  spec:
+                    serviceAccount: prometheus-operator-0-22-2
+                    containers:
+                    - name: prometheus-operator
+                      image: quay.io/coreos/prometheus-operator@sha256:3daa69a8c6c2f1d35dcf1fe48a7cd8b230e55f5229a1ded438f687debade5bcf
+                      args:
+                      - -namespace=$(K8S_NAMESPACE)
+                      - -manage-crds=false
+                      - -logtostderr=true
+                      - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+                      - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.22.2
+                      env:
+                      - name: K8S_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      ports:
+                      - containerPort: 8080
+                        name: http
+                      resources:
+                        limits:
+                          cpu: 200m
+                          memory: 100Mi
+                        requests:
+                          cpu: 100m
+                          memory: 50Mi
+                      securityContext:
+                        allowPrivilegeEscalation: false
+                        readOnlyRootFilesystem: true
+                    nodeSelector:
+                      beta.kubernetes.io/os: linux
+        maturity: alpha
+        version: 0.22.2
+        customresourcedefinitions:
+          owned:
+          - name: prometheuses.monitoring.coreos.com
+            version: v1
+            kind: Prometheus
+            displayName: Prometheus
+            description: A running Prometheus instance
+            resources:
+              - kind: StatefulSet
+                version: v1beta2
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            - description: A selector for the ConfigMaps from which to load rule files
+              displayName: Rule Config Map Selector
+              path: ruleSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:ConfigMap'
+            - description: ServiceMonitors to be selected for target discovery
+              displayName: Service Monitor Selector
+              path: serviceMonitorSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:selector:monitoring.coreos.com:v1:ServiceMonitor'
+            - description: The ServiceAccount to use to run the Prometheus pods
+              displayName: Service Account
+              path: serviceAccountName
+              x-descriptors:
+                - 'urn:alm:descriptor:io.kubernetes:ServiceAccount'
+            - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+              displayName: Resource Requirements
+              path: resources
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+          - name: prometheusrules.monitoring.coreos.com
+            version: v1
+            kind: PrometheusRule
+            displayName: Prometheus Rule
+            description: A Prometheus Rule configures groups of sequentially evaluated recording and alerting rules.
+          - name: servicemonitors.monitoring.coreos.com
+            version: v1
+            kind: ServiceMonitor
+            displayName: Service Monitor
+            description: Configures prometheus to monitor a particular k8s service
+            resources:
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Selector to select which namespaces the Endpoints objects are discovered from
+              displayName: Monitoring Namespaces
+              path: namespaceSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:namespaceSelector'
+            - description: The label to use to retrieve the job name from
+              displayName: Job Label
+              path: jobLabel
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:label'
+            - description: A list of endpoints allowed as part of this ServiceMonitor
+              displayName: Endpoints
+              path: endpoints
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:endpointList'
+          - name: alertmanagers.monitoring.coreos.com
+            version: v1
+            kind: Alertmanager
+            displayName: Alert Manager
+            description: Configures an Alert Manager for the namespace
+            resources:
+              - kind: StatefulSet
+                version: v1beta2
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+              displayName: Resource Requirements
+              path: resources
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      
+  packages: |-
+    - #! package-manifest: ./deploy/chart/catalog_resources/ocs/etcdoperator.v0.9.2.clusterserviceversion.yaml
+      packageName: etcd
+      channels:
+      - name: alpha
+        currentCSV: etcdoperator.v0.9.2
+      
+    - #! package-manifest: ./deploy/chart/catalog_resources/ocs/prometheusoperator.0.22.2.clusterserviceversion.yaml
+      packageName: prometheus
+      channels:
+      - name: alpha
+        currentCSV: prometheusoperator.0.22.2
+      
+

--- a/ansible/roles/olm_setup/files/0.6.0/08-ocs.configmap.yaml
+++ b/ansible/roles/olm_setup/files/0.6.0/08-ocs.configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: ocs
-  namespace: kube-system
+  namespace: operator-lifecycle-manager
 
 data:
   customResourceDefinitions: |-
@@ -6584,7 +6584,7 @@ data:
                         - >
                           /bin/operator --namespace=$K8S_NAMESPACE --crd-apigroup monitoring.coreos.com
                           --labels alm-status-descriptors=prometheusoperator.0.14.0,alm-owner-prometheus=prometheusoperator
-                          --kubelet-service=kube-system/kubelet
+                          --kubelet-service=operator-lifecycle-manager/kubelet
                           --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
                       env:
                         - name: K8S_NAMESPACE
@@ -6841,7 +6841,7 @@ data:
                         - >
                           /bin/operator --namespace=$K8S_NAMESPACE --crd-apigroup monitoring.coreos.com
                           --labels alm-status-descriptors=prometheusoperator.0.15.0,alm-owner-prometheus=prometheusoperator
-                          --kubelet-service=kube-system/kubelet
+                          --kubelet-service=operator-lifecycle-manager/kubelet
                           --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
                       env:
                         - name: K8S_NAMESPACE

--- a/ansible/roles/olm_setup/files/0.6.0/10-ocs.catalogsource.yaml
+++ b/ansible/roles/olm_setup/files/0.6.0/10-ocs.catalogsource.yaml
@@ -1,0 +1,16 @@
+##---
+# Source: olm/templates/10-ocs.catalogsource.yaml
+
+#! validate-crd: ./deploy/chart/templates/05-catalogsource.crd.yaml
+#! parse-kind: CatalogSource
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ocs
+  namespace: kube-system
+spec:
+  sourceType: internal
+  configMap: ocs
+  displayName: Open Cloud Services
+  publisher: Red Hat
+

--- a/ansible/roles/olm_setup/files/0.6.0/10-ocs.catalogsource.yaml
+++ b/ansible/roles/olm_setup/files/0.6.0/10-ocs.catalogsource.yaml
@@ -7,7 +7,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
   name: ocs
-  namespace: kube-system
+  namespace: operator-lifecycle-manager
 spec:
   sourceType: internal
   configMap: ocs

--- a/ansible/roles/olm_setup/files/0.6.0/12-alm-operator.deployment.yaml
+++ b/ansible/roles/olm_setup/files/0.6.0/12-alm-operator.deployment.yaml
@@ -1,0 +1,47 @@
+##---
+# Source: olm/templates/12-alm-operator.deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alm-operator
+  namespace: kube-system
+  labels:
+    app: alm-operator
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alm-operator
+  template:
+    metadata:
+      labels:
+        app: alm-operator
+    spec:
+      serviceAccountName: olm-operator-serviceaccount
+      containers:
+        - name: alm-operator
+          command:
+          - /bin/olm
+          image: quay.io/coreos/olm@sha256:d2e51372b3251321c38d2159e8060fe0bf2f3eeb60a4a3cd53fbee3e1cdd5756
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          env:
+          - name: OPERATOR_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: OPERATOR_NAME
+            value: alm-operator
+      imagePullSecrets:
+        - name: coreos-pull-secret

--- a/ansible/roles/olm_setup/files/0.6.0/12-alm-operator.deployment.yaml
+++ b/ansible/roles/olm_setup/files/0.6.0/12-alm-operator.deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: alm-operator
-  namespace: kube-system
+  namespace: operator-lifecycle-manager
   labels:
     app: alm-operator
 spec:

--- a/ansible/roles/olm_setup/files/0.6.0/13-catalog-operator.deployment.yaml
+++ b/ansible/roles/olm_setup/files/0.6.0/13-catalog-operator.deployment.yaml
@@ -1,0 +1,43 @@
+##---
+# Source: olm/templates/13-catalog-operator.deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: catalog-operator
+  namespace: kube-system
+  labels:
+    app: catalog-operator
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: catalog-operator
+  template:
+    metadata:
+      labels:
+        app: catalog-operator
+    spec:
+      serviceAccountName: olm-operator-serviceaccount
+      containers:
+        - name: catalog-operator
+          command:
+          - /bin/catalog
+          - '-namespace'
+          - kube-system
+          - '-debug'
+          image: quay.io/coreos/catalog@sha256:cc60359f7fdeaf71e4d989b470dd8c35c693756b5f24485b0f3df6612a730101
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+      imagePullSecrets:
+        - name: coreos-pull-secret

--- a/ansible/roles/olm_setup/files/0.6.0/13-catalog-operator.deployment.yaml
+++ b/ansible/roles/olm_setup/files/0.6.0/13-catalog-operator.deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: catalog-operator
-  namespace: kube-system
+  namespace: operator-lifecycle-manager
   labels:
     app: catalog-operator
 spec:
@@ -25,7 +25,7 @@ spec:
           command:
           - /bin/catalog
           - '-namespace'
-          - kube-system
+          - operator-lifecycle-manager
           - '-debug'
           image: quay.io/coreos/catalog@sha256:cc60359f7fdeaf71e4d989b470dd8c35c693756b5f24485b0f3df6612a730101
           imagePullPolicy: IfNotPresent

--- a/ansible/roles/olm_setup/files/0.6.0/20-aggregated-edit.clusterrole.yaml
+++ b/ansible/roles/olm_setup/files/0.6.0/20-aggregated-edit.clusterrole.yaml
@@ -1,0 +1,14 @@
+##---
+# Source: olm/templates/20-aggregated-edit.clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-olm-edit
+  labels:
+    # Add these permissions to the "admin" and "edit" default roles.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["operators.coreos.com"]
+  resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/ansible/roles/olm_setup/files/0.6.0/21-aggregated-view.clusterrole.yaml
+++ b/ansible/roles/olm_setup/files/0.6.0/21-aggregated-view.clusterrole.yaml
@@ -1,0 +1,13 @@
+##---
+# Source: olm/templates/21-aggregated-view.clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-olm-view
+  labels:
+    # Add these permissions to the "view" default roles
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups: ["operators.coreos.com"]
+  resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions"]
+  verbs: ["get", "list", "watch"]

--- a/ansible/roles/olm_setup/files/0.7.0/00-olm-operator.clusterrole.yaml
+++ b/ansible/roles/olm_setup/files/0.7.0/00-olm-operator.clusterrole.yaml
@@ -1,0 +1,12 @@
+##---
+# Source: olm/templates/00-olm-operator.clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:controller:operator-lifecycle-manager
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+- nonResourceURLs: ["*"]
+  verbs: ["*"]

--- a/ansible/roles/olm_setup/files/0.7.0/01-olm-operator.serviceaccount.yaml
+++ b/ansible/roles/olm_setup/files/0.7.0/01-olm-operator.serviceaccount.yaml
@@ -1,0 +1,7 @@
+##---
+# Source: olm/templates/01-olm-operator.serviceaccount.yaml
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: olm-operator-serviceaccount
+  namespace: operator-lifecycle-manager

--- a/ansible/roles/olm_setup/files/0.7.0/02-olm-operator.rolebinding.yaml
+++ b/ansible/roles/olm_setup/files/0.7.0/02-olm-operator.rolebinding.yaml
@@ -1,0 +1,14 @@
+##---
+# Source: olm/templates/02-olm-operator.rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: olm-operator-binding-operator-lifecycle-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:controller:operator-lifecycle-manager
+subjects:
+- kind: ServiceAccount
+  name: olm-operator-serviceaccount
+  namespace: operator-lifecycle-manager

--- a/ansible/roles/olm_setup/files/0.7.0/03-clusterserviceversion.crd.yaml
+++ b/ansible/roles/olm_setup/files/0.7.0/03-clusterserviceversion.crd.yaml
@@ -1,0 +1,465 @@
+##---
+# Source: olm/templates/03-clusterserviceversion.crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterserviceversions.operators.coreos.com
+  annotations:
+    displayName: Operator Version
+    description: Represents an Operator that should be running on the cluster, including requirements and install strategy.
+spec:
+  names:
+    plural: clusterserviceversions
+    singular: clusterserviceversion
+    kind: ClusterServiceVersion
+    listKind: ClusterServiceVersionList
+    shortNames:
+    - csv
+    categories:
+    - all
+    - olm
+  additionalPrinterColumns:
+  - name: Display
+    type: string
+    description: The name of the CSV
+    JSONPath: .spec.displayName
+  - name: Version
+    type: string
+    description: The version of the CSV
+    JSONPath: .spec.version
+  - name: Replaces
+    type: string
+    description: The name of a CSV that this one replaces
+    JSONPath: .spec.replaces
+  - name: Phase
+    type: string
+    JSONPath: .status.phase
+  group: operators.coreos.com
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  scope: Namespaced
+  subresources:
+    # status enables the status subresource.
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          description: Spec for a ClusterServiceVersion
+          required:
+          - displayName
+          - install
+          properties:
+            displayName:
+              type: string
+              description: Human readable name of the application that will be displayed in the ALM UI
+
+            description:
+              type: string
+              description: Human readable description of what the application does
+
+            keywords:
+              type: array
+              description: List of keywords which will be used to discover and categorize app types
+              items:
+                type: string
+
+            maintainers:
+              type: array
+              description: Those responsible for the creation of this specific app type
+              items:
+                type: object
+                description: Information for a single maintainer
+                required:
+                - name
+                - email
+                properties:
+                  name:
+                    type: string
+                    description: Maintainer's name
+                  email:
+                    type: string
+                    description: Maintainer's email address
+                    format: email
+                optionalProperties:
+                  type: string
+                  description: "Any additional key-value metadata you wish to expose about the maintainer, e.g. github: <username>"
+
+            links:
+              type: array
+              description: Interesting links to find more information about the project, such as marketing page, documentation, or github page
+              items:
+                type: object
+                description: A single link to describe one aspect of the project
+                required:
+                - name
+                - url
+                properties:
+                  name:
+                    type: string
+                    description: Name of the link type, e.g. homepage or github url
+                  url:
+                    type: string
+                    description: URL to which the link should point
+                    format: uri
+
+            icon:
+              type: array
+              description: Icon which should be rendered with the application information
+              required:
+              - base64data
+              - mediatype
+              properties:
+                base64data:
+                  type: string
+                  description: Base64 binary representation of the icon image
+                  pattern: ^(?:[A-Za-z0-9+/]{4}){0,16250}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$
+                mediatype:
+                  type: string
+                  description: Mediatype for the binary data specified in the base64data property
+                  enum:
+                  - image/gif
+                  - image/jpeg
+                  - image/png
+                  - image/svg+xml
+            version:
+              type: string
+              description: Version string, recommended that users use semantic versioning
+              pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$
+
+            replaces:
+              type: string
+              description: Name of the ClusterServiceVersion custom resource that this version replaces
+
+            maturity:
+              type: string
+              description: What level of maturity the software has achieved at this version
+              enum:
+              - planning
+              - pre-alpha
+              - alpha
+              - beta
+              - stable
+              - mature
+              - inactive
+              - deprecated
+            labels:
+              type: object
+              description: Labels that will be applied to associated resources created by the operator.
+            selector:
+              type: object
+              description: Label selector to find resources associated with or managed by the operator
+              properties:
+                matchLabels:
+                  type: object
+                  description: Label key:value pairs to match directly
+                matchExpressions:
+                  type: array
+                  description: A set of expressions to match against the resource.
+                  items:
+                    allOf:
+                      - type: object
+                        required:
+                        - key
+                        - operator
+                        - values
+                        properties:
+                          key:
+                            type: string
+                            description: the key to match
+                          operator:
+                            type: string
+                            description: the operator for the expression
+                            enum:
+                            - In
+                            - NotIn
+                            - Exists
+                            - DoesNotExist
+                          values:
+                            type: array
+                            description: set of values for the expression
+            customresourcedefinitions:
+              type: object
+              properties:
+                owned:
+                  type: array
+                  description: What resources this operator is responsible for managing. No two running operators should manage the same resource.
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - version
+                      - kind
+                      - displayName
+                      - description
+                    properties:
+                      name:
+                        type: string
+                        description: Fully qualified name of the CustomResourceDefinition (e.g. my-resource-v1.app.coreos.com)
+                      version:
+                        type: string
+                        description: The version field of the CustomResourceDefinition
+                      kind:
+                        type: string
+                        description: The kind field of the CustomResourceDefinition
+                      displayName:
+                        type: string
+                        description: A human-readable name for the CRD.
+                      description:
+                        type: string
+                        description: A description of the CRD
+                      resources:
+                        type: array
+                        items:
+                          type: object
+                          description: A list of resources that should be displayed for the CRD
+                          required:
+                            - kind
+                            - version
+                          properties:
+                            name:
+                              type: string
+                              description: If a CRD, the fully qualified name of the CustomResourceDefinition (e.g. my-resource-v1.app.coreos.com)
+                            version:
+                              type: string
+                              description: The version of the resource kind
+                            kind:
+                              type: string
+                              description: The kind field of the resource kind
+                      statusDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the status block of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the status object on the CR where the the status value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the status entry.
+                            description:
+                              type: string
+                              description: A description of the status entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the status entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              type: object
+                              description: If present, the value of this status is the same for all instances of the CRD and can be found here instead of on the CR.
+                      specDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the spec block of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the spec object on the CR where the the spec value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the spec entry.
+                            description:
+                              type: string
+                              description: A description of the spec entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the spec entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              type: object
+                              description: If present, the value of this spec is the same for all instances of the CRD and can be found here instead of on the CR.
+                      actionDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for actions that can be performed on instances of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the spec object on the CR where the the spec value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the action.
+                            description:
+                              type: string
+                              description: A description of the action.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the action that indicate the meaning of the action.
+                              items:
+                                type: string
+                            value:
+                              type: object
+                              description: If present, the value of this action is the same for all instances of the CRD and can be found here instead of on the CR.
+                required:
+                  type: array
+                  description: What resources this operator is responsible for managing. No two running operators should manage the same resource.
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - version
+                      - kind
+                      - displayName
+                      - description
+                    properties:
+                      name:
+                        type: string
+                        description: Fully qualified name of the CustomResourceDefinition (e.g. my-resource-v1.app.coreos.com)
+                      version:
+                        type: string
+                        description: The version field of the CustomResourceDefinition
+                      kind:
+                        type: string
+                        description: The kind field of the CustomResourceDefinition
+                      displayName:
+                        type: string
+                        description: A human-readable name for the CRD.
+                      description:
+                        type: string
+                        description: A description of the CRD
+                      statusDescriptors:
+                        type: array
+                        items:
+                          type: object
+                          description: A spec for a field in the status block of the CRD
+                          required:
+                            - path
+                            - displayName
+                            - description
+                          properties:
+                            path:
+                              type: string
+                              description: A jsonpath indexing into the status object on the CR where the the status value can be found.
+                            displayName:
+                              type: string
+                              description: A human-readable name for the status entry.
+                            description:
+                              type: string
+                              description: A description of the status entry.
+                            x-descriptors:
+                              type: array
+                              description: A list of descriptors for the status entry that indicate the meaning of the field.
+                              items:
+                                type: string
+                            value:
+                              type: object
+                              description: If present, the value of this status is the same for all instances of the CRD and can be found here instead of on the CR.
+
+
+            install:
+              type: object
+              description: Information required to install this specific version of the operator software
+              oneOf:
+              - type: object
+                required:
+                - strategy
+                - spec
+                properties:
+                  strategy:
+                    type: string
+                    enum: ['image']
+                  spec:
+                    type: object
+                    required:
+                    - image
+                    properties:
+                      image:
+                        type: string
+              - type: object
+                required:
+                - strategy
+                - spec
+                properties:
+                  strategy:
+                    type: string
+                    enum: ['deployment']
+                  spec:
+                    type: object
+                    required:
+                    - deployments
+                    properties:
+                      deployments:
+                        type: array
+                        description: List of deployments to create
+                        items:
+                          type: object
+                          description: A name and deployment to create in the cluster
+                          required:
+                            - name
+                            - spec
+                          properties:
+                            name:
+                              type: string
+                              description: the consistent name of the deployment
+                            spec:
+                              type: object
+                              description: The deployment spec to create in the cluster
+                      permissions:
+                        type: array
+                        description: Permissions needed by the deployement to run correctly
+                        items:
+                          type: object
+                          required:
+                            - serviceAccountName
+                            - rules
+                          properties:
+                            serviceAccountName:
+                              type: string
+                              description: The service account name to create for the deployment
+                            rules:
+                              type: array
+                              items:
+                                type: object
+                                description: a rule required by the service account
+                                properties:
+                                  apiGroups:
+                                    type: array
+                                    description: apiGroups the rule applies to
+                                    items:
+                                      type: string
+                                  resources:
+                                    type: array
+                                    items:
+                                      type: string
+                                  resourceNames:
+                                    type: array
+                                    items:
+                                      type: string
+                                  verbs:
+                                    type: array
+                                    items:
+                                      type: string
+                                      enum:
+                                        - "*"
+                                        - get
+                                        - list
+                                        - watch
+                                        - create
+                                        - update
+                                        - patch
+                                        - delete
+                                        - deletecollection
+        status:
+          type: object
+          description: Status for a ClusterServiceVersion

--- a/ansible/roles/olm_setup/files/0.7.0/05-catalogsource.crd.yaml
+++ b/ansible/roles/olm_setup/files/0.7.0/05-catalogsource.crd.yaml
@@ -1,0 +1,81 @@
+##---
+# Source: olm/templates/05-catalogsource.crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: catalogsources.operators.coreos.com
+  annotations:
+    displayName: CatalogSource
+    description: A source configured to find packages and updates.
+spec:
+  group: operators.coreos.com
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: catalogsources
+    singular: catalogsource
+    kind: CatalogSource
+    listKind: CatalogSourceList
+    categories:
+    - all
+    - olm
+  additionalPrinterColumns:
+  - name: Name
+    type: string
+    description: The pretty name of the catalog
+    JSONPath: .spec.displayName
+  - name: Type
+    type: string
+    description: The type of the catalog
+    JSONPath: .spec.sourceType
+  - name: Publisher
+    type: string
+    description: The publisher of the catalog
+    JSONPath: .spec.publisher
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+  # status enables the status subresource.
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          description: Represents a subscription to a source and channel
+          required:
+          - spec
+          type: object
+          description: Spec for a catalog source.
+          required:
+          - sourceType
+          properties:
+            sourceType:
+              type: string
+              description: The type of the source. Currently the only supported type is "internal".
+              enum:
+              - internal
+
+            configMap:
+              type: string
+              description: The name of a ConfigMap that holds the entries for an in-memory catalog.
+
+            displayName:
+              type: string
+              description: Pretty name for display
+
+            publisher:
+              type: string
+              description: The name of an entity that publishes this catalog
+
+            secrets:
+              type: array
+              description: A set of secrets that can be used to access the contents of the catalog. It is best to keep this list small, since each will need to be tried for every catalog entry.
+              items:
+                type: string
+                description: A name of a secret in the namespace where the CatalogSource is defined.

--- a/ansible/roles/olm_setup/files/0.7.0/06-installplan.crd.yaml
+++ b/ansible/roles/olm_setup/files/0.7.0/06-installplan.crd.yaml
@@ -1,0 +1,78 @@
+##---
+# Source: olm/templates/06-installplan.crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: installplans.operators.coreos.com
+  annotations:
+    displayName: Install Plan
+    description: Represents a plan to install and resolve dependencies for Cluster Services
+spec:
+  group: operators.coreos.com
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: installplans
+    singular: installplan
+    kind: InstallPlan
+    listKind: InstallPlanList
+    categories:
+    - all
+    - olm
+  additionalPrinterColumns:
+  - name: CSV
+    type: string
+    description: The first CSV in the list of clusterServiceVersionNames
+    JSONPath: .spec.clusterServiceVersionNames[0]
+  - name: Source
+    type: string
+    description: The catalog source for the specified CSVs.
+    JSONPath: .spec.source
+  - name: Approval
+    type: string
+    description: The approval mode
+    JSONPath: .spec.approval
+  - name: Approved
+    type: boolean
+    JSONPath: .spec.approved
+  subresources:
+    # status enables the status subresource.
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          description: Spec for an InstallPlan
+          required:
+          - clusterServiceVersionNames
+          - approval
+          properties:
+            source:
+              type: string
+              description: Name of the preferred CatalogSource
+            sourceNamespace:
+              type: string
+              description: Namespace that contains the preffered CatalogSource
+            clusterServiceVersionNames:
+              type: array
+              description: A list of the names of the Cluster Services
+              items:
+                type: string
+          anyOf:
+            - properties:
+                approval:
+                  enum:
+                    - Manual
+                approved:
+                  type: boolean
+              required:
+                - approved
+            - properties:
+                approval:
+                  enum:
+                    - Automatic

--- a/ansible/roles/olm_setup/files/0.7.0/07-subscription.crd.yaml
+++ b/ansible/roles/olm_setup/files/0.7.0/07-subscription.crd.yaml
@@ -1,0 +1,72 @@
+##---
+# Source: olm/templates/07-subscription.crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: subscriptions.operators.coreos.com
+  annotations:
+    displayName: Subscription
+    description: Subcribes service catalog to a source and channel to recieve updates for packages.
+spec:
+  group: operators.coreos.com
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: subscriptions
+    singular: subscription
+    kind: Subscription
+    listKind: SubscriptionList
+    categories:
+    - all
+    - olm
+  additionalPrinterColumns:
+  - name: Package
+    type: string
+    description: The package subscribed to
+    JSONPath: .spec.name
+  - name: Source
+    type: string
+    description: The catalog source for the specified package
+    JSONPath: .spec.source
+  - name: Channel
+    type: string
+    description: The channel of updates to subscribe to
+    JSONPath: .spec.channel
+  subresources:
+    # status enables the status subresource.
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          description: Spec for a Subscription
+          required:
+          - source
+          - name
+          properties:
+            source:
+              type: string
+              description: Name of a CatalogSource that defines where and how to find the channel
+            sourceNamespace:
+              type: string
+              description: The Kubernetes namespace where the CatalogSource used is located
+            name:
+              type: string
+              description: Name of the package that defines the application
+            channel:
+              type: string
+              description: Name of the channel to track
+            startingCSV:
+              type: string
+              description: Name of the AppType that this subscription tracks
+            installPlanApproval:
+              type: string
+              description: Approval mode for emitted InstallPlans
+              enum:
+              - Manual
+              - Automatic

--- a/ansible/roles/olm_setup/files/0.7.0/08-rh-operators.configmap.yaml
+++ b/ansible/roles/olm_setup/files/0.7.0/08-rh-operators.configmap.yaml
@@ -1,0 +1,9699 @@
+##---
+# Source: olm/templates/08-rh-operators.configmap.yaml
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: rh-operators
+  namespace: operator-lifecycle-manager
+
+data:
+  customResourceDefinitions: |-
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: alertmanagers.monitoring.coreos.com
+      spec:
+        group: monitoring.coreos.com
+        names:
+          kind: Alertmanager
+          plural: alertmanagers
+        scope: Namespaced
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                description: 'Specification of the desired behavior of the Alertmanager
+                  cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+                properties:
+                  affinity:
+                    description: Affinity is a group of affinity scheduling rules.
+                    properties:
+                      nodeAffinity:
+                        description: Node affinity is a group of node affinity scheduling
+                          rules.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes
+                              that satisfy the affinity expressions specified by this field,
+                              but it may choose a node that violates one or more of the
+                              expressions. The node that is most preferred is the one with
+                              the greatest sum of weights, i.e. for each node that meets
+                              all of the scheduling requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating through
+                              the elements of this field and adding "weight" to the sum
+                              if the node matches the corresponding matchExpressions; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all
+                                objects with implicit weight 0 (i.e. it's a no-op). A null
+                                preferred scheduling term matches no objects (i.e. is also
+                                a no-op).
+                              properties:
+                                preference:
+                                  description: A null or empty node selector term matches
+                                    no objects. The requirements of them are ANDed. The
+                                    TopologySelectorTerm type implements a subset of the
+                                    NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the
+                                              operator is In or NotIn, the values array
+                                              must be non-empty. If the operator is Exists
+                                              or DoesNotExist, the values array must be
+                                              empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will
+                                              be interpreted as an integer. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the
+                                              operator is In or NotIn, the values array
+                                              must be non-empty. If the operator is Exists
+                                              or DoesNotExist, the values array must be
+                                              empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will
+                                              be interpreted as an integer. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                weight:
+                                  description: Weight associated with matching the corresponding
+                                    nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - preference
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: A node selector represents the union of the results
+                              of one or more label queries over a set of nodes; that is,
+                              it represents the OR of the selectors represented by the node
+                              selector terms.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The
+                                  terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches
+                                    no objects. The requirements of them are ANDed. The
+                                    TopologySelectorTerm type implements a subset of the
+                                    NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the
+                                              operator is In or NotIn, the values array
+                                              must be non-empty. If the operator is Exists
+                                              or DoesNotExist, the values array must be
+                                              empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will
+                                              be interpreted as an integer. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the
+                                              operator is In or NotIn, the values array
+                                              must be non-empty. If the operator is Exists
+                                              or DoesNotExist, the values array must be
+                                              empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will
+                                              be interpreted as an integer. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                      podAffinity:
+                        description: Pod affinity is a group of inter pod affinity scheduling
+                          rules.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes
+                              that satisfy the affinity expressions specified by this field,
+                              but it may choose a node that violates one or more of the
+                              expressions. The node that is most preferred is the one with
+                              the greatest sum of weights, i.e. for each node that meets
+                              all of the scheduling requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating through
+                              the elements of this field and adding "weight" to the sum
+                              if the node has pods which matches the corresponding podAffinityTerm;
+                              the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Defines a set of pods (namely those matching
+                                    the labelSelector relative to the given namespace(s))
+                                    that this pod should be co-located (affinity) or not
+                                    co-located (anti-affinity) with, where co-located is
+                                    defined as running on a node whose value of the label
+                                    with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label selector is a label query over
+                                        a set of resources. The result of matchLabels and
+                                        matchExpressions are ANDed. An empty label selector
+                                        matches all objects. A null label selector matches
+                                        no objects.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label
+                                            selector requirements. The requirements are
+                                            ANDed.
+                                          items:
+                                            description: A label selector requirement is
+                                              a selector that contains values, a key, and
+                                              an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If
+                                                  the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array
+                                                  is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                          type: array
+                                        matchLabels:
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is "In",
+                                            and the values array contains only "value".
+                                            The requirements are ANDed.
+                                          type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified namespaces,
+                                        where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches
+                                        that of any node on which any of the selected pods
+                                        is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                weight:
+                                  description: weight associated with matching the corresponding
+                                    podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - podAffinityTerm
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this
+                              field are not met at scheduling time, the pod will not be
+                              scheduled onto the node. If the affinity requirements specified
+                              by this field cease to be met at some point during pod execution
+                              (e.g. due to a pod label update), the system may or may not
+                              try to eventually evict the pod from its node. When there
+                              are multiple elements, the lists of nodes corresponding to
+                              each podAffinityTerm are intersected, i.e. all terms must
+                              be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s)) that
+                                this pod should be co-located (affinity) or not co-located
+                                (anti-affinity) with, where co-located is defined as running
+                                on a node whose value of the label with key <topologyKey>
+                                matches that of any node on which a pod of the set of pods
+                                is running
+                              properties:
+                                labelSelector:
+                                  description: A label selector is a label query over a
+                                    set of resources. The result of matchLabels and matchExpressions
+                                    are ANDed. An empty label selector matches all objects.
+                                    A null label selector matches no objects.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector
+                                        requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator is
+                                              Exists or DoesNotExist, the values array must
+                                              be empty. This array is replaced during a
+                                              strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                    matchLabels:
+                                      description: matchLabels is a map of {key,value} pairs.
+                                        A single {key,value} in the matchLabels map is equivalent
+                                        to an element of matchExpressions, whose key field
+                                        is "key", the operator is "In", and the values array
+                                        contains only "value". The requirements are ANDed.
+                                      type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the
+                                    labelSelector applies to (matches against); null or
+                                    empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where
+                                    co-located is defined as running on a node whose value
+                                    of the label with key topologyKey matches that of any
+                                    node on which any of the selected pods is running. Empty
+                                    topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                            type: array
+                      podAntiAffinity:
+                        description: Pod anti affinity is a group of inter pod anti affinity
+                          scheduling rules.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes
+                              that satisfy the anti-affinity expressions specified by this
+                              field, but it may choose a node that violates one or more
+                              of the expressions. The node that is most preferred is the
+                              one with the greatest sum of weights, i.e. for each node that
+                              meets all of the scheduling requirements (resource request,
+                              requiredDuringScheduling anti-affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field
+                              and adding "weight" to the sum if the node has pods which
+                              matches the corresponding podAffinityTerm; the node(s) with
+                              the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Defines a set of pods (namely those matching
+                                    the labelSelector relative to the given namespace(s))
+                                    that this pod should be co-located (affinity) or not
+                                    co-located (anti-affinity) with, where co-located is
+                                    defined as running on a node whose value of the label
+                                    with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label selector is a label query over
+                                        a set of resources. The result of matchLabels and
+                                        matchExpressions are ANDed. An empty label selector
+                                        matches all objects. A null label selector matches
+                                        no objects.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label
+                                            selector requirements. The requirements are
+                                            ANDed.
+                                          items:
+                                            description: A label selector requirement is
+                                              a selector that contains values, a key, and
+                                              an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If
+                                                  the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array
+                                                  is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                          type: array
+                                        matchLabels:
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is "In",
+                                            and the values array contains only "value".
+                                            The requirements are ANDed.
+                                          type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified namespaces,
+                                        where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches
+                                        that of any node on which any of the selected pods
+                                        is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                weight:
+                                  description: weight associated with matching the corresponding
+                                    podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - podAffinityTerm
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by
+                              this field are not met at scheduling time, the pod will not
+                              be scheduled onto the node. If the anti-affinity requirements
+                              specified by this field cease to be met at some point during
+                              pod execution (e.g. due to a pod label update), the system
+                              may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding
+                              to each podAffinityTerm are intersected, i.e. all terms must
+                              be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s)) that
+                                this pod should be co-located (affinity) or not co-located
+                                (anti-affinity) with, where co-located is defined as running
+                                on a node whose value of the label with key <topologyKey>
+                                matches that of any node on which a pod of the set of pods
+                                is running
+                              properties:
+                                labelSelector:
+                                  description: A label selector is a label query over a
+                                    set of resources. The result of matchLabels and matchExpressions
+                                    are ANDed. An empty label selector matches all objects.
+                                    A null label selector matches no objects.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector
+                                        requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator is
+                                              Exists or DoesNotExist, the values array must
+                                              be empty. This array is replaced during a
+                                              strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                    matchLabels:
+                                      description: matchLabels is a map of {key,value} pairs.
+                                        A single {key,value} in the matchLabels map is equivalent
+                                        to an element of matchExpressions, whose key field
+                                        is "key", the operator is "In", and the values array
+                                        contains only "value". The requirements are ANDed.
+                                      type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the
+                                    labelSelector applies to (matches against); null or
+                                    empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where
+                                    co-located is defined as running on a node whose value
+                                    of the label with key topologyKey matches that of any
+                                    node on which any of the selected pods is running. Empty
+                                    topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                            type: array
+                  baseImage:
+                    description: Base image that is used to deploy pods, without tag.
+                    type: string
+                  containers:
+                    description: Containers allows injecting additional containers. This
+                      is meant to allow adding an authentication proxy to an Alertmanager
+                      pod.
+                    items:
+                      description: A single application container that you want to run within
+                        a pod.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The docker image''s
+                            CMD is used if this is not provided. Variable references $(VAR_NAME)
+                            are expanded using the container''s environment. If a variable
+                            cannot be resolved, the reference in the input string will be
+                            unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                            $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot be
+                            updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell. The
+                            docker image''s ENTRYPOINT is used if this is not provided.
+                            Variable references $(VAR_NAME) are expanded using the container''s
+                            environment. If a variable cannot be resolved, the reference
+                            in the input string will be unchanged. The $(VAR_NAME) syntax
+                            can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable exists
+                            or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the container.
+                            Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable present
+                              in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must be a
+                                  C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are expanded
+                                  using the previous defined environment variables in the
+                                  container and any service environment variables. If a
+                                  variable cannot be resolved, the reference in the input
+                                  string will be unchanged. The $(VAR_NAME) syntax can be
+                                  escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                                  will never be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
+                                type: string
+                              valueFrom:
+                                description: EnvVarSource represents a source for the value
+                                  of an EnvVar.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key from a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or it's
+                                          key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                  fieldRef:
+                                    description: ObjectFieldSelector selects an APIVersioned
+                                      field of an object.
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in the
+                                          specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                  resourceFieldRef:
+                                    description: ResourceFieldSelector represents container
+                                      resources (cpu, memory) and their output format
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for volumes,
+                                          optional for env vars'
+                                        type: string
+                                      divisor: {}
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                  secretKeyRef:
+                                    description: SecretKeySelector selects a key of a Secret.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must
+                                          be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or it's
+                                          key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                            required:
+                            - name
+                          type: array
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must be a
+                            C_IDENTIFIER. All invalid keys will be reported as an event
+                            when the container is starting. When a key exists in multiple
+                            sources, the value associated with the last source will take
+                            precedence. Values defined by an Env with a duplicate key will
+                            take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a set of
+                              ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: |-
+                                  ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+      
+                                  The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must be defined
+                                    type: boolean
+                              prefix:
+                                description: An optional identifier to prepend to each key
+                                  in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: |-
+                                  SecretEnvSource selects a Secret to populate the environment variables with.
+      
+                                  The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be defined
+                                    type: boolean
+                          type: array
+                        image:
+                          description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management
+                            to default or override container images in workload controllers
+                            like Deployments and StatefulSets.'
+                          type: string
+                        imagePullPolicy:
+                          description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                            Defaults to Always if :latest tag is specified, or IfNotPresent
+                            otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                          type: string
+                        lifecycle:
+                          description: Lifecycle describes actions that the management system
+                            should take in response to container lifecycle events. For the
+                            PostStart and PreStop lifecycle handlers, management of the
+                            container blocks until the action is complete, unless the container
+                            process fails, in which case the handler is aborted.
+                          properties:
+                            postStart:
+                              description: Handler defines a specific action that should
+                                be taken
+                              properties:
+                                exec:
+                                  description: ExecAction describes a "run in container"
+                                    action.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to execute
+                                        inside the container, the working directory for
+                                        the command  is root ('/') in the container's filesystem.
+                                        The command is simply exec'd, it is not run inside
+                                        a shell, so traditional shell instructions ('|',
+                                        etc) won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is treated
+                                        as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                httpGet:
+                                  description: HTTPGetAction describes an action based on
+                                    HTTP Get requests.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults to
+                                        the pod IP. You probably want to set "Host" in httpHeaders
+                                        instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom header
+                                          to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                    scheme:
+                                      description: Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                tcpSocket:
+                                  description: TCPSocketAction describes an action based
+                                    on opening a socket
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect to, defaults
+                                        to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                  required:
+                                  - port
+                            preStop:
+                              description: Handler defines a specific action that should
+                                be taken
+                              properties:
+                                exec:
+                                  description: ExecAction describes a "run in container"
+                                    action.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to execute
+                                        inside the container, the working directory for
+                                        the command  is root ('/') in the container's filesystem.
+                                        The command is simply exec'd, it is not run inside
+                                        a shell, so traditional shell instructions ('|',
+                                        etc) won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is treated
+                                        as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                httpGet:
+                                  description: HTTPGetAction describes an action based on
+                                    HTTP Get requests.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults to
+                                        the pod IP. You probably want to set "Host" in httpHeaders
+                                        instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom header
+                                          to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                    scheme:
+                                      description: Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                tcpSocket:
+                                  description: TCPSocketAction describes an action based
+                                    on opening a socket
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect to, defaults
+                                        to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                  required:
+                                  - port
+                        livenessProbe:
+                          description: Probe describes a health check to be performed against
+                            a container to determine whether it is alive or ready to receive
+                            traffic.
+                          properties:
+                            exec:
+                              description: ExecAction describes a "run in container" action.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute inside
+                                    the container, the working directory for the command  is
+                                    root ('/') in the container's filesystem. The command
+                                    is simply exec'd, it is not run inside a shell, so traditional
+                                    shell instructions ('|', etc) won't work. To use a shell,
+                                    you need to explicitly call out to that shell. Exit
+                                    status of 0 is treated as live/healthy and non-zero
+                                    is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe to
+                                be considered failed after having succeeded. Defaults to
+                                3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGetAction describes an action based on HTTP
+                                Get requests.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to the
+                                    pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request. HTTP
+                                    allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header to
+                                      be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: string
+                                  - type: integer
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has started
+                                before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe to
+                                be considered successful after having failed. Defaults to
+                                1. Must be 1 for liveness. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocketAction describes an action based on
+                                opening a socket
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: string
+                                  - type: integer
+                              required:
+                              - port
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe times
+                                out. Defaults to 1 second. Minimum value is 1. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                        name:
+                          description: Name of the container specified as a DNS_LABEL. Each
+                            container in a pod must have a unique name (DNS_LABEL). Cannot
+                            be updated.
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container. Exposing
+                            a port here gives the system additional information about the
+                            network connections a container uses, but is primarily informational.
+                            Not specifying a port here DOES NOT prevent that port from being
+                            exposed. Any port which is listening on the default "0.0.0.0"
+                            address inside a container will be accessible from the network.
+                            Cannot be updated.
+                          items:
+                            description: ContainerPort represents a network port in a single
+                              container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's IP address.
+                                  This must be a valid port number, 0 < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host. If specified,
+                                  this must be a valid port number, 0 < x < 65536. If HostNetwork
+                                  is specified, this must match ContainerPort. Most containers
+                                  do not need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a pod must
+                                  have a unique name. Name for the port that can be referred
+                                  to by services.
+                                type: string
+                              protocol:
+                                description: Protocol for port. Must be UDP or TCP. Defaults
+                                  to "TCP".
+                                type: string
+                            required:
+                            - containerPort
+                          type: array
+                        readinessProbe:
+                          description: Probe describes a health check to be performed against
+                            a container to determine whether it is alive or ready to receive
+                            traffic.
+                          properties:
+                            exec:
+                              description: ExecAction describes a "run in container" action.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute inside
+                                    the container, the working directory for the command  is
+                                    root ('/') in the container's filesystem. The command
+                                    is simply exec'd, it is not run inside a shell, so traditional
+                                    shell instructions ('|', etc) won't work. To use a shell,
+                                    you need to explicitly call out to that shell. Exit
+                                    status of 0 is treated as live/healthy and non-zero
+                                    is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe to
+                                be considered failed after having succeeded. Defaults to
+                                3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGetAction describes an action based on HTTP
+                                Get requests.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to the
+                                    pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request. HTTP
+                                    allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header to
+                                      be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: string
+                                  - type: integer
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has started
+                                before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe to
+                                be considered successful after having failed. Defaults to
+                                1. Must be 1 for liveness. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocketAction describes an action based on
+                                opening a socket
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: string
+                                  - type: integer
+                              required:
+                              - port
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe times
+                                out. Defaults to 1 second. Minimum value is 1. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                        resources:
+                          description: ResourceRequirements describes the compute resource
+                            requirements.
+                          properties:
+                            limits:
+                              description: 'Limits describes the maximum amount of compute
+                                resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              description: 'Requests describes the minimum amount of compute
+                                resources required. If Requests is omitted for a container,
+                                it defaults to Limits if that is explicitly specified, otherwise
+                                to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                        securityContext:
+                          description: SecurityContext holds security configuration that
+                            will be applied to a container. Some fields are present in both
+                            SecurityContext and PodSecurityContext.  When both are set,
+                            the values in SecurityContext take precedence.
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether a
+                                process can gain more privileges than its parent process.
+                                This bool directly controls if the no_new_privs flag will
+                                be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN'
+                              type: boolean
+                            capabilities:
+                              description: Adds and removes POSIX capabilities from running
+                                containers.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                            privileged:
+                              description: Run container in privileged mode. Processes in
+                                privileged containers are essentially equivalent to root
+                                on the host. Defaults to false.
+                              type: boolean
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only root filesystem.
+                                Default is false.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be set
+                                in PodSecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as a non-root
+                                user. If true, the Kubelet will validate the image at runtime
+                                to ensure that it does not run as UID 0 (root) and fail
+                                to start the container if it does. If unset or false, no
+                                such validation will be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext, the
+                                value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata if
+                                unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext, the
+                                value specified in SecurityContext takes precedence.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: SELinuxOptions are the labels to be applied to
+                                the container
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                        stdin:
+                          description: Whether this container should allocate a buffer for
+                            stdin in the container runtime. If this is not set, reads from
+                            stdin in the container will always result in EOF. Default is
+                            false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close the stdin
+                            channel after it has been opened by a single attach. When stdin
+                            is true the stdin stream will remain open across multiple attach
+                            sessions. If stdinOnce is set to true, stdin is opened on container
+                            start, is empty until the first client attaches to stdin, and
+                            then remains open and accepts data until the client disconnects,
+                            at which time stdin is closed and remains closed until the container
+                            is restarted. If this flag is false, a container processes that
+                            reads from stdin will never receive an EOF. Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which the container''s
+                            termination message will be written is mounted into the container''s
+                            filesystem. Message written is intended to be brief final status,
+                            such as an assertion failure message. Will be truncated by the
+                            node if greater than 4096 bytes. The total message length across
+                            all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: Indicate how the termination message should be populated.
+                            File will use the contents of terminationMessagePath to populate
+                            the container status message on both success and failure. FallbackToLogsOnError
+                            will use the last chunk of container log output if the termination
+                            message file is empty and the container exited with an error.
+                            The log output is limited to 2048 bytes or 80 lines, whichever
+                            is smaller. Defaults to File. Cannot be updated.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY for
+                            itself, also requires 'stdin' to be true. Default is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices to be
+                            used by the container. This is an alpha feature and may change
+                            in the future.
+                          items:
+                            description: volumeDevice describes a mapping of a raw block
+                              device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the container
+                                  that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - name
+                            - devicePath
+                          type: array
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume within
+                              a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the volume
+                                  should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts are
+                                  propagated from the host to container and the other way
+                                  around. When not set, MountPropagationHostToContainer
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write otherwise
+                                  (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the container's
+                                  volume should be mounted. Defaults to "" (volume's root).
+                                type: string
+                            required:
+                            - name
+                            - mountPath
+                          type: array
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might be
+                            configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                    type: array
+                  externalUrl:
+                    description: The external URL the Alertmanager instances will be available
+                      under. This is necessary to generate correct URLs. This is necessary
+                      if Alertmanager is not served from root of a DNS name.
+                    type: string
+                  imagePullSecrets:
+                    description: An optional list of references to secrets in the same namespace
+                      to use for pulling prometheus and alertmanager images from registries
+                      see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
+                    items:
+                      description: LocalObjectReference contains enough information to let
+                        you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                    type: array
+                  listenLocal:
+                    description: ListenLocal makes the Alertmanager server listen on loopback,
+                      so that it does not bind against the Pod IP. Note this is only for
+                      the Alertmanager UI, not the gossip communication.
+                    type: boolean
+                  logLevel:
+                    description: Log level for Alertmanager to be configured with.
+                    type: string
+                  nodeSelector:
+                    description: Define which Nodes the Pods are scheduled on.
+                    type: object
+                  paused:
+                    description: If set to true all actions on the underlaying managed objects
+                      are not goint to be performed, except for delete actions.
+                    type: boolean
+                  podMetadata:
+                    description: ObjectMeta is metadata that all persisted resources must
+                      have, which includes all objects users must create.
+                    properties:
+                      annotations:
+                        description: 'Annotations is an unstructured key value map stored
+                          with a resource that may be set by external tools to store and
+                          retrieve arbitrary metadata. They are not queryable and should
+                          be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      clusterName:
+                        description: The name of the cluster which the object belongs to.
+                          This is used to distinguish resources with same name and namespace
+                          in different clusters. This field is not set anywhere right now
+                          and apiserver is going to ignore it if set in create or update
+                          request.
+                        type: string
+                      creationTimestamp:
+                        description: Time is a wrapper around time.Time which supports correct
+                          marshaling to YAML and JSON.  Wrappers are provided for many of
+                          the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                      deletionGracePeriodSeconds:
+                        description: Number of seconds allowed for this object to gracefully
+                          terminate before it will be removed from the system. Only set
+                          when deletionTimestamp is also set. May only be shortened. Read-only.
+                        format: int64
+                        type: integer
+                      deletionTimestamp:
+                        description: Time is a wrapper around time.Time which supports correct
+                          marshaling to YAML and JSON.  Wrappers are provided for many of
+                          the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                      finalizers:
+                        description: Must be empty before the object is deleted from the
+                          registry. Each entry is an identifier for the responsible component
+                          that will remove the entry from the list. If the deletionTimestamp
+                          of the object is non-nil, entries in this list can only be removed.
+                        items:
+                          type: string
+                        type: array
+                      generateName:
+                        description: |-
+                          GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+      
+                          If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+      
+                          Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                        type: string
+                      generation:
+                        description: A sequence number representing a specific generation
+                          of the desired state. Populated by the system. Read-only.
+                        format: int64
+                        type: integer
+                      initializers:
+                        description: Initializers tracks the progress of initialization.
+                        properties:
+                          pending:
+                            description: Pending is a list of initializers that must execute
+                              in order before this object is visible. When the last pending
+                              initializer is removed, and no failing result is set, the
+                              initializers struct will be set to nil and the object is considered
+                              as initialized and visible to all clients.
+                            items:
+                              description: Initializer is information about an initializer
+                                that has not yet completed.
+                              properties:
+                                name:
+                                  description: name of the process that is responsible for
+                                    initializing this object.
+                                  type: string
+                              required:
+                              - name
+                            type: array
+                          result:
+                            description: Status is a return value for calls that don't return
+                              other objects.
+                            properties:
+                              apiVersion:
+                                description: 'APIVersion defines the versioned schema of
+                                  this representation of an object. Servers should convert
+                                  recognized schemas to the latest internal value, and may
+                                  reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                                type: string
+                              code:
+                                description: Suggested HTTP return code for this status,
+                                  0 if not set.
+                                format: int32
+                                type: integer
+                              details:
+                                description: StatusDetails is a set of additional properties
+                                  that MAY be set by the server to provide additional information
+                                  about a response. The Reason field of a Status object
+                                  defines what attributes will be set. Clients must ignore
+                                  fields that do not match the defined type of each attribute,
+                                  and should assume that any attribute may be empty, invalid,
+                                  or under defined.
+                                properties:
+                                  causes:
+                                    description: The Causes array includes more details
+                                      associated with the StatusReason failure. Not all
+                                      StatusReasons may provide detailed causes.
+                                    items:
+                                      description: StatusCause provides more information
+                                        about an api.Status failure, including cases when
+                                        multiple errors are encountered.
+                                      properties:
+                                        field:
+                                          description: |-
+                                            The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+      
+                                            Examples:
+                                              "name" - the field "name" on the current resource
+                                              "items[0].name" - the field "name" on the first array entry in "items"
+                                          type: string
+                                        message:
+                                          description: A human-readable description of the
+                                            cause of the error.  This field may be presented
+                                            as-is to a reader.
+                                          type: string
+                                        reason:
+                                          description: A machine-readable description of
+                                            the cause of the error. If this value is empty
+                                            there is no information available.
+                                          type: string
+                                    type: array
+                                  group:
+                                    description: The group attribute of the resource associated
+                                      with the status StatusReason.
+                                    type: string
+                                  kind:
+                                    description: 'The kind attribute of the resource associated
+                                      with the status StatusReason. On some operations may
+                                      differ from the requested resource Kind. More info:
+                                      https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                    type: string
+                                  name:
+                                    description: The name attribute of the resource associated
+                                      with the status StatusReason (when there is a single
+                                      name which can be described).
+                                    type: string
+                                  retryAfterSeconds:
+                                    description: If specified, the time in seconds before
+                                      the operation should be retried. Some errors may indicate
+                                      the client must take an alternate action - for those
+                                      errors this field may indicate how long to wait before
+                                      taking the alternate action.
+                                    format: int32
+                                    type: integer
+                                  uid:
+                                    description: 'UID of the resource. (when there is a
+                                      single resource which can be described). More info:
+                                      http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                    type: string
+                              kind:
+                                description: 'Kind is a string value representing the REST
+                                  resource this object represents. Servers may infer this
+                                  from the endpoint the client submits requests to. Cannot
+                                  be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                type: string
+                              message:
+                                description: A human-readable description of the status
+                                  of this operation.
+                                type: string
+                              metadata:
+                                description: ListMeta describes metadata that synthetic
+                                  resources must have, including lists and various status
+                                  objects. A resource may have only one of {ObjectMeta,
+                                  ListMeta}.
+                                properties:
+                                  continue:
+                                    description: continue may be set if the user set a limit
+                                      on the number of items returned, and indicates that
+                                      the server has more data available. The value is opaque
+                                      and may be used to issue another request to the endpoint
+                                      that served this list to retrieve the next set of
+                                      available objects. Continuing a list may not be possible
+                                      if the server configuration has changed or more than
+                                      a few minutes have passed. The resourceVersion field
+                                      returned when using this continue value will be identical
+                                      to the value in the first response.
+                                    type: string
+                                  resourceVersion:
+                                    description: 'String that identifies the server''s internal
+                                      version of this object that can be used by clients
+                                      to determine when objects have changed. Value must
+                                      be treated as opaque by clients and passed unmodified
+                                      back to the server. Populated by the system. Read-only.
+                                      More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                                    type: string
+                                  selfLink:
+                                    description: selfLink is a URL representing this object.
+                                      Populated by the system. Read-only.
+                                    type: string
+                              reason:
+                                description: A machine-readable description of why this
+                                  operation is in the "Failure" status. If this value is
+                                  empty there is no information available. A Reason clarifies
+                                  an HTTP status code but does not override it.
+                                type: string
+                              status:
+                                description: 'Status of the operation. One of: "Success"
+                                  or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                                type: string
+                        required:
+                        - pending
+                      labels:
+                        description: 'Map of string keys and values that can be used to
+                          organize and categorize (scope and select) objects. May match
+                          selectors of replication controllers and services. More info:
+                          http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                      name:
+                        description: 'Name must be unique within a namespace. Is required
+                          when creating resources, although some resources may allow a client
+                          to request the generation of an appropriate name automatically.
+                          Name is primarily intended for creation idempotence and configuration
+                          definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+      
+                          Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                        type: string
+                      ownerReferences:
+                        description: List of objects depended by this object. If ALL objects
+                          in the list have been deleted, this object will be garbage collected.
+                          If this object is managed by a controller, then an entry in this
+                          list will point to this controller, with the controller field
+                          set to true. There cannot be more than one managing controller.
+                        items:
+                          description: OwnerReference contains enough information to let
+                            you identify an owning object. Currently, an owning object must
+                            be in the same namespace, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: If true, AND if the owner has the "foregroundDeletion"
+                                finalizer, then the owner cannot be deleted from the key-value
+                                store until this reference is removed. Defaults to false.
+                                To set this field, a user needs "delete" permission of the
+                                owner, otherwise 422 (Unprocessable Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing
+                                controller.
+                              type: boolean
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                        type: array
+                      resourceVersion:
+                        description: |-
+                          An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+      
+                          Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      selfLink:
+                        description: SelfLink is a URL representing this object. Populated
+                          by the system. Read-only.
+                        type: string
+                      uid:
+                        description: |-
+                          UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+      
+                          Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                        type: string
+                  replicas:
+                    description: Size is the expected size of the alertmanager cluster.
+                      The controller will eventually make the size of the running cluster
+                      equal to the expected size.
+                    format: int32
+                    type: integer
+                  resources:
+                    description: ResourceRequirements describes the compute resource requirements.
+                    properties:
+                      limits:
+                        description: 'Limits describes the maximum amount of compute resources
+                          allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        description: 'Requests describes the minimum amount of compute resources
+                          required. If Requests is omitted for a container, it defaults
+                          to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                  routePrefix:
+                    description: The route prefix Alertmanager registers HTTP handlers for.
+                      This is useful, if using ExternalURL and a proxy is rewriting HTTP
+                      routes of a request, and the actual ExternalURL is still true, but
+                      the server serves requests under a different route prefix. For example
+                      for use with `kubectl proxy`.
+                    type: string
+                  secrets:
+                    description: Secrets is a list of Secrets in the same namespace as the
+                      Alertmanager object, which shall be mounted into the Alertmanager
+                      Pods. The Secrets are mounted into /etc/alertmanager/secrets/<secret-name>.
+                    items:
+                      type: string
+                    type: array
+                  securityContext:
+                    description: PodSecurityContext holds pod-level security attributes
+                      and common container settings. Some fields are also present in container.securityContext.  Field
+                      values of container.securityContext take precedence over field values
+                      of PodSecurityContext.
+                    properties:
+                      fsGroup:
+                        description: |-
+                          A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+      
+                          1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+      
+                          If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                        format: int64
+                        type: integer
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail to start
+                          the container if it does. If unset or false, no such validation
+                          will be performed. May also be set in SecurityContext.  If set
+                          in both SecurityContext and PodSecurityContext, the value specified
+                          in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified. May
+                          also be set in SecurityContext.  If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: SELinuxOptions are the labels to be applied to the
+                          container
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies to the
+                              container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies to the
+                              container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies to the
+                              container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies to the
+                              container.
+                            type: string
+                      supplementalGroups:
+                        description: A list of groups applied to the first process run in
+                          each container, in addition to the container's primary GID.  If
+                          unspecified, no groups will be added to any container.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used for
+                          the pod. Pods with unsupported sysctls (by the container runtime)
+                          might fail to launch.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                        type: array
+                  serviceAccountName:
+                    description: ServiceAccountName is the name of the ServiceAccount to
+                      use to run the Prometheus Pods.
+                    type: string
+                  storage:
+                    description: StorageSpec defines the configured storage for a group
+                      Prometheus servers.
+                    properties:
+                      class:
+                        description: 'Name of the StorageClass to use when requesting storage
+                          provisioning. More info: https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses
+                          DEPRECATED'
+                        type: string
+                      emptyDir:
+                        description: Represents an empty directory for a pod. Empty directory
+                          volumes support ownership management and SELinux relabeling.
+                        properties:
+                          medium:
+                            description: 'What type of storage medium should back this directory.
+                              The default is "" which means to use the node''s default medium.
+                              Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            type: string
+                          sizeLimit: {}
+                      resources:
+                        description: ResourceRequirements describes the compute resource
+                          requirements.
+                        properties:
+                          limits:
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            description: 'Requests describes the minimum amount of compute
+                              resources required. If Requests is omitted for a container,
+                              it defaults to Limits if that is explicitly specified, otherwise
+                              to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                      selector:
+                        description: A label selector is a label query over a set of resources.
+                          The result of matchLabels and matchExpressions are ANDed. An empty
+                          label selector matches all objects. A null label selector matches
+                          no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements.
+                              The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector that
+                                contains values, a key, and an operator that relates the
+                                key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies
+                                    to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn, Exists
+                                    and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the
+                                    operator is In or NotIn, the values array must be non-empty.
+                                    If the operator is Exists or DoesNotExist, the values
+                                    array must be empty. This array is replaced during a
+                                    strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                            type: array
+                          matchLabels:
+                            description: matchLabels is a map of {key,value} pairs. A single
+                              {key,value} in the matchLabels map is equivalent to an element
+                                           of matchExpressions, whose key field is "key", the operator
+                                           is "In", and the values array contains only "value". The requirements
+                                           are ANDed.
+                            type: object
+                      volumeClaimTemplate:
+                        description: PersistentVolumeClaim is a user's request for and claim
+                          to a persistent volume
+                        properties:
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema of this
+                              representation of an object. Servers should convert recognized
+                              schemas to the latest internal value, and may reject unrecognized
+                              values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                            type: string
+                          kind:
+                            description: 'Kind is a string value representing the REST resource
+                              this object represents. Servers may infer this from the endpoint
+                              the client submits requests to. Cannot be updated. In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                            type: string
+                          metadata:
+                            description: ObjectMeta is metadata that all persisted resources
+                              must have, which includes all objects users must create.
+                            properties:
+                              annotations:
+                                description: 'Annotations is an unstructured key value map
+                                  stored with a resource that may be set by external tools
+                                  to store and retrieve arbitrary metadata. They are not
+                                  queryable and should be preserved when modifying objects.
+                                  More info: http://kubernetes.io/docs/user-guide/annotations'
+                                type: object
+                              clusterName:
+                                description: The name of the cluster which the object belongs
+                                  to. This is used to distinguish resources with same name
+                                  and namespace in different clusters. This field is not
+                                  set anywhere right now and apiserver is going to ignore
+                                  it if set in create or update request.
+                                type: string
+                              creationTimestamp:
+                                description: Time is a wrapper around time.Time which supports
+                                  correct marshaling to YAML and JSON.  Wrappers are provided
+                                  for many of the factory methods that the time package
+                                  offers.
+                                format: date-time
+                                type: string
+                              deletionGracePeriodSeconds:
+                                description: Number of seconds allowed for this object to
+                                  gracefully terminate before it will be removed from the
+                                  system. Only set when deletionTimestamp is also set. May
+                                  only be shortened. Read-only.
+                                format: int64
+                                type: integer
+                              deletionTimestamp:
+                                description: Time is a wrapper around time.Time which supports
+                                  correct marshaling to YAML and JSON.  Wrappers are provided
+                                  for many of the factory methods that the time package
+                                  offers.
+                                format: date-time
+                                type: string
+                              finalizers:
+                                description: Must be empty before the object is deleted
+                                  from the registry. Each entry is an identifier for the
+                                  responsible component that will remove the entry from
+                                  the list. If the deletionTimestamp of the object is non-nil,
+                                  entries in this list can only be removed.
+                                items:
+                                  type: string
+                                type: array
+                              generateName:
+                                description: |-
+                                  GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+      
+                                  If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+      
+                                  Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                                type: string
+                              generation:
+                                description: A sequence number representing a specific generation
+                                  of the desired state. Populated by the system. Read-only.
+                                format: int64
+                                type: integer
+                              initializers:
+                                description: Initializers tracks the progress of initialization.
+                                properties:
+                                  pending:
+                                    description: Pending is a list of initializers that
+                                      must execute in order before this object is visible.
+                                      When the last pending initializer is removed, and
+                                      no failing result is set, the initializers struct
+                                      will be set to nil and the object is considered as
+                                      initialized and visible to all clients.
+                                    items:
+                                      description: Initializer is information about an initializer
+                                        that has not yet completed.
+                                      properties:
+                                        name:
+                                          description: name of the process that is responsible
+                                            for initializing this object.
+                                          type: string
+                                      required:
+                                      - name
+                                    type: array
+                                  result:
+                                    description: Status is a return value for calls that
+                                      don't return other objects.
+                                    properties:
+                                      apiVersion:
+                                        description: 'APIVersion defines the versioned schema
+                                          of this representation of an object. Servers should
+                                          convert recognized schemas to the latest internal
+                                          value, and may reject unrecognized values. More
+                                          info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                                        type: string
+                                      code:
+                                        description: Suggested HTTP return code for this
+                                          status, 0 if not set.
+                                        format: int32
+                                        type: integer
+                                      details:
+                                        description: StatusDetails is a set of additional
+                                          properties that MAY be set by the server to provide
+                                          additional information about a response. The Reason
+                                          field of a Status object defines what attributes
+                                          will be set. Clients must ignore fields that do
+                                          not match the defined type of each attribute,
+                                          and should assume that any attribute may be empty,
+                                          invalid, or under defined.
+                                        properties:
+                                          causes:
+                                            description: The Causes array includes more
+                                              details associated with the StatusReason failure.
+                                              Not all StatusReasons may provide detailed
+                                              causes.
+                                            items:
+                                              description: StatusCause provides more information
+                                                about an api.Status failure, including cases
+                                                when multiple errors are encountered.
+                                              properties:
+                                                field:
+                                                  description: |-
+                                                    The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+      
+                                                    Examples:
+                                                      "name" - the field "name" on the current resource
+                                                      "items[0].name" - the field "name" on the first array entry in "items"
+                                                  type: string
+                                                message:
+                                                  description: A human-readable description
+                                                    of the cause of the error.  This field
+                                                    may be presented as-is to a reader.
+                                                  type: string
+                                                reason:
+                                                  description: A machine-readable description
+                                                    of the cause of the error. If this value
+                                                    is empty there is no information available.
+                                                  type: string
+                                            type: array
+                                          group:
+                                            description: The group attribute of the resource
+                                              associated with the status StatusReason.
+                                            type: string
+                                          kind:
+                                            description: 'The kind attribute of the resource
+                                              associated with the status StatusReason. On
+                                              some operations may differ from the requested
+                                              resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                            type: string
+                                          name:
+                                            description: The name attribute of the resource
+                                              associated with the status StatusReason (when
+                                              there is a single name which can be described).
+                                            type: string
+                                          retryAfterSeconds:
+                                            description: If specified, the time in seconds
+                                              before the operation should be retried. Some
+                                              errors may indicate the client must take an
+                                              alternate action - for those errors this field
+                                              may indicate how long to wait before taking
+                                              the alternate action.
+                                            format: int32
+                                            type: integer
+                                          uid:
+                                            description: 'UID of the resource. (when there
+                                              is a single resource which can be described).
+                                              More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                            type: string
+                                      kind:
+                                        description: 'Kind is a string value representing
+                                          the REST resource this object represents. Servers
+                                          may infer this from the endpoint the client submits
+                                          requests to. Cannot be updated. In CamelCase.
+                                          More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                        type: string
+                                      message:
+                                        description: A human-readable description of the
+                                          status of this operation.
+                                        type: string
+                                      metadata:
+                                        description: ListMeta describes metadata that synthetic
+                                                       resources must have, including lists and various
+                                                       status objects. A resource may have only one of
+                                          {ObjectMeta, ListMeta}.
+                                        properties:
+                                          continue:
+                                            description: continue may be set if the user
+                                              set a limit on the number of items returned,
+                                              and indicates that the server has more data
+                                              available. The value is opaque and may be
+                                              used to issue another request to the endpoint
+                                              that served this list to retrieve the next
+                                              set of available objects. Continuing a list
+                                              may not be possible if the server configuration
+                                              has changed or more than a few minutes have
+                                              passed. The resourceVersion field returned
+                                              when using this continue value will be identical
+                                              to the value in the first response.
+                                            type: string
+                                          resourceVersion:
+                                            description: 'String that identifies the server''s
+                                              internal version of this object that can be
+                                              used by clients to determine when objects
+                                              have changed. Value must be treated as opaque
+                                              by clients and passed unmodified back to the
+                                              server. Populated by the system. Read-only.
+                                              More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                                            type: string
+                                          selfLink:
+                                            description: selfLink is a URL representing
+                                              this object. Populated by the system. Read-only.
+                                            type: string
+                                      reason:
+                                        description: A machine-readable description of why
+                                          this operation is in the "Failure" status. If
+                                          this value is empty there is no information available.
+                                          A Reason clarifies an HTTP status code but does
+                                          not override it.
+                                        type: string
+                                      status:
+                                        description: 'Status of the operation. One of: "Success"
+                                          or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                                        type: string
+                                required:
+                                - pending
+                              labels:
+                                description: 'Map of string keys and values that can be
+                                  used to organize and categorize (scope and select) objects.
+                                  May match selectors of replication controllers and services.
+                                  More info: http://kubernetes.io/docs/user-guide/labels'
+                                type: object
+                              name:
+                                description: 'Name must be unique within a namespace. Is
+                                  required when creating resources, although some resources
+                                  may allow a client to request the generation of an appropriate
+                                  name automatically. Name is primarily intended for creation
+                                  idempotence and configuration definition. Cannot be updated.
+                                  More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+      
+                                  Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                                type: string
+                              ownerReferences:
+                                description: List of objects depended by this object. If
+                                  ALL objects in the list have been deleted, this object
+                                  will be garbage collected. If this object is managed by
+                                  a controller, then an entry in this list will point to
+                                  this controller, with the controller field set to true.
+                                  There cannot be more than one managing controller.
+                                items:
+                                  description: OwnerReference contains enough information
+                                    to let you identify an owning object. Currently, an
+                                    owning object must be in the same namespace, so there
+                                    is no namespace field.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    blockOwnerDeletion:
+                                      description: If true, AND if the owner has the "foregroundDeletion"
+                                                     finalizer, then the owner cannot be deleted from
+                                                     the key-value store until this reference is removed.
+                                                     Defaults to false. To set this field, a user needs
+                                                     "delete" permission of the owner, otherwise 422
+                                                     (Unprocessable Entity) will be returned.
+                                      type: boolean
+                                    controller:
+                                      description: If true, this reference points to the
+                                        managing controller.
+                                      type: boolean
+                                    kind:
+                                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                      type: string
+                                    uid:
+                                      description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                      type: string
+                                  required:
+                                  - apiVersion
+                                  - kind
+                                  - name
+                                  - uid
+                                type: array
+                              resourceVersion:
+                                description: |-
+                                  An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+      
+                                  Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              selfLink:
+                                description: SelfLink is a URL representing this object.
+                                  Populated by the system. Read-only.
+                                type: string
+                              uid:
+                                description: |-
+                                  UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+      
+                                  Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                                type: string
+                          spec:
+                            description: PersistentVolumeClaimSpec describes the common
+                              attributes of storage devices and allows a Source for provider-specific
+                              attributes
+                            properties:
+                              accessModes:
+                                description: 'AccessModes contains the desired access modes
+                                  the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceRequirements describes the compute
+                                  resource requirements.
+                                properties:
+                                  limits:
+                                    description: 'Limits describes the maximum amount of
+                                      compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                  requests:
+                                    description: 'Requests describes the minimum amount
+                                      of compute resources required. If Requests is omitted
+                                      for a container, it defaults to Limits if that is
+                                      explicitly specified, otherwise to an implementation-defined
+                                      value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                              selector:
+                                description: A label selector is a label query over a set
+                                  of resources. The result of matchLabels and matchExpressions
+                                  are ANDed. An empty label selector matches all objects.
+                                  A null label selector matches no objects.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector
+                                      requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a selector
+                                        that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship
+                                            to a set of values. Valid operators are In,
+                                            NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string values.
+                                            If the operator is In or NotIn, the values array
+                                            must be non-empty. If the operator is Exists
+                                            or DoesNotExist, the values array must be empty.
+                                            This array is replaced during a strategic merge
+                                            patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                    type: array
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value} pairs.
+                                      A single {key,value} in the matchLabels map is equivalent
+                                      to an element of matchExpressions, whose key field
+                                      is "key", the operator is "In", and the values array
+                                      contains only "value". The requirements are ANDed.
+                                    type: object
+                              storageClassName:
+                                description: 'Name of the StorageClass required by the claim.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                type: string
+                              volumeMode:
+                                description: volumeMode defines what type of volume is required
+                                  by the claim. Value of Filesystem is implied when not
+                                  included in claim spec. This is an alpha feature and may
+                                  change in the future.
+                                type: string
+                              volumeName:
+                                description: VolumeName is the binding reference to the
+                                  PersistentVolume backing this claim.
+                                type: string
+                          status:
+                            description: PersistentVolumeClaimStatus is the current status
+                              of a persistent volume claim.
+                            properties:
+                              accessModes:
+                                description: 'AccessModes contains the actual access modes
+                                  the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                items:
+                                  type: string
+                                type: array
+                              capacity:
+                                description: Represents the actual resources of the underlying
+                                  volume.
+                                type: object
+                              conditions:
+                                description: Current Condition of persistent volume claim.
+                                  If underlying persistent volume is being resized then
+                                  the Condition will be set to 'ResizeStarted'.
+                                items:
+                                  description: PersistentVolumeClaimCondition contails details
+                                    about state of pvc
+                                  properties:
+                                    lastProbeTime:
+                                      description: Time is a wrapper around time.Time which
+                                        supports correct marshaling to YAML and JSON.  Wrappers
+                                        are provided for many of the factory methods that
+                                        the time package offers.
+                                      format: date-time
+                                      type: string
+                                    lastTransitionTime:
+                                      description: Time is a wrapper around time.Time which
+                                        supports correct marshaling to YAML and JSON.  Wrappers
+                                        are provided for many of the factory methods that
+                                        the time package offers.
+                                      format: date-time
+                                      type: string
+                                    message:
+                                      description: Human-readable message indicating details
+                                        about last transition.
+                                      type: string
+                                    reason:
+                                      description: Unique, this should be a short, machine
+                                        understandable string that gives the reason for
+                                        condition's last transition. If it reports "ResizeStarted"
+                                        that means the underlying persistent volume is being
+                                        resized.
+                                      type: string
+                                    status:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
+                                  - status
+                                type: array
+                              phase:
+                                description: Phase represents the current phase of PersistentVolumeClaim.
+                                type: string
+                  tag:
+                    description: Tag of Alertmanager container image to be deployed. Defaults
+                      to the value of `version`.
+                    type: string
+                  tolerations:
+                    description: If specified, the pod's tolerations.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any
+                        taint that matches the triple <key,value,effect> using the matching
+                        operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty
+                            means match all taint effects. When specified, allowed values
+                            are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty, operator
+                            must be Exists; this combination means to match all values and
+                            all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal. Exists
+                            is equivalent to wildcard for value, so that a pod can tolerate
+                            all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the
+                            toleration (which must be of effect NoExecute, otherwise this
+                            field is ignored) tolerates the taint. By default, it is not
+                            set, which means tolerate the taint forever (do not evict).
+                            Zero and negative values will be treated as 0 (evict immediately)
+                            by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise
+                            just a regular string.
+                          type: string
+                    type: array
+                  version:
+                    description: Version the cluster should be on.
+                    type: string
+              status:
+                description: 'Most recent observed status of the Alertmanager cluster. Read-only.
+                  Not included when requesting from the apiserver, only from the Prometheus
+                  Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+                properties:
+                  availableReplicas:
+                    description: Total number of available pods (ready for at least minReadySeconds)
+                      targeted by this Alertmanager cluster.
+                    format: int32
+                    type: integer
+                  paused:
+                    description: Represents whether any actions on the underlaying managed
+                      objects are being performed. Only delete actions will be performed.
+                    type: boolean
+                  replicas:
+                    description: Total number of non-terminated pods targeted by this Alertmanager
+                      cluster (their labels match the selector).
+                    format: int32
+                    type: integer
+                  unavailableReplicas:
+                    description: Total number of unavailable pods targeted by this Alertmanager
+                      cluster.
+                    format: int32
+                    type: integer
+                  updatedReplicas:
+                    description: Total number of non-terminated pods targeted by this Alertmanager
+                      cluster that have the desired version spec.
+                    format: int32
+                    type: integer
+                required:
+                - paused
+                - replicas
+                - updatedReplicas
+                - availableReplicas
+                - unavailableReplicas
+        version: v1
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: kafkas.kafka.strimzi.io
+        labels:
+          app: strimzi
+      spec:
+        group: kafka.strimzi.io
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          kind: Kafka
+          listKind: KafkaList
+          singular: kafka
+          plural: kafkas
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                type: object
+                properties:
+                  kafka:
+                    type: object
+                    properties:
+                      replicas:
+                        type: integer
+                        minimum: 1
+                      image:
+                        type: string
+                      storage:
+                        type: object
+                        properties:
+                          class:
+                            type: string
+                          deleteClaim:
+                            type: boolean
+                          selector:
+                            type: object
+                          size:
+                            type: string
+                          type:
+                            type: string
+                      listeners:
+                        type: object
+                        properties:
+                          plain:
+                            type: object
+                            properties: {}
+                          tls:
+                            type: object
+                            properties:
+                              authentication:
+                                type: object
+                                properties:
+                                  type:
+                                    type: string
+                      authorization:
+                        type: object
+                        properties:
+                          superUsers:
+                            type: array
+                            items:
+                              type: string
+                          type:
+                            type: string
+                      config:
+                        type: object
+                      rack:
+                        type: object
+                        properties:
+                          topologyKey:
+                            type: string
+                            example: failure-domain.beta.kubernetes.io/zone
+                        required:
+                        - topologyKey
+                      brokerRackInitImage:
+                        type: string
+                      affinity:
+                        type: object
+                        properties:
+                          nodeAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    preference:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: object
+                                properties:
+                                  nodeSelectorTerms:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                          podAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    podAffinityTerm:
+                                      type: object
+                                      properties:
+                                        labelSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              type: object
+                                        namespaces:
+                                          type: array
+                                          items:
+                                            type: string
+                                        topologyKey:
+                                          type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                          podAntiAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    podAffinityTerm:
+                                      type: object
+                                      properties:
+                                        labelSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              type: object
+                                        namespaces:
+                                          type: array
+                                          items:
+                                            type: string
+                                        topologyKey:
+                                          type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                      tolerations:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              type: integer
+                            value:
+                              type: string
+                      livenessProbe:
+                        type: object
+                        properties:
+                          initialDelaySeconds:
+                            type: integer
+                            minimum: 0
+                          timeoutSeconds:
+                            type: integer
+                            minimum: 0
+                      readinessProbe:
+                        type: object
+                        properties:
+                          initialDelaySeconds:
+                            type: integer
+                            minimum: 0
+                          timeoutSeconds:
+                            type: integer
+                            minimum: 0
+                      jvmOptions:
+                        type: object
+                        properties:
+                          -XX:
+                            type: object
+                          -Xms:
+                            type: string
+                            pattern: '[0-9]+[mMgG]?'
+                          -Xmx:
+                            type: string
+                            pattern: '[0-9]+[mMgG]?'
+                      resources:
+                        type: object
+                        properties:
+                          limits:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                                pattern: '[0-9]+m?$'
+                              memory:
+                                type: string
+                                pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                          requests:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                                pattern: '[0-9]+m?$'
+                              memory:
+                                type: string
+                                pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                      metrics:
+                        type: object
+                      logging:
+                        type: object
+                        properties:
+                          loggers:
+                            type: object
+                          name:
+                            type: string
+                          type:
+                            type: string
+                      tlsSidecar:
+                        type: object
+                        properties:
+                          image:
+                            type: string
+                          resources:
+                            type: object
+                            properties:
+                              limits:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                    pattern: '[0-9]+m?$'
+                                  memory:
+                                    type: string
+                                    pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                              requests:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                    pattern: '[0-9]+m?$'
+                                  memory:
+                                    type: string
+                                    pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                    required:
+                    - replicas
+                    - storage
+                    - listeners
+                  zookeeper:
+                    type: object
+                    properties:
+                      replicas:
+                        type: integer
+                        minimum: 1
+                      image:
+                        type: string
+                      storage:
+                        type: object
+                        properties:
+                          class:
+                            type: string
+                          deleteClaim:
+                            type: boolean
+                          selector:
+                            type: object
+                          size:
+                            type: string
+                          type:
+                            type: string
+                      config:
+                        type: object
+                      affinity:
+                        type: object
+                        properties:
+                          nodeAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    preference:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: object
+                                properties:
+                                  nodeSelectorTerms:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                          podAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    podAffinityTerm:
+                                      type: object
+                                      properties:
+                                        labelSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              type: object
+                                        namespaces:
+                                          type: array
+                                          items:
+                                            type: string
+                                        topologyKey:
+                                          type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                          podAntiAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    podAffinityTerm:
+                                      type: object
+                                      properties:
+                                        labelSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              type: object
+                                        namespaces:
+                                          type: array
+                                          items:
+                                            type: string
+                                        topologyKey:
+                                          type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                      tolerations:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              type: integer
+                            value:
+                              type: string
+                      livenessProbe:
+                        type: object
+                        properties:
+                          initialDelaySeconds:
+                            type: integer
+                            minimum: 0
+                          timeoutSeconds:
+                            type: integer
+                            minimum: 0
+                      readinessProbe:
+                        type: object
+                        properties:
+                          initialDelaySeconds:
+                            type: integer
+                            minimum: 0
+                          timeoutSeconds:
+                            type: integer
+                            minimum: 0
+                      jvmOptions:
+                        type: object
+                        properties:
+                          -XX:
+                            type: object
+                          -Xms:
+                            type: string
+                            pattern: '[0-9]+[mMgG]?'
+                          -Xmx:
+                            type: string
+                            pattern: '[0-9]+[mMgG]?'
+                      resources:
+                        type: object
+                        properties:
+                          limits:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                                pattern: '[0-9]+m?$'
+                              memory:
+                                type: string
+                                pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                          requests:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                                pattern: '[0-9]+m?$'
+                              memory:
+                                type: string
+                                pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                      metrics:
+                        type: object
+                      logging:
+                        type: object
+                        properties:
+                          loggers:
+                            type: object
+                          name:
+                            type: string
+                          type:
+                            type: string
+                      tlsSidecar:
+                        type: object
+                        properties:
+                          image:
+                            type: string
+                          resources:
+                            type: object
+                            properties:
+                              limits:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                    pattern: '[0-9]+m?$'
+                                  memory:
+                                    type: string
+                                    pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                              requests:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                    pattern: '[0-9]+m?$'
+                                  memory:
+                                    type: string
+                                    pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                    required:
+                    - replicas
+                    - storage
+                  topicOperator:
+                    type: object
+                    properties:
+                      watchedNamespace:
+                        type: string
+                      image:
+                        type: string
+                      reconciliationIntervalSeconds:
+                        type: integer
+                        minimum: 0
+                      zookeeperSessionTimeoutSeconds:
+                        type: integer
+                        minimum: 0
+                      affinity:
+                        type: object
+                        properties:
+                          nodeAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    preference:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: object
+                                properties:
+                                  nodeSelectorTerms:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                          podAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    podAffinityTerm:
+                                      type: object
+                                      properties:
+                                        labelSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              type: object
+                                        namespaces:
+                                          type: array
+                                          items:
+                                            type: string
+                                        topologyKey:
+                                          type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                          podAntiAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    podAffinityTerm:
+                                      type: object
+                                      properties:
+                                        labelSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              type: object
+                                        namespaces:
+                                          type: array
+                                          items:
+                                            type: string
+                                        topologyKey:
+                                          type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                      resources:
+                        type: object
+                        properties:
+                          limits:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                                pattern: '[0-9]+m?$'
+                              memory:
+                                type: string
+                                pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                          requests:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                                pattern: '[0-9]+m?$'
+                              memory:
+                                type: string
+                                pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                      topicMetadataMaxAttempts:
+                        type: integer
+                        minimum: 0
+                      tlsSidecar:
+                        type: object
+                        properties:
+                          image:
+                            type: string
+                          resources:
+                            type: object
+                            properties:
+                              limits:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                    pattern: '[0-9]+m?$'
+                                  memory:
+                                    type: string
+                                    pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                              requests:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                    pattern: '[0-9]+m?$'
+                                  memory:
+                                    type: string
+                                    pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                      logging:
+                        type: object
+                        properties:
+                          loggers:
+                            type: object
+                          name:
+                            type: string
+                          type:
+                            type: string
+                  entityOperator:
+                    type: object
+                    properties:
+                      topicOperator:
+                        type: object
+                        properties:
+                          watchedNamespace:
+                            type: string
+                          image:
+                            type: string
+                          reconciliationIntervalSeconds:
+                            type: integer
+                            minimum: 0
+                          zookeeperSessionTimeoutSeconds:
+                            type: integer
+                            minimum: 0
+                          resources:
+                            type: object
+                            properties:
+                              limits:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                    pattern: '[0-9]+m?$'
+                                  memory:
+                                    type: string
+                                    pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                              requests:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                    pattern: '[0-9]+m?$'
+                                  memory:
+                                    type: string
+                                    pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                          topicMetadataMaxAttempts:
+                            type: integer
+                            minimum: 0
+                          logging:
+                            type: object
+                            properties:
+                              loggers:
+                                type: object
+                              name:
+                                type: string
+                              type:
+                                type: string
+                      userOperator:
+                        type: object
+                        properties:
+                          watchedNamespace:
+                            type: string
+                          image:
+                            type: string
+                          reconciliationIntervalSeconds:
+                            type: integer
+                            minimum: 0
+                          zookeeperSessionTimeoutSeconds:
+                            type: integer
+                            minimum: 0
+                          resources:
+                            type: object
+                            properties:
+                              limits:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                    pattern: '[0-9]+m?$'
+                                  memory:
+                                    type: string
+                                    pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                              requests:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                    pattern: '[0-9]+m?$'
+                                  memory:
+                                    type: string
+                                    pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                          logging:
+                            type: object
+                            properties:
+                              loggers:
+                                type: object
+                              name:
+                                type: string
+                              type:
+                                type: string
+                      affinity:
+                        type: object
+                        properties:
+                          nodeAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    preference:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: object
+                                properties:
+                                  nodeSelectorTerms:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                          podAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    podAffinityTerm:
+                                      type: object
+                                      properties:
+                                        labelSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              type: object
+                                        namespaces:
+                                          type: array
+                                          items:
+                                            type: string
+                                        topologyKey:
+                                          type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                          podAntiAffinity:
+                            type: object
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    podAffinityTerm:
+                                      type: object
+                                      properties:
+                                        labelSelector:
+                                          type: object
+                                          properties:
+                                            matchExpressions:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                            matchLabels:
+                                              type: object
+                                        namespaces:
+                                          type: array
+                                          items:
+                                            type: string
+                                        topologyKey:
+                                          type: string
+                                    weight:
+                                      type: integer
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                      tolerations:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              type: integer
+                            value:
+                              type: string
+                      tlsSidecar:
+                        type: object
+                        properties:
+                          image:
+                            type: string
+                          resources:
+                            type: object
+                            properties:
+                              limits:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                    pattern: '[0-9]+m?$'
+                                  memory:
+                                    type: string
+                                    pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                              requests:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                    pattern: '[0-9]+m?$'
+                                  memory:
+                                    type: string
+                                    pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                required:
+                - kafka
+                - zookeeper
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: kafkaconnects.kafka.strimzi.io
+        labels:
+          app: strimzi
+      spec:
+        group: kafka.strimzi.io
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          kind: KafkaConnect
+          listKind: KafkaConnectList
+          singular: kafkaconnect
+          plural: kafkaconnects
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                type: object
+                properties:
+                  replicas:
+                    type: integer
+                  image:
+                    type: string
+                  livenessProbe:
+                    type: object
+                    properties:
+                      initialDelaySeconds:
+                        type: integer
+                        minimum: 0
+                      timeoutSeconds:
+                        type: integer
+                        minimum: 0
+                  readinessProbe:
+                    type: object
+                    properties:
+                      initialDelaySeconds:
+                        type: integer
+                        minimum: 0
+                      timeoutSeconds:
+                        type: integer
+                        minimum: 0
+                  jvmOptions:
+                    type: object
+                    properties:
+                      -XX:
+                        type: object
+                      -Xms:
+                        type: string
+                        pattern: '[0-9]+[mMgG]?'
+                      -Xmx:
+                        type: string
+                        pattern: '[0-9]+[mMgG]?'
+                  affinity:
+                    type: object
+                    properties:
+                      nodeAffinity:
+                        type: object
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                preference:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                weight:
+                                  type: integer
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            type: object
+                            properties:
+                              nodeSelectorTerms:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                      podAffinity:
+                        type: object
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                podAffinityTerm:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                                weight:
+                                  type: integer
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      type: object
+                                namespaces:
+                                  type: array
+                                  items:
+                                    type: string
+                                topologyKey:
+                                  type: string
+                      podAntiAffinity:
+                        type: object
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                podAffinityTerm:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                                weight:
+                                  type: integer
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      type: object
+                                namespaces:
+                                  type: array
+                                  items:
+                                    type: string
+                                topologyKey:
+                                  type: string
+                  tolerations:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        effect:
+                          type: string
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        tolerationSeconds:
+                          type: integer
+                        value:
+                          type: string
+                  logging:
+                    type: object
+                    properties:
+                      loggers:
+                        type: object
+                      name:
+                        type: string
+                      type:
+                        type: string
+                  metrics:
+                    type: object
+                  authentication:
+                    type: object
+                    properties:
+                      certificateAndKey:
+                        type: object
+                        properties:
+                          certificate:
+                            type: string
+                          key:
+                            type: string
+                          secretName:
+                            type: string
+                        required:
+                        - certificate
+                        - key
+                        - secretName
+                      type:
+                        type: string
+                    required:
+                    - certificateAndKey
+                  bootstrapServers:
+                    type: string
+                  config:
+                    type: object
+                  resources:
+                    type: object
+                    properties:
+                      limits:
+                        type: object
+                        properties:
+                          cpu:
+                            type: string
+                            pattern: '[0-9]+m?$'
+                          memory:
+                            type: string
+                            pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                      requests:
+                        type: object
+                        properties:
+                          cpu:
+                            type: string
+                            pattern: '[0-9]+m?$'
+                          memory:
+                            type: string
+                            pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                  tls:
+                    type: object
+                    properties:
+                      trustedCertificates:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            certificate:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                          - certificate
+                          - secretName
+                    required:
+                    - trustedCertificates
+                required:
+                - bootstrapServers
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: kafkaconnects2is.kafka.strimzi.io
+        labels:
+          app: strimzi
+      spec:
+        group: kafka.strimzi.io
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          kind: KafkaConnectS2I
+          listKind: KafkaConnectS2IList
+          singular: kafkaconnects2i
+          plural: kafkaconnects2is
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                type: object
+                properties:
+                  replicas:
+                    type: integer
+                  image:
+                    type: string
+                  livenessProbe:
+                    type: object
+                    properties:
+                      initialDelaySeconds:
+                        type: integer
+                        minimum: 0
+                      timeoutSeconds:
+                        type: integer
+                        minimum: 0
+                  readinessProbe:
+                    type: object
+                    properties:
+                      initialDelaySeconds:
+                        type: integer
+                        minimum: 0
+                      timeoutSeconds:
+                        type: integer
+                        minimum: 0
+                  jvmOptions:
+                    type: object
+                    properties:
+                      -XX:
+                        type: object
+                      -Xms:
+                        type: string
+                        pattern: '[0-9]+[mMgG]?'
+                      -Xmx:
+                        type: string
+                        pattern: '[0-9]+[mMgG]?'
+                  affinity:
+                    type: object
+                    properties:
+                      nodeAffinity:
+                        type: object
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                preference:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                weight:
+                                  type: integer
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            type: object
+                            properties:
+                              nodeSelectorTerms:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                      podAffinity:
+                        type: object
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                podAffinityTerm:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                                weight:
+                                  type: integer
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      type: object
+                                namespaces:
+                                  type: array
+                                  items:
+                                    type: string
+                                topologyKey:
+                                  type: string
+                      podAntiAffinity:
+                        type: object
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                podAffinityTerm:
+                                  type: object
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          type: object
+                                    namespaces:
+                                      type: array
+                                      items:
+                                        type: string
+                                    topologyKey:
+                                      type: string
+                                weight:
+                                  type: integer
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                labelSelector:
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      type: object
+                                namespaces:
+                                  type: array
+                                  items:
+                                    type: string
+                                topologyKey:
+                                  type: string
+                  metrics:
+                    type: object
+                  authentication:
+                    type: object
+                    properties:
+                      certificateAndKey:
+                        type: object
+                        properties:
+                          certificate:
+                            type: string
+                          key:
+                            type: string
+                          secretName:
+                            type: string
+                        required:
+                        - certificate
+                        - key
+                        - secretName
+                      type:
+                        type: string
+                    required:
+                    - certificateAndKey
+                  bootstrapServers:
+                    type: string
+                  config:
+                    type: object
+                  insecureSourceRepository:
+                    type: boolean
+                  logging:
+                    type: object
+                    properties:
+                      loggers:
+                        type: object
+                      name:
+                        type: string
+                      type:
+                        type: string
+                  resources:
+                    type: object
+                    properties:
+                      limits:
+                        type: object
+                        properties:
+                          cpu:
+                            type: string
+                            pattern: '[0-9]+m?$'
+                          memory:
+                            type: string
+                            pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                      requests:
+                        type: object
+                        properties:
+                          cpu:
+                            type: string
+                            pattern: '[0-9]+m?$'
+                          memory:
+                            type: string
+                            pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                  tls:
+                    type: object
+                    properties:
+                      trustedCertificates:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            certificate:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                          - certificate
+                          - secretName
+                    required:
+                    - trustedCertificates
+                  tolerations:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        effect:
+                          type: string
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        tolerationSeconds:
+                          type: integer
+                        value:
+                          type: string
+                required:
+                - bootstrapServers
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: kafkatopics.kafka.strimzi.io
+        labels:
+          app: strimzi
+      spec:
+        group: kafka.strimzi.io
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          kind: KafkaTopic
+          listKind: KafkaTopicList
+          singular: kafkatopic
+          plural: kafkatopics
+          shortNames:
+          - kt
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                type: object
+                properties:
+                  partitions:
+                    type: integer
+                    minimum: 1
+                  replicas:
+                    type: integer
+                    minimum: 1
+                    maximum: 32767
+                  config:
+                    type: object
+                  topicName:
+                    type: string
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: kafkausers.kafka.strimzi.io
+        labels:
+          app: strimzi
+      spec:
+        group: kafka.strimzi.io
+        version: v1alpha1
+        scope: Namespaced
+        names:
+          kind: KafkaUser
+          listKind: KafkaUserList
+          singular: kafkauser
+          plural: kafkausers
+          shortNames:
+          - ku
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                type: object
+                properties:
+                  authentication:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                  authorization:
+                    type: object
+                    properties:
+                      acls:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            host:
+                              type: string
+                            operation:
+                              type: string
+                              enum:
+                              - Read
+                              - Write
+                              - Create
+                              - Delete
+                              - Alter
+                              - Describe
+                              - ClusterAction
+                              - AlterConfigs
+                              - DescribeConfigs
+                              - IdempotentWrite
+                              - All
+                            resource:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                patternType:
+                                  type: string
+                                  enum:
+                                  - literal
+                                  - prefix
+                                type:
+                                  type: string
+                            type:
+                              type: string
+                              enum:
+                              - allow
+                              - deny
+                          required:
+                          - operation
+                          - resource
+                      type:
+                        type: string
+                    required:
+                    - acls
+                required:
+                - authentication
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: etcdbackups.etcd.database.coreos.com
+      spec:
+        group: etcd.database.coreos.com
+        version: v1beta2
+        scope: Namespaced
+        names:
+          kind: EtcdBackup
+          listKind: EtcdBackupList
+          plural: etcdbackups
+          singular: etcdbackup
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: etcdclusters.etcd.database.coreos.com
+      spec:
+        group: etcd.database.coreos.com
+        version: v1beta2
+        scope: Namespaced
+        names:
+          plural: etcdclusters
+          singular: etcdcluster
+          kind: EtcdCluster
+          listKind: EtcdClusterList
+          shortNames:
+            - etcdclus
+            - etcd
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: etcdrestores.etcd.database.coreos.com
+      spec:
+        group: etcd.database.coreos.com
+        version: v1beta2
+        scope: Namespaced
+        names:
+          kind: EtcdRestore
+          listKind: EtcdRestoreList
+          plural: etcdrestores
+          singular: etcdrestore
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: prometheuses.monitoring.coreos.com
+      spec:
+        group: monitoring.coreos.com
+        names:
+          kind: Prometheus
+          plural: prometheuses
+        scope: Namespaced
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                description: 'Specification of the desired behavior of the Prometheus cluster.
+                  More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+                properties:
+                  additionalAlertManagerConfigs:
+                    description: SecretKeySelector selects a key of a Secret.
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be a valid
+                          secret key.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or it's key must be defined
+                        type: boolean
+                    required:
+                    - key
+                  additionalScrapeConfigs:
+                    description: SecretKeySelector selects a key of a Secret.
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be a valid
+                          secret key.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or it's key must be defined
+                        type: boolean
+                    required:
+                    - key
+                  affinity:
+                    description: Affinity is a group of affinity scheduling rules.
+                    properties:
+                      nodeAffinity:
+                        description: Node affinity is a group of node affinity scheduling
+                          rules.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes
+                              that satisfy the affinity expressions specified by this field,
+                              but it may choose a node that violates one or more of the
+                              expressions. The node that is most preferred is the one with
+                              the greatest sum of weights, i.e. for each node that meets
+                              all of the scheduling requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating through
+                              the elements of this field and adding "weight" to the sum
+                              if the node matches the corresponding matchExpressions; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all
+                                objects with implicit weight 0 (i.e. it's a no-op). A null
+                                preferred scheduling term matches no objects (i.e. is also
+                                a no-op).
+                              properties:
+                                preference:
+                                  description: A null or empty node selector term matches
+                                    no objects. The requirements of them are ANDed. The
+                                    TopologySelectorTerm type implements a subset of the
+                                    NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the
+                                              operator is In or NotIn, the values array
+                                              must be non-empty. If the operator is Exists
+                                              or DoesNotExist, the values array must be
+                                              empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will
+                                              be interpreted as an integer. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the
+                                              operator is In or NotIn, the values array
+                                              must be non-empty. If the operator is Exists
+                                              or DoesNotExist, the values array must be
+                                              empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will
+                                              be interpreted as an integer. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                weight:
+                                  description: Weight associated with matching the corresponding
+                                    nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - preference
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: A node selector represents the union of the results
+                              of one or more label queries over a set of nodes; that is,
+                              it represents the OR of the selectors represented by the node
+                              selector terms.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The
+                                  terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches
+                                    no objects. The requirements of them are ANDed. The
+                                    TopologySelectorTerm type implements a subset of the
+                                    NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the
+                                              operator is In or NotIn, the values array
+                                              must be non-empty. If the operator is Exists
+                                              or DoesNotExist, the values array must be
+                                              empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will
+                                              be interpreted as an integer. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the
+                                              operator is In or NotIn, the values array
+                                              must be non-empty. If the operator is Exists
+                                              or DoesNotExist, the values array must be
+                                              empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will
+                                              be interpreted as an integer. This array is
+                                              replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                      podAffinity:
+                        description: Pod affinity is a group of inter pod affinity scheduling
+                          rules.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes
+                              that satisfy the affinity expressions specified by this field,
+                              but it may choose a node that violates one or more of the
+                              expressions. The node that is most preferred is the one with
+                              the greatest sum of weights, i.e. for each node that meets
+                              all of the scheduling requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating through
+                              the elements of this field and adding "weight" to the sum
+                              if the node has pods which matches the corresponding podAffinityTerm;
+                              the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Defines a set of pods (namely those matching
+                                    the labelSelector relative to the given namespace(s))
+                                    that this pod should be co-located (affinity) or not
+                                    co-located (anti-affinity) with, where co-located is
+                                    defined as running on a node whose value of the label
+                                    with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label selector is a label query over
+                                        a set of resources. The result of matchLabels and
+                                        matchExpressions are ANDed. An empty label selector
+                                        matches all objects. A null label selector matches
+                                        no objects.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label
+                                            selector requirements. The requirements are
+                                            ANDed.
+                                          items:
+                                            description: A label selector requirement is
+                                              a selector that contains values, a key, and
+                                              an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If
+                                                  the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array
+                                                  is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                          type: array
+                                        matchLabels:
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is "In",
+                                            and the values array contains only "value".
+                                            The requirements are ANDed.
+                                          type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified namespaces,
+                                        where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches
+                                        that of any node on which any of the selected pods
+                                        is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                weight:
+                                  description: weight associated with matching the corresponding
+                                    podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - podAffinityTerm
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this
+                              field are not met at scheduling time, the pod will not be
+                              scheduled onto the node. If the affinity requirements specified
+                              by this field cease to be met at some point during pod execution
+                              (e.g. due to a pod label update), the system may or may not
+                              try to eventually evict the pod from its node. When there
+                              are multiple elements, the lists of nodes corresponding to
+                              each podAffinityTerm are intersected, i.e. all terms must
+                              be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s)) that
+                                this pod should be co-located (affinity) or not co-located
+                                (anti-affinity) with, where co-located is defined as running
+                                on a node whose value of the label with key <topologyKey>
+                                matches that of any node on which a pod of the set of pods
+                                is running
+                              properties:
+                                labelSelector:
+                                  description: A label selector is a label query over a
+                                    set of resources. The result of matchLabels and matchExpressions
+                                    are ANDed. An empty label selector matches all objects.
+                                    A null label selector matches no objects.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector
+                                        requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator is
+                                              Exists or DoesNotExist, the values array must
+                                              be empty. This array is replaced during a
+                                              strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                    matchLabels:
+                                      description: matchLabels is a map of {key,value} pairs.
+                                        A single {key,value} in the matchLabels map is equivalent
+                                        to an element of matchExpressions, whose key field
+                                        is "key", the operator is "In", and the values array
+                                        contains only "value". The requirements are ANDed.
+                                      type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the
+                                    labelSelector applies to (matches against); null or
+                                    empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where
+                                    co-located is defined as running on a node whose value
+                                    of the label with key topologyKey matches that of any
+                                    node on which any of the selected pods is running. Empty
+                                    topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                            type: array
+                      podAntiAffinity:
+                        description: Pod anti affinity is a group of inter pod anti affinity
+                          scheduling rules.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes
+                              that satisfy the anti-affinity expressions specified by this
+                              field, but it may choose a node that violates one or more
+                              of the expressions. The node that is most preferred is the
+                              one with the greatest sum of weights, i.e. for each node that
+                              meets all of the scheduling requirements (resource request,
+                              requiredDuringScheduling anti-affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field
+                              and adding "weight" to the sum if the node has pods which
+                              matches the corresponding podAffinityTerm; the node(s) with
+                              the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Defines a set of pods (namely those matching
+                                    the labelSelector relative to the given namespace(s))
+                                    that this pod should be co-located (affinity) or not
+                                    co-located (anti-affinity) with, where co-located is
+                                    defined as running on a node whose value of the label
+                                    with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label selector is a label query over
+                                        a set of resources. The result of matchLabels and
+                                        matchExpressions are ANDed. An empty label selector
+                                        matches all objects. A null label selector matches
+                                        no objects.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label
+                                            selector requirements. The requirements are
+                                            ANDed.
+                                          items:
+                                            description: A label selector requirement is
+                                              a selector that contains values, a key, and
+                                              an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If
+                                                  the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array
+                                                  is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                          type: array
+                                        matchLabels:
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is "In",
+                                            and the values array contains only "value".
+                                            The requirements are ANDed.
+                                          type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified namespaces,
+                                        where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches
+                                        that of any node on which any of the selected pods
+                                        is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                weight:
+                                  description: weight associated with matching the corresponding
+                                    podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - podAffinityTerm
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by
+                              this field are not met at scheduling time, the pod will not
+                              be scheduled onto the node. If the anti-affinity requirements
+                              specified by this field cease to be met at some point during
+                              pod execution (e.g. due to a pod label update), the system
+                              may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding
+                              to each podAffinityTerm are intersected, i.e. all terms must
+                              be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s)) that
+                                this pod should be co-located (affinity) or not co-located
+                                (anti-affinity) with, where co-located is defined as running
+                                on a node whose value of the label with key <topologyKey>
+                                matches that of any node on which a pod of the set of pods
+                                is running
+                              properties:
+                                labelSelector:
+                                  description: A label selector is a label query over a
+                                    set of resources. The result of matchLabels and matchExpressions
+                                    are ANDed. An empty label selector matches all objects.
+                                    A null label selector matches no objects.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector
+                                        requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector
+                                          that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship
+                                              to a set of values. Valid operators are In,
+                                              NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator is
+                                              Exists or DoesNotExist, the values array must
+                                              be empty. This array is replaced during a
+                                              strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                      type: array
+                                    matchLabels:
+                                      description: matchLabels is a map of {key,value} pairs.
+                                        A single {key,value} in the matchLabels map is equivalent
+                                        to an element of matchExpressions, whose key field
+                                        is "key", the operator is "In", and the values array
+                                        contains only "value". The requirements are ANDed.
+                                      type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces the
+                                    labelSelector applies to (matches against); null or
+                                    empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where
+                                    co-located is defined as running on a node whose value
+                                    of the label with key topologyKey matches that of any
+                                    node on which any of the selected pods is running. Empty
+                                    topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                            type: array
+                  alerting:
+                    description: AlertingSpec defines parameters for alerting configuration
+                      of Prometheus servers.
+                    properties:
+                      alertmanagers:
+                        description: AlertmanagerEndpoints Prometheus should fire alerts
+                          against.
+                        items:
+                          description: AlertmanagerEndpoints defines a selection of a single
+                            Endpoints object containing alertmanager IPs to fire alerts
+                            against.
+                          properties:
+                            bearerTokenFile:
+                              description: BearerTokenFile to read from filesystem to use
+                                when authenticating to Alertmanager.
+                              type: string
+                            name:
+                              description: Name of Endpoints object in Namespace.
+                              type: string
+                            namespace:
+                              description: Namespace of Endpoints object.
+                              type: string
+                            pathPrefix:
+                              description: Prefix for the HTTP path alerts are pushed to.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: string
+                              - type: integer
+                            scheme:
+                              description: Scheme to use when firing alerts.
+                              type: string
+                            tlsConfig:
+                              description: TLSConfig specifies TLS configuration parameters.
+                              properties:
+                                caFile:
+                                  description: The CA cert to use for the targets.
+                                  type: string
+                                certFile:
+                                  description: The client cert file for the targets.
+                                  type: string
+                                insecureSkipVerify:
+                                  description: Disable target certificate validation.
+                                  type: boolean
+                                keyFile:
+                                  description: The client key file for the targets.
+                                  type: string
+                                serverName:
+                                  description: Used to verify the hostname for the targets.
+                                  type: string
+                          required:
+                          - namespace
+                          - name
+                          - port
+                        type: array
+                    required:
+                    - alertmanagers
+                  baseImage:
+                    description: Base image to use for a Prometheus deployment.
+                    type: string
+                  containers:
+                    description: Containers allows injecting additional containers. This
+                      is meant to allow adding an authentication proxy to a Prometheus pod.
+                    items:
+                      description: A single application container that you want to run within
+                        a pod.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The docker image''s
+                            CMD is used if this is not provided. Variable references $(VAR_NAME)
+                            are expanded using the container''s environment. If a variable
+                            cannot be resolved, the reference in the input string will be
+                            unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                            $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot be
+                            updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell. The
+                            docker image''s ENTRYPOINT is used if this is not provided.
+                            Variable references $(VAR_NAME) are expanded using the container''s
+                            environment. If a variable cannot be resolved, the reference
+                            in the input string will be unchanged. The $(VAR_NAME) syntax
+                            can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable exists
+                            or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the container.
+                            Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable present
+                              in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must be a
+                                  C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are expanded
+                                  using the previous defined environment variables in the
+                                  container and any service environment variables. If a
+                                  variable cannot be resolved, the reference in the input
+                                  string will be unchanged. The $(VAR_NAME) syntax can be
+                                  escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                                  will never be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
+                                type: string
+                              valueFrom:
+                                description: EnvVarSource represents a source for the value
+                                  of an EnvVar.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key from a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or it's
+                                          key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                  fieldRef:
+                                    description: ObjectFieldSelector selects an APIVersioned
+                                      field of an object.
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in the
+                                          specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                  resourceFieldRef:
+                                    description: ResourceFieldSelector represents container
+                                      resources (cpu, memory) and their output format
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for volumes,
+                                          optional for env vars'
+                                        type: string
+                                      divisor: {}
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                  secretKeyRef:
+                                    description: SecretKeySelector selects a key of a Secret.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must
+                                          be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or it's
+                                          key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                            required:
+                            - name
+                          type: array
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must be a
+                            C_IDENTIFIER. All invalid keys will be reported as an event
+                            when the container is starting. When a key exists in multiple
+                            sources, the value associated with the last source will take
+                            precedence. Values defined by an Env with a duplicate key will
+                            take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a set of
+                              ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: |-
+                                  ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+                                  The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must be defined
+                                    type: boolean
+                              prefix:
+                                description: An optional identifier to prepend to each key
+                                  in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: |-
+                                  SecretEnvSource selects a Secret to populate the environment variables with.
+                                  The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be defined
+                                    type: boolean
+                          type: array
+                        image:
+                          description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management
+                            to default or override container images in workload controllers
+                            like Deployments and StatefulSets.'
+                          type: string
+                        imagePullPolicy:
+                          description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                            Defaults to Always if :latest tag is specified, or IfNotPresent
+                            otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                          type: string
+                        lifecycle:
+                          description: Lifecycle describes actions that the management system
+                            should take in response to container lifecycle events. For the
+                            PostStart and PreStop lifecycle handlers, management of the
+                            container blocks until the action is complete, unless the container
+                            process fails, in which case the handler is aborted.
+                          properties:
+                            postStart:
+                              description: Handler defines a specific action that should
+                                be taken
+                              properties:
+                                exec:
+                                  description: ExecAction describes a "run in container"
+                                    action.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to execute
+                                        inside the container, the working directory for
+                                        the command  is root ('/') in the container's filesystem.
+                                        The command is simply exec'd, it is not run inside
+                                        a shell, so traditional shell instructions ('|',
+                                        etc) won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is treated
+                                        as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                httpGet:
+                                  description: HTTPGetAction describes an action based on
+                                    HTTP Get requests.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults to
+                                        the pod IP. You probably want to set "Host" in httpHeaders
+                                        instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom header
+                                          to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                    scheme:
+                                      description: Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                tcpSocket:
+                                  description: TCPSocketAction describes an action based
+                                    on opening a socket
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect to, defaults
+                                        to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                  required:
+                                  - port
+                            preStop:
+                              description: Handler defines a specific action that should
+                                be taken
+                              properties:
+                                exec:
+                                  description: ExecAction describes a "run in container"
+                                    action.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to execute
+                                        inside the container, the working directory for
+                                        the command  is root ('/') in the container's filesystem.
+                                        The command is simply exec'd, it is not run inside
+                                        a shell, so traditional shell instructions ('|',
+                                        etc) won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is treated
+                                        as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                httpGet:
+                                  description: HTTPGetAction describes an action based on
+                                    HTTP Get requests.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults to
+                                        the pod IP. You probably want to set "Host" in httpHeaders
+                                        instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom header
+                                          to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                    scheme:
+                                      description: Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                tcpSocket:
+                                  description: TCPSocketAction describes an action based
+                                    on opening a socket
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect to, defaults
+                                        to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                  required:
+                                  - port
+                        livenessProbe:
+                          description: Probe describes a health check to be performed against
+                            a container to determine whether it is alive or ready to receive
+                            traffic.
+                          properties:
+                            exec:
+                              description: ExecAction describes a "run in container" action.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute inside
+                                    the container, the working directory for the command  is
+                                    root ('/') in the container's filesystem. The command
+                                    is simply exec'd, it is not run inside a shell, so traditional
+                                    shell instructions ('|', etc) won't work. To use a shell,
+                                    you need to explicitly call out to that shell. Exit
+                                    status of 0 is treated as live/healthy and non-zero
+                                    is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe to
+                                be considered failed after having succeeded. Defaults to
+                                3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGetAction describes an action based on HTTP
+                                Get requests.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to the
+                                    pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request. HTTP
+                                    allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header to
+                                      be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: string
+                                  - type: integer
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has started
+                                before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe to
+                                be considered successful after having failed. Defaults to
+                                1. Must be 1 for liveness. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocketAction describes an action based on
+                                opening a socket
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: string
+                                  - type: integer
+                              required:
+                              - port
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe times
+                                out. Defaults to 1 second. Minimum value is 1. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                        name:
+                          description: Name of the container specified as a DNS_LABEL. Each
+                            container in a pod must have a unique name (DNS_LABEL). Cannot
+                            be updated.
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container. Exposing
+                            a port here gives the system additional information about the
+                            network connections a container uses, but is primarily informational.
+                            Not specifying a port here DOES NOT prevent that port from being
+                            exposed. Any port which is listening on the default "0.0.0.0"
+                            address inside a container will be accessible from the network.
+                            Cannot be updated.
+                          items:
+                            description: ContainerPort represents a network port in a single
+                              container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's IP address.
+                                  This must be a valid port number, 0 < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host. If specified,
+                                  this must be a valid port number, 0 < x < 65536. If HostNetwork
+                                  is specified, this must match ContainerPort. Most containers
+                                  do not need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a pod must
+                                  have a unique name. Name for the port that can be referred
+                                  to by services.
+                                type: string
+                              protocol:
+                                description: Protocol for port. Must be UDP or TCP. Defaults
+                                  to "TCP".
+                                type: string
+                            required:
+                            - containerPort
+                          type: array
+                        readinessProbe:
+                          description: Probe describes a health check to be performed against
+                            a container to determine whether it is alive or ready to receive
+                            traffic.
+                          properties:
+                            exec:
+                              description: ExecAction describes a "run in container" action.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute inside
+                                    the container, the working directory for the command  is
+                                    root ('/') in the container's filesystem. The command
+                                    is simply exec'd, it is not run inside a shell, so traditional
+                                    shell instructions ('|', etc) won't work. To use a shell,
+                                    you need to explicitly call out to that shell. Exit
+                                    status of 0 is treated as live/healthy and non-zero
+                                    is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe to
+                                be considered failed after having succeeded. Defaults to
+                                3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGetAction describes an action based on HTTP
+                                Get requests.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to the
+                                    pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request. HTTP
+                                    allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header to
+                                      be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: string
+                                  - type: integer
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has started
+                                before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe to
+                                be considered successful after having failed. Defaults to
+                                1. Must be 1 for liveness. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocketAction describes an action based on
+                                opening a socket
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: string
+                                  - type: integer
+                              required:
+                              - port
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe times
+                                out. Defaults to 1 second. Minimum value is 1. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                        resources:
+                          description: ResourceRequirements describes the compute resource
+                            requirements.
+                          properties:
+                            limits:
+                              description: 'Limits describes the maximum amount of compute
+                                resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              description: 'Requests describes the minimum amount of compute
+                                resources required. If Requests is omitted for a container,
+                                it defaults to Limits if that is explicitly specified, otherwise
+                                to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                        securityContext:
+                          description: SecurityContext holds security configuration that
+                            will be applied to a container. Some fields are present in both
+                            SecurityContext and PodSecurityContext.  When both are set,
+                            the values in SecurityContext take precedence.
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether a
+                                process can gain more privileges than its parent process.
+                                This bool directly controls if the no_new_privs flag will
+                                be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN'
+                              type: boolean
+                            capabilities:
+                              description: Adds and removes POSIX capabilities from running
+                                containers.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                            privileged:
+                              description: Run container in privileged mode. Processes in
+                                privileged containers are essentially equivalent to root
+                                on the host. Defaults to false.
+                              type: boolean
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only root filesystem.
+                                Default is false.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be set
+                                in PodSecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as a non-root
+                                user. If true, the Kubelet will validate the image at runtime
+                                to ensure that it does not run as UID 0 (root) and fail
+                                to start the container if it does. If unset or false, no
+                                such validation will be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext, the
+                                value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata if
+                                unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext, the
+                                value specified in SecurityContext takes precedence.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: SELinuxOptions are the labels to be applied to
+                                the container
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                        stdin:
+                          description: Whether this container should allocate a buffer for
+                            stdin in the container runtime. If this is not set, reads from
+                            stdin in the container will always result in EOF. Default is
+                            false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close the stdin
+                            channel after it has been opened by a single attach. When stdin
+                            is true the stdin stream will remain open across multiple attach
+                            sessions. If stdinOnce is set to true, stdin is opened on container
+                            start, is empty until the first client attaches to stdin, and
+                            then remains open and accepts data until the client disconnects,
+                            at which time stdin is closed and remains closed until the container
+                            is restarted. If this flag is false, a container processes that
+                            reads from stdin will never receive an EOF. Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which the container''s
+                            termination message will be written is mounted into the container''s
+                            filesystem. Message written is intended to be brief final status,
+                            such as an assertion failure message. Will be truncated by the
+                            node if greater than 4096 bytes. The total message length across
+                            all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: Indicate how the termination message should be populated.
+                            File will use the contents of terminationMessagePath to populate
+                            the container status message on both success and failure. FallbackToLogsOnError
+                            will use the last chunk of container log output if the termination
+                            message file is empty and the container exited with an error.
+                            The log output is limited to 2048 bytes or 80 lines, whichever
+                            is smaller. Defaults to File. Cannot be updated.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY for
+                            itself, also requires 'stdin' to be true. Default is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices to be
+                            used by the container. This is an alpha feature and may change
+                            in the future.
+                          items:
+                            description: volumeDevice describes a mapping of a raw block
+                              device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the container
+                                  that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - name
+                            - devicePath
+                          type: array
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume within
+                              a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the volume
+                                  should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts are
+                                  propagated from the host to container and the other way
+                                  around. When not set, MountPropagationHostToContainer
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write otherwise
+                                  (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the container's
+                                  volume should be mounted. Defaults to "" (volume's root).
+                                type: string
+                            required:
+                            - name
+                            - mountPath
+                          type: array
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might be
+                            configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                    type: array
+                  evaluationInterval:
+                    description: Interval between consecutive evaluations.
+                    type: string
+                  externalLabels:
+                    description: The labels to add to any time series or alerts when communicating
+                      with external systems (federation, remote storage, Alertmanager).
+                    type: object
+                  externalUrl:
+                    description: The external URL the Prometheus instances will be available
+                      under. This is necessary to generate correct URLs. This is necessary
+                      if Prometheus is not served from root of a DNS name.
+                    type: string
+                  imagePullSecrets:
+                    description: An optional list of references to secrets in the same namespace
+                      to use for pulling prometheus and alertmanager images from registries
+                      see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
+                    items:
+                      description: LocalObjectReference contains enough information to let
+                        you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                    type: array
+                  listenLocal:
+                    description: ListenLocal makes the Prometheus server listen on loopback,
+                      so that it does not bind against the Pod IP.
+                    type: boolean
+                  logLevel:
+                    description: Log level for Prometheus to be configured with.
+                    type: string
+                  nodeSelector:
+                    description: Define which Nodes the Pods are scheduled on.
+                    type: object
+                  paused:
+                    description: When a Prometheus deployment is paused, no actions except
+                      for deletion will be performed on the underlying objects.
+                    type: boolean
+                  podMetadata:
+                    description: ObjectMeta is metadata that all persisted resources must
+                      have, which includes all objects users must create.
+                    properties:
+                      annotations:
+                        description: 'Annotations is an unstructured key value map stored
+                          with a resource that may be set by external tools to store and
+                          retrieve arbitrary metadata. They are not queryable and should
+                          be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      clusterName:
+                        description: The name of the cluster which the object belongs to.
+                          This is used to distinguish resources with same name and namespace
+                          in different clusters. This field is not set anywhere right now
+                          and apiserver is going to ignore it if set in create or update
+                          request.
+                        type: string
+                      creationTimestamp:
+                        description: Time is a wrapper around time.Time which supports correct
+                          marshaling to YAML and JSON.  Wrappers are provided for many of
+                          the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                      deletionGracePeriodSeconds:
+                        description: Number of seconds allowed for this object to gracefully
+                          terminate before it will be removed from the system. Only set
+                          when deletionTimestamp is also set. May only be shortened. Read-only.
+                        format: int64
+                        type: integer
+                      deletionTimestamp:
+                        description: Time is a wrapper around time.Time which supports correct
+                          marshaling to YAML and JSON.  Wrappers are provided for many of
+                          the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                      finalizers:
+                        description: Must be empty before the object is deleted from the
+                          registry. Each entry is an identifier for the responsible component
+                          that will remove the entry from the list. If the deletionTimestamp
+                          of the object is non-nil, entries in this list can only be removed.
+                        items:
+                          type: string
+                        type: array
+                      generateName:
+                        description: |-
+                          GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+                          If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+                          Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                        type: string
+                      generation:
+                        description: A sequence number representing a specific generation
+                          of the desired state. Populated by the system. Read-only.
+                        format: int64
+                        type: integer
+                      initializers:
+                        description: Initializers tracks the progress of initialization.
+                        properties:
+                          pending:
+                            description: Pending is a list of initializers that must execute
+                              in order before this object is visible. When the last pending
+                              initializer is removed, and no failing result is set, the
+                              initializers struct will be set to nil and the object is considered
+                              as initialized and visible to all clients.
+                            items:
+                              description: Initializer is information about an initializer
+                                that has not yet completed.
+                              properties:
+                                name:
+                                  description: name of the process that is responsible for
+                                    initializing this object.
+                                  type: string
+                              required:
+                              - name
+                            type: array
+                          result:
+                            description: Status is a return value for calls that don't return
+                              other objects.
+                            properties:
+                              apiVersion:
+                                description: 'APIVersion defines the versioned schema of
+                                  this representation of an object. Servers should convert
+                                  recognized schemas to the latest internal value, and may
+                                  reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                                type: string
+                              code:
+                                description: Suggested HTTP return code for this status,
+                                  0 if not set.
+                                format: int32
+                                type: integer
+                              details:
+                                description: StatusDetails is a set of additional properties
+                                  that MAY be set by the server to provide additional information
+                                  about a response. The Reason field of a Status object
+                                  defines what attributes will be set. Clients must ignore
+                                  fields that do not match the defined type of each attribute,
+                                  and should assume that any attribute may be empty, invalid,
+                                  or under defined.
+                                properties:
+                                  causes:
+                                    description: The Causes array includes more details
+                                      associated with the StatusReason failure. Not all
+                                      StatusReasons may provide detailed causes.
+                                    items:
+                                      description: StatusCause provides more information
+                                        about an api.Status failure, including cases when
+                                        multiple errors are encountered.
+                                      properties:
+                                        field:
+                                          description: |-
+                                            The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+                                            Examples:
+                                              "name" - the field "name" on the current resource
+                                              "items[0].name" - the field "name" on the first array entry in "items"
+                                          type: string
+                                        message:
+                                          description: A human-readable description of the
+                                            cause of the error.  This field may be presented
+                                            as-is to a reader.
+                                          type: string
+                                        reason:
+                                          description: A machine-readable description of
+                                            the cause of the error. If this value is empty
+                                            there is no information available.
+                                          type: string
+                                    type: array
+                                  group:
+                                    description: The group attribute of the resource associated
+                                      with the status StatusReason.
+                                    type: string
+                                  kind:
+                                    description: 'The kind attribute of the resource associated
+                                      with the status StatusReason. On some operations may
+                                      differ from the requested resource Kind. More info:
+                                      https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                    type: string
+                                  name:
+                                    description: The name attribute of the resource associated
+                                      with the status StatusReason (when there is a single
+                                      name which can be described).
+                                    type: string
+                                  retryAfterSeconds:
+                                    description: If specified, the time in seconds before
+                                      the operation should be retried. Some errors may indicate
+                                      the client must take an alternate action - for those
+                                      errors this field may indicate how long to wait before
+                                      taking the alternate action.
+                                    format: int32
+                                    type: integer
+                                  uid:
+                                    description: 'UID of the resource. (when there is a
+                                      single resource which can be described). More info:
+                                      http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                    type: string
+                              kind:
+                                description: 'Kind is a string value representing the REST
+                                  resource this object represents. Servers may infer this
+                                  from the endpoint the client submits requests to. Cannot
+                                  be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                type: string
+                              message:
+                                description: A human-readable description of the status
+                                  of this operation.
+                                type: string
+                              metadata:
+                                description: ListMeta describes metadata that synthetic
+                                  resources must have, including lists and various status
+                                  objects. A resource may have only one of {ObjectMeta,
+                                  ListMeta}.
+                                properties:
+                                  continue:
+                                    description: continue may be set if the user set a limit
+                                      on the number of items returned, and indicates that
+                                      the server has more data available. The value is opaque
+                                      and may be used to issue another request to the endpoint
+                                      that served this list to retrieve the next set of
+                                      available objects. Continuing a list may not be possible
+                                      if the server configuration has changed or more than
+                                      a few minutes have passed. The resourceVersion field
+                                      returned when using this continue value will be identical
+                                      to the value in the first response.
+                                    type: string
+                                  resourceVersion:
+                                    description: 'String that identifies the server''s internal
+                                      version of this object that can be used by clients
+                                      to determine when objects have changed. Value must
+                                      be treated as opaque by clients and passed unmodified
+                                      back to the server. Populated by the system. Read-only.
+                                      More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                                    type: string
+                                  selfLink:
+                                    description: selfLink is a URL representing this object.
+                                      Populated by the system. Read-only.
+                                    type: string
+                              reason:
+                                description: A machine-readable description of why this
+                                  operation is in the "Failure" status. If this value is
+                                  empty there is no information available. A Reason clarifies
+                                  an HTTP status code but does not override it.
+                                type: string
+                              status:
+                                description: 'Status of the operation. One of: "Success"
+                                  or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                                type: string
+                        required:
+                        - pending
+                      labels:
+                        description: 'Map of string keys and values that can be used to
+                          organize and categorize (scope and select) objects. May match
+                          selectors of replication controllers and services. More info:
+                          http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                      name:
+                        description: 'Name must be unique within a namespace. Is required
+                          when creating resources, although some resources may allow a client
+                          to request the generation of an appropriate name automatically.
+                          Name is primarily intended for creation idempotence and configuration
+                          definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+                          Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                        type: string
+                      ownerReferences:
+                        description: List of objects depended by this object. If ALL objects
+                          in the list have been deleted, this object will be garbage collected.
+                          If this object is managed by a controller, then an entry in this
+                          list will point to this controller, with the controller field
+                          set to true. There cannot be more than one managing controller.
+                        items:
+                          description: OwnerReference contains enough information to let
+                            you identify an owning object. Currently, an owning object must
+                            be in the same namespace, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: If true, AND if the owner has the "foregroundDeletion"
+                                finalizer, then the owner cannot be deleted from the key-value
+                                store until this reference is removed. Defaults to false.
+                                To set this field, a user needs "delete" permission of the
+                                owner, otherwise 422 (Unprocessable Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing
+                                controller.
+                              type: boolean
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                        type: array
+                      resourceVersion:
+                        description: |-
+                          An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+                          Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      selfLink:
+                        description: SelfLink is a URL representing this object. Populated
+                          by the system. Read-only.
+                        type: string
+                      uid:
+                        description: |-
+                          UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+                          Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                        type: string
+                  remoteRead:
+                    description: If specified, the remote_read spec. This is an experimental
+                      feature, it may change in any upcoming release in a breaking way.
+                    items:
+                      description: RemoteReadSpec defines the remote_read configuration
+                        for prometheus.
+                      properties:
+                        basicAuth:
+                          description: 'BasicAuth allow an endpoint to authenticate over
+                            basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                          properties:
+                            password:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or it's key must
+                                    be defined
+                                  type: boolean
+                              required:
+                              - key
+                            username:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or it's key must
+                                    be defined
+                                  type: boolean
+                              required:
+                              - key
+                        bearerToken:
+                          description: bearer token for remote read.
+                          type: string
+                        bearerTokenFile:
+                          description: File to read bearer token for remote read.
+                          type: string
+                        proxyUrl:
+                          description: Optional ProxyURL
+                          type: string
+                        readRecent:
+                          description: Whether reads should be made for queries for time
+                            ranges that the local storage should have complete data for.
+                          type: boolean
+                        remoteTimeout:
+                          description: Timeout for requests to the remote read endpoint.
+                          type: string
+                        requiredMatchers:
+                          description: An optional list of equality matchers which have
+                            to be present in a selector to query the remote read endpoint.
+                          type: object
+                        tlsConfig:
+                          description: TLSConfig specifies TLS configuration parameters.
+                          properties:
+                            caFile:
+                              description: The CA cert to use for the targets.
+                              type: string
+                            certFile:
+                              description: The client cert file for the targets.
+                              type: string
+                            insecureSkipVerify:
+                              description: Disable target certificate validation.
+                              type: boolean
+                            keyFile:
+                              description: The client key file for the targets.
+                              type: string
+                            serverName:
+                              description: Used to verify the hostname for the targets.
+                              type: string
+                        url:
+                          description: The URL of the endpoint to send samples to.
+                          type: string
+                      required:
+                      - url
+                    type: array
+                  remoteWrite:
+                    description: If specified, the remote_write spec. This is an experimental
+                      feature, it may change in any upcoming release in a breaking way.
+                    items:
+                      description: RemoteWriteSpec defines the remote_write configuration
+                        for prometheus.
+                      properties:
+                        basicAuth:
+                          description: 'BasicAuth allow an endpoint to authenticate over
+                            basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                          properties:
+                            password:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or it's key must
+                                    be defined
+                                  type: boolean
+                              required:
+                              - key
+                            username:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or it's key must
+                                    be defined
+                                  type: boolean
+                              required:
+                              - key
+                        bearerToken:
+                          description: File to read bearer token for remote write.
+                          type: string
+                        bearerTokenFile:
+                          description: File to read bearer token for remote write.
+                          type: string
+                        proxyUrl:
+                          description: Optional ProxyURL
+                          type: string
+                        queueConfig:
+                          description: QueueConfig allows the tuning of remote_write queue_config
+                            parameters. This object is referenced in the RemoteWriteSpec
+                            object.
+                          properties:
+                            batchSendDeadline:
+                              description: BatchSendDeadline is the maximum time a sample
+                                will wait in buffer.
+                              type: string
+                            capacity:
+                              description: Capacity is the number of samples to buffer per
+                                shard before we start dropping them.
+                              format: int32
+                              type: integer
+                            maxBackoff:
+                              description: MaxBackoff is the maximum retry delay.
+                              type: string
+                            maxRetries:
+                              description: MaxRetries is the maximum number of times to
+                                retry a batch on recoverable errors.
+                              format: int32
+                              type: integer
+                            maxSamplesPerSend:
+                              description: MaxSamplesPerSend is the maximum number of samples
+                                per send.
+                              format: int32
+                              type: integer
+                            maxShards:
+                              description: MaxShards is the maximum number of shards, i.e.
+                                amount of concurrency.
+                              format: int32
+                              type: integer
+                            minBackoff:
+                              description: MinBackoff is the initial retry delay. Gets doubled
+                                for every retry.
+                              type: string
+                        remoteTimeout:
+                          description: Timeout for requests to the remote write endpoint.
+                          type: string
+                        tlsConfig:
+                          description: TLSConfig specifies TLS configuration parameters.
+                          properties:
+                            caFile:
+                              description: The CA cert to use for the targets.
+                              type: string
+                            certFile:
+                              description: The client cert file for the targets.
+                              type: string
+                            insecureSkipVerify:
+                              description: Disable target certificate validation.
+                              type: boolean
+                            keyFile:
+                              description: The client key file for the targets.
+                              type: string
+                            serverName:
+                              description: Used to verify the hostname for the targets.
+                              type: string
+                        url:
+                          description: The URL of the endpoint to send samples to.
+                          type: string
+                        writeRelabelConfigs:
+                          description: The list of remote write relabel configurations.
+                          items:
+                            description: 'RelabelConfig allows dynamic rewriting of the
+                              label set, being applied to samples before ingestion. It defines
+                              `<metric_relabel_configs>`-section of Prometheus configuration.
+                              More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                            properties:
+                              action:
+                                description: Action to perform based on regex matching.
+                                  Default is 'replace'
+                                type: string
+                              modulus:
+                                description: Modulus to take of the hash of the source label
+                                  values.
+                                format: int64
+                                type: integer
+                              regex:
+                                description: Regular expression against which the extracted
+                                  value is matched. defailt is '(.*)'
+                                type: string
+                              replacement:
+                                description: Replacement value against which a regex replace
+                                  is performed if the regular expression matches. Regex
+                                  capture groups are available. Default is '$1'
+                                type: string
+                              separator:
+                                description: Separator placed between concatenated source
+                                  label values. default is ';'.
+                                type: string
+                              sourceLabels:
+                                description: The source labels select values from existing
+                                  labels. Their content is concatenated using the configured
+                                  separator and matched against the configured regular expression
+                                  for the replace, keep, and drop actions.
+                                items:
+                                  type: string
+                                type: array
+                              targetLabel:
+                                description: Label to which the resulting value is written
+                                  in a replace action. It is mandatory for replace actions.
+                                  Regex capture groups are available.
+                                type: string
+                          type: array
+                      required:
+                      - url
+                    type: array
+                  replicas:
+                    description: Number of instances to deploy for a Prometheus deployment.
+                    format: int32
+                    type: integer
+                  resources:
+                    description: ResourceRequirements describes the compute resource requirements.
+                    properties:
+                      limits:
+                        description: 'Limits describes the maximum amount of compute resources
+                          allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        description: 'Requests describes the minimum amount of compute resources
+                          required. If Requests is omitted for a container, it defaults
+                          to Limits if that is explicitly specified, otherwise to an implementation-defined
+                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                  retention:
+                    description: Time duration Prometheus shall retain data for.
+                    type: string
+                  routePrefix:
+                    description: The route prefix Prometheus registers HTTP handlers for.
+                      This is useful, if using ExternalURL and a proxy is rewriting HTTP
+                      routes of a request, and the actual ExternalURL is still true, but
+                      the server serves requests under a different route prefix. For example
+                      for use with `kubectl proxy`.
+                    type: string
+                  ruleNamespaceSelector:
+                    description: A label selector is a label query over a set of resources.
+                      The result of matchLabels and matchExpressions are ANDed. An empty
+                      label selector matches all objects. A null label selector matches
+                      no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements.
+                          The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector that contains
+                            values, a key, and an operator that relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies
+                                to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a
+                                set of values. Valid operators are In, NotIn, Exists and
+                                DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator
+                                is In or NotIn, the values array must be non-empty. If the
+                                operator is Exists or DoesNotExist, the values array must
+                                be empty. This array is replaced during a strategic merge
+                                patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                        type: array
+                      matchLabels:
+                        description: matchLabels is a map of {key,value} pairs. A single
+                          {key,value} in the matchLabels map is equivalent to an element
+                                       of matchExpressions, whose key field is "key", the operator is
+                                       "In", and the values array contains only "value". The requirements
+                                       are ANDed.
+                        type: object
+                  ruleSelector:
+                    description: A label selector is a label query over a set of resources.
+                      The result of matchLabels and matchExpressions are ANDed. An empty
+                      label selector matches all objects. A null label selector matches
+                      no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements.
+                          The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector that contains
+                            values, a key, and an operator that relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies
+                                to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a
+                                set of values. Valid operators are In, NotIn, Exists and
+                                DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator
+                                is In or NotIn, the values array must be non-empty. If the
+                                operator is Exists or DoesNotExist, the values array must
+                                be empty. This array is replaced during a strategic merge
+                                patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                        type: array
+                      matchLabels:
+                        description: matchLabels is a map of {key,value} pairs. A single
+                          {key,value} in the matchLabels map is equivalent to an element
+                                       of matchExpressions, whose key field is "key", the operator is
+                                       "In", and the values array contains only "value". The requirements
+                                       are ANDed.
+                        type: object
+                  scrapeInterval:
+                    description: Interval between consecutive scrapes.
+                    type: string
+                  secrets:
+                    description: Secrets is a list of Secrets in the same namespace as the
+                      Prometheus object, which shall be mounted into the Prometheus Pods.
+                      The Secrets are mounted into /etc/prometheus/secrets/<secret-name>.
+                      Secrets changes after initial creation of a Prometheus object are
+                      not reflected in the running Pods. To change the secrets mounted into
+                      the Prometheus Pods, the object must be deleted and recreated with
+                      the new list of secrets.
+                    items:
+                      type: string
+                    type: array
+                  securityContext:
+                    description: PodSecurityContext holds pod-level security attributes
+                      and common container settings. Some fields are also present in container.securityContext.  Field
+                      values of container.securityContext take precedence over field values
+                      of PodSecurityContext.
+                    properties:
+                      fsGroup:
+                        description: |-
+                          A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+                          1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                          If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                        format: int64
+                        type: integer
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail to start
+                          the container if it does. If unset or false, no such validation
+                          will be performed. May also be set in SecurityContext.  If set
+                          in both SecurityContext and PodSecurityContext, the value specified
+                          in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified. May
+                          also be set in SecurityContext.  If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: SELinuxOptions are the labels to be applied to the
+                          container
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies to the
+                              container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies to the
+                              container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies to the
+                              container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies to the
+                              container.
+                            type: string
+                      supplementalGroups:
+                        description: A list of groups applied to the first process run in
+                          each container, in addition to the container's primary GID.  If
+                          unspecified, no groups will be added to any container.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used for
+                          the pod. Pods with unsupported sysctls (by the container runtime)
+                          might fail to launch.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                        type: array
+                  serviceAccountName:
+                    description: ServiceAccountName is the name of the ServiceAccount to
+                      use to run the Prometheus Pods.
+                    type: string
+                  serviceMonitorNamespaceSelector:
+                    description: A label selector is a label query over a set of resources.
+                      The result of matchLabels and matchExpressions are ANDed. An empty
+                      label selector matches all objects. A null label selector matches
+                      no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements.
+                          The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector that contains
+                            values, a key, and an operator that relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies
+                                to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a
+                                set of values. Valid operators are In, NotIn, Exists and
+                                DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator
+                                is In or NotIn, the values array must be non-empty. If the
+                                operator is Exists or DoesNotExist, the values array must
+                                be empty. This array is replaced during a strategic merge
+                                patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                        type: array
+                      matchLabels:
+                        description: matchLabels is a map of {key,value} pairs. A single
+                          {key,value} in the matchLabels map is equivalent to an element
+                                       of matchExpressions, whose key field is "key", the operator is
+                                       "In", and the values array contains only "value". The requirements
+                                       are ANDed.
+                        type: object
+                  serviceMonitorSelector:
+                    description: A label selector is a label query over a set of resources.
+                      The result of matchLabels and matchExpressions are ANDed. An empty
+                      label selector matches all objects. A null label selector matches
+                      no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements.
+                          The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector that contains
+                            values, a key, and an operator that relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies
+                                to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a
+                                set of values. Valid operators are In, NotIn, Exists and
+                                DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator
+                                is In or NotIn, the values array must be non-empty. If the
+                                operator is Exists or DoesNotExist, the values array must
+                                be empty. This array is replaced during a strategic merge
+                                patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                        type: array
+                      matchLabels:
+                        description: matchLabels is a map of {key,value} pairs. A single
+                          {key,value} in the matchLabels map is equivalent to an element
+                                       of matchExpressions, whose key field is "key", the operator is
+                                       "In", and the values array contains only "value". The requirements
+                                       are ANDed.
+                        type: object
+                  storage:
+                    description: StorageSpec defines the configured storage for a group
+                      Prometheus servers.
+                    properties:
+                      class:
+                        description: 'Name of the StorageClass to use when requesting storage
+                          provisioning. More info: https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses
+                          DEPRECATED'
+                        type: string
+                      emptyDir:
+                        description: Represents an empty directory for a pod. Empty directory
+                          volumes support ownership management and SELinux relabeling.
+                        properties:
+                          medium:
+                            description: 'What type of storage medium should back this directory.
+                              The default is "" which means to use the node''s default medium.
+                              Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            type: string
+                          sizeLimit: {}
+                      resources:
+                        description: ResourceRequirements describes the compute resource
+                          requirements.
+                        properties:
+                          limits:
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            description: 'Requests describes the minimum amount of compute
+                              resources required. If Requests is omitted for a container,
+                              it defaults to Limits if that is explicitly specified, otherwise
+                              to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                      selector:
+                        description: A label selector is a label query over a set of resources.
+                          The result of matchLabels and matchExpressions are ANDed. An empty
+                          label selector matches all objects. A null label selector matches
+                          no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements.
+                              The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector that
+                                contains values, a key, and an operator that relates the
+                                key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies
+                                    to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn, Exists
+                                    and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the
+                                    operator is In or NotIn, the values array must be non-empty.
+                                    If the operator is Exists or DoesNotExist, the values
+                                    array must be empty. This array is replaced during a
+                                    strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                            type: array
+                          matchLabels:
+                            description: matchLabels is a map of {key,value} pairs. A single
+                              {key,value} in the matchLabels map is equivalent to an element
+                                           of matchExpressions, whose key field is "key", the operator
+                                           is "In", and the values array contains only "value". The requirements
+                                           are ANDed.
+                            type: object
+                      volumeClaimTemplate:
+                        description: PersistentVolumeClaim is a user's request for and claim
+                          to a persistent volume
+                        properties:
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema of this
+                              representation of an object. Servers should convert recognized
+                              schemas to the latest internal value, and may reject unrecognized
+                              values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                            type: string
+                          kind:
+                            description: 'Kind is a string value representing the REST resource
+                              this object represents. Servers may infer this from the endpoint
+                              the client submits requests to. Cannot be updated. In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                            type: string
+                          metadata:
+                            description: ObjectMeta is metadata that all persisted resources
+                              must have, which includes all objects users must create.
+                            properties:
+                              annotations:
+                                description: 'Annotations is an unstructured key value map
+                                  stored with a resource that may be set by external tools
+                                  to store and retrieve arbitrary metadata. They are not
+                                  queryable and should be preserved when modifying objects.
+                                  More info: http://kubernetes.io/docs/user-guide/annotations'
+                                type: object
+                              clusterName:
+                                description: The name of the cluster which the object belongs
+                                  to. This is used to distinguish resources with same name
+                                  and namespace in different clusters. This field is not
+                                  set anywhere right now and apiserver is going to ignore
+                                  it if set in create or update request.
+                                type: string
+                              creationTimestamp:
+                                description: Time is a wrapper around time.Time which supports
+                                  correct marshaling to YAML and JSON.  Wrappers are provided
+                                  for many of the factory methods that the time package
+                                  offers.
+                                format: date-time
+                                type: string
+                              deletionGracePeriodSeconds:
+                                description: Number of seconds allowed for this object to
+                                  gracefully terminate before it will be removed from the
+                                  system. Only set when deletionTimestamp is also set. May
+                                  only be shortened. Read-only.
+                                format: int64
+                                type: integer
+                              deletionTimestamp:
+                                description: Time is a wrapper around time.Time which supports
+                                  correct marshaling to YAML and JSON.  Wrappers are provided
+                                  for many of the factory methods that the time package
+                                  offers.
+                                format: date-time
+                                type: string
+                              finalizers:
+                                description: Must be empty before the object is deleted
+                                  from the registry. Each entry is an identifier for the
+                                  responsible component that will remove the entry from
+                                  the list. If the deletionTimestamp of the object is non-nil,
+                                  entries in this list can only be removed.
+                                items:
+                                  type: string
+                                type: array
+                              generateName:
+                                description: |-
+                                  GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+                                  If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+                                  Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                                type: string
+                              generation:
+                                description: A sequence number representing a specific generation
+                                  of the desired state. Populated by the system. Read-only.
+                                format: int64
+                                type: integer
+                              initializers:
+                                description: Initializers tracks the progress of initialization.
+                                properties:
+                                  pending:
+                                    description: Pending is a list of initializers that
+                                      must execute in order before this object is visible.
+                                      When the last pending initializer is removed, and
+                                      no failing result is set, the initializers struct
+                                      will be set to nil and the object is considered as
+                                      initialized and visible to all clients.
+                                    items:
+                                      description: Initializer is information about an initializer
+                                        that has not yet completed.
+                                      properties:
+                                        name:
+                                          description: name of the process that is responsible
+                                            for initializing this object.
+                                          type: string
+                                      required:
+                                      - name
+                                    type: array
+                                  result:
+                                    description: Status is a return value for calls that
+                                      don't return other objects.
+                                    properties:
+                                      apiVersion:
+                                        description: 'APIVersion defines the versioned schema
+                                          of this representation of an object. Servers should
+                                          convert recognized schemas to the latest internal
+                                          value, and may reject unrecognized values. More
+                                          info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                                        type: string
+                                      code:
+                                        description: Suggested HTTP return code for this
+                                          status, 0 if not set.
+                                        format: int32
+                                        type: integer
+                                      details:
+                                        description: StatusDetails is a set of additional
+                                          properties that MAY be set by the server to provide
+                                          additional information about a response. The Reason
+                                          field of a Status object defines what attributes
+                                          will be set. Clients must ignore fields that do
+                                          not match the defined type of each attribute,
+                                          and should assume that any attribute may be empty,
+                                          invalid, or under defined.
+                                        properties:
+                                          causes:
+                                            description: The Causes array includes more
+                                              details associated with the StatusReason failure.
+                                              Not all StatusReasons may provide detailed
+                                              causes.
+                                            items:
+                                              description: StatusCause provides more information
+                                                about an api.Status failure, including cases
+                                                when multiple errors are encountered.
+                                              properties:
+                                                field:
+                                                  description: |-
+                                                    The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+                                                    Examples:
+                                                      "name" - the field "name" on the current resource
+                                                      "items[0].name" - the field "name" on the first array entry in "items"
+                                                  type: string
+                                                message:
+                                                  description: A human-readable description
+                                                    of the cause of the error.  This field
+                                                    may be presented as-is to a reader.
+                                                  type: string
+                                                reason:
+                                                  description: A machine-readable description
+                                                    of the cause of the error. If this value
+                                                    is empty there is no information available.
+                                                  type: string
+                                            type: array
+                                          group:
+                                            description: The group attribute of the resource
+                                              associated with the status StatusReason.
+                                            type: string
+                                          kind:
+                                            description: 'The kind attribute of the resource
+                                              associated with the status StatusReason. On
+                                              some operations may differ from the requested
+                                              resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                            type: string
+                                          name:
+                                            description: The name attribute of the resource
+                                              associated with the status StatusReason (when
+                                              there is a single name which can be described).
+                                            type: string
+                                          retryAfterSeconds:
+                                            description: If specified, the time in seconds
+                                              before the operation should be retried. Some
+                                              errors may indicate the client must take an
+                                              alternate action - for those errors this field
+                                              may indicate how long to wait before taking
+                                              the alternate action.
+                                            format: int32
+                                            type: integer
+                                          uid:
+                                            description: 'UID of the resource. (when there
+                                              is a single resource which can be described).
+                                              More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                            type: string
+                                      kind:
+                                        description: 'Kind is a string value representing
+                                          the REST resource this object represents. Servers
+                                          may infer this from the endpoint the client submits
+                                          requests to. Cannot be updated. In CamelCase.
+                                          More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                        type: string
+                                      message:
+                                        description: A human-readable description of the
+                                          status of this operation.
+                                        type: string
+                                      metadata:
+                                        description: ListMeta describes metadata that synthetic
+                                                       resources must have, including lists and various
+                                                       status objects. A resource may have only one of
+                                          {ObjectMeta, ListMeta}.
+                                        properties:
+                                          continue:
+                                            description: continue may be set if the user
+                                              set a limit on the number of items returned,
+                                              and indicates that the server has more data
+                                              available. The value is opaque and may be
+                                              used to issue another request to the endpoint
+                                              that served this list to retrieve the next
+                                              set of available objects. Continuing a list
+                                              may not be possible if the server configuration
+                                              has changed or more than a few minutes have
+                                              passed. The resourceVersion field returned
+                                              when using this continue value will be identical
+                                              to the value in the first response.
+                                            type: string
+                                          resourceVersion:
+                                            description: 'String that identifies the server''s
+                                              internal version of this object that can be
+                                              used by clients to determine when objects
+                                              have changed. Value must be treated as opaque
+                                              by clients and passed unmodified back to the
+                                              server. Populated by the system. Read-only.
+                                              More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                                            type: string
+                                          selfLink:
+                                            description: selfLink is a URL representing
+                                              this object. Populated by the system. Read-only.
+                                            type: string
+                                      reason:
+                                        description: A machine-readable description of why
+                                          this operation is in the "Failure" status. If
+                                          this value is empty there is no information available.
+                                          A Reason clarifies an HTTP status code but does
+                                          not override it.
+                                        type: string
+                                      status:
+                                        description: 'Status of the operation. One of: "Success"
+                                          or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                                        type: string
+                                required:
+                                - pending
+                              labels:
+                                description: 'Map of string keys and values that can be
+                                  used to organize and categorize (scope and select) objects.
+                                  May match selectors of replication controllers and services.
+                                  More info: http://kubernetes.io/docs/user-guide/labels'
+                                type: object
+                              name:
+                                description: 'Name must be unique within a namespace. Is
+                                  required when creating resources, although some resources
+                                  may allow a client to request the generation of an appropriate
+                                  name automatically. Name is primarily intended for creation
+                                  idempotence and configuration definition. Cannot be updated.
+                                  More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+                                  Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                                type: string
+                              ownerReferences:
+                                description: List of objects depended by this object. If
+                                  ALL objects in the list have been deleted, this object
+                                  will be garbage collected. If this object is managed by
+                                  a controller, then an entry in this list will point to
+                                  this controller, with the controller field set to true.
+                                  There cannot be more than one managing controller.
+                                items:
+                                  description: OwnerReference contains enough information
+                                    to let you identify an owning object. Currently, an
+                                    owning object must be in the same namespace, so there
+                                    is no namespace field.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    blockOwnerDeletion:
+                                      description: If true, AND if the owner has the "foregroundDeletion"
+                                                     finalizer, then the owner cannot be deleted from
+                                                     the key-value store until this reference is removed.
+                                                     Defaults to false. To set this field, a user needs
+                                                     "delete" permission of the owner, otherwise 422
+                                                     (Unprocessable Entity) will be returned.
+                                      type: boolean
+                                    controller:
+                                      description: If true, this reference points to the
+                                        managing controller.
+                                      type: boolean
+                                    kind:
+                                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                      type: string
+                                    uid:
+                                      description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                      type: string
+                                  required:
+                                  - apiVersion
+                                  - kind
+                                  - name
+                                  - uid
+                                type: array
+                              resourceVersion:
+                                description: |-
+                                  An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+                                  Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              selfLink:
+                                description: SelfLink is a URL representing this object.
+                                  Populated by the system. Read-only.
+                                type: string
+                              uid:
+                                description: |-
+                                  UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+                                  Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                                type: string
+                          spec:
+                            description: PersistentVolumeClaimSpec describes the common
+                              attributes of storage devices and allows a Source for provider-specific
+                              attributes
+                            properties:
+                              accessModes:
+                                description: 'AccessModes contains the desired access modes
+                                  the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                items:
+                                  type: string
+                                type: array
+                              resources:
+                                description: ResourceRequirements describes the compute
+                                  resource requirements.
+                                properties:
+                                  limits:
+                                    description: 'Limits describes the maximum amount of
+                                      compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                  requests:
+                                    description: 'Requests describes the minimum amount
+                                      of compute resources required. If Requests is omitted
+                                      for a container, it defaults to Limits if that is
+                                      explicitly specified, otherwise to an implementation-defined
+                                      value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                              selector:
+                                description: A label selector is a label query over a set
+                                  of resources. The result of matchLabels and matchExpressions
+                                  are ANDed. An empty label selector matches all objects.
+                                  A null label selector matches no objects.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector
+                                      requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a selector
+                                        that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship
+                                            to a set of values. Valid operators are In,
+                                            NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string values.
+                                            If the operator is In or NotIn, the values array
+                                            must be non-empty. If the operator is Exists
+                                            or DoesNotExist, the values array must be empty.
+                                            This array is replaced during a strategic merge
+                                            patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                    type: array
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value} pairs.
+                                      A single {key,value} in the matchLabels map is equivalent
+                                      to an element of matchExpressions, whose key field
+                                      is "key", the operator is "In", and the values array
+                                      contains only "value". The requirements are ANDed.
+                                    type: object
+                              storageClassName:
+                                description: 'Name of the StorageClass required by the claim.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                type: string
+                              volumeMode:
+                                description: volumeMode defines what type of volume is required
+                                  by the claim. Value of Filesystem is implied when not
+                                  included in claim spec. This is an alpha feature and may
+                                  change in the future.
+                                type: string
+                              volumeName:
+                                description: VolumeName is the binding reference to the
+                                  PersistentVolume backing this claim.
+                                type: string
+                          status:
+                            description: PersistentVolumeClaimStatus is the current status
+                              of a persistent volume claim.
+                            properties:
+                              accessModes:
+                                description: 'AccessModes contains the actual access modes
+                                  the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                items:
+                                  type: string
+                                type: array
+                              capacity:
+                                description: Represents the actual resources of the underlying
+                                  volume.
+                                type: object
+                              conditions:
+                                description: Current Condition of persistent volume claim.
+                                  If underlying persistent volume is being resized then
+                                  the Condition will be set to 'ResizeStarted'.
+                                items:
+                                  description: PersistentVolumeClaimCondition contails details
+                                    about state of pvc
+                                  properties:
+                                    lastProbeTime:
+                                      description: Time is a wrapper around time.Time which
+                                        supports correct marshaling to YAML and JSON.  Wrappers
+                                        are provided for many of the factory methods that
+                                        the time package offers.
+                                      format: date-time
+                                      type: string
+                                    lastTransitionTime:
+                                      description: Time is a wrapper around time.Time which
+                                        supports correct marshaling to YAML and JSON.  Wrappers
+                                        are provided for many of the factory methods that
+                                        the time package offers.
+                                      format: date-time
+                                      type: string
+                                    message:
+                                      description: Human-readable message indicating details
+                                        about last transition.
+                                      type: string
+                                    reason:
+                                      description: Unique, this should be a short, machine
+                                        understandable string that gives the reason for
+                                        condition's last transition. If it reports "ResizeStarted"
+                                        that means the underlying persistent volume is being
+                                        resized.
+                                      type: string
+                                    status:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
+                                  - status
+                                type: array
+                              phase:
+                                description: Phase represents the current phase of PersistentVolumeClaim.
+                                type: string
+                  tag:
+                    description: Tag of Prometheus container image to be deployed. Defaults
+                      to the value of `version`.
+                    type: string
+                  thanos:
+                    description: ThanosSpec defines parameters for a Prometheus server within
+                      a Thanos deployment.
+                    properties:
+                      baseImage:
+                        description: Thanos base image if other than default.
+                        type: string
+                      gcs:
+                        description: ThanosGCSSpec defines parameters for use of Google
+                          Cloud Storage (GCS) with Thanos.
+                        properties:
+                          bucket:
+                            description: Google Cloud Storage bucket name for stored blocks.
+                              If empty it won't store any block inside Google Cloud Storage.
+                            type: string
+                      peers:
+                        description: Peers is a DNS name for Thanos to discover peers through.
+                        type: string
+                      s3:
+                        description: ThanosSpec defines parameters for of AWS Simple Storage
+                          Service (S3) with Thanos. (S3 compatible services apply as well)
+                        properties:
+                          accessKey:
+                            description: SecretKeySelector selects a key of a Secret.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or it's key must
+                                  be defined
+                                type: boolean
+                            required:
+                            - key
+                          bucket:
+                            description: S3-Compatible API bucket name for stored blocks.
+                            type: string
+                          endpoint:
+                            description: S3-Compatible API endpoint for stored blocks.
+                            type: string
+                          insecure:
+                            description: Whether to use an insecure connection with an S3-Compatible
+                              API.
+                            type: boolean
+                          secretKey:
+                            description: SecretKeySelector selects a key of a Secret.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or it's key must
+                                  be defined
+                                type: boolean
+                            required:
+                            - key
+                          signatureVersion2:
+                            description: Whether to use S3 Signature Version 2; otherwise
+                              Signature Version 4 will be used.
+                            type: boolean
+                      tag:
+                        description: Tag of Thanos sidecar container image to be deployed.
+                          Defaults to the value of `version`.
+                        type: string
+                      version:
+                        description: Version describes the version of Thanos to use.
+                        type: string
+                  tolerations:
+                    description: If specified, the pod's tolerations.
+                    items:
+                      description: The pod this Toleration is attached to tolerates any
+                        taint that matches the triple <key,value,effect> using the matching
+                        operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty
+                            means match all taint effects. When specified, allowed values
+                            are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty, operator
+                            must be Exists; this combination means to match all values and
+                            all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal. Exists
+                            is equivalent to wildcard for value, so that a pod can tolerate
+                            all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the
+                            toleration (which must be of effect NoExecute, otherwise this
+                            field is ignored) tolerates the taint. By default, it is not
+                            set, which means tolerate the taint forever (do not evict).
+                            Zero and negative values will be treated as 0 (evict immediately)
+                            by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise
+                            just a regular string.
+                          type: string
+                    type: array
+                  version:
+                    description: Version of Prometheus to be deployed.
+                    type: string
+              status:
+                description: 'Most recent observed status of the Prometheus cluster. Read-only.
+                  Not included when requesting from the apiserver, only from the Prometheus
+                  Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+                properties:
+                  availableReplicas:
+                    description: Total number of available pods (ready for at least minReadySeconds)
+                      targeted by this Prometheus deployment.
+                    format: int32
+                    type: integer
+                  paused:
+                    description: Represents whether any actions on the underlaying managed
+                      objects are being performed. Only delete actions will be performed.
+                    type: boolean
+                  replicas:
+                    description: Total number of non-terminated pods targeted by this Prometheus
+                      deployment (their labels match the selector).
+                    format: int32
+                    type: integer
+                  unavailableReplicas:
+                    description: Total number of unavailable pods targeted by this Prometheus
+                      deployment.
+                    format: int32
+                    type: integer
+                  updatedReplicas:
+                    description: Total number of non-terminated pods targeted by this Prometheus
+                      deployment that have the desired version spec.
+                    format: int32
+                    type: integer
+                required:
+                - paused
+                - replicas
+                - updatedReplicas
+                - availableReplicas
+                - unavailableReplicas
+        version: v1
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: prometheusrules.monitoring.coreos.com
+      spec:
+        group: monitoring.coreos.com
+        names:
+          kind: PrometheusRule
+          plural: prometheusrules
+        scope: Namespaced
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                description: PrometheusRuleSpec contains specification parameters for a
+                  Rule.
+                properties:
+                  groups:
+                    description: Content of Prometheus rule file
+                    items:
+                      description: RuleGroup is a list of sequentially evaluated recording
+                        and alerting rules.
+                      properties:
+                        interval:
+                          type: string
+                        name:
+                          type: string
+                        rules:
+                          items:
+                            description: Rule describes an alerting or recording rule.
+                            properties:
+                              alert:
+                                type: string
+                              annotations:
+                                type: object
+                              expr:
+                                type: string
+                              for:
+                                type: string
+                              labels:
+                                type: object
+                              record:
+                                type: string
+                            required:
+                            - expr
+                          type: array
+                      required:
+                      - name
+                      - rules
+                    type: array
+        version: v1
+      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: servicemonitors.monitoring.coreos.com
+      spec:
+        group: monitoring.coreos.com
+        names:
+          kind: ServiceMonitor
+          plural: servicemonitors
+        scope: Namespaced
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                description: ServiceMonitorSpec contains specification parameters for a
+                  ServiceMonitor.
+                properties:
+                  endpoints:
+                    description: A list of endpoints allowed as part of this ServiceMonitor.
+                    items:
+                      description: Endpoint defines a scrapeable endpoint serving Prometheus
+                        metrics.
+                      properties:
+                        basicAuth:
+                          description: 'BasicAuth allow an endpoint to authenticate over
+                            basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                          properties:
+                            password:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or it's key must
+                                    be defined
+                                  type: boolean
+                              required:
+                              - key
+                            username:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or it's key must
+                                    be defined
+                                  type: boolean
+                              required:
+                              - key
+                        bearerTokenFile:
+                          description: File to read bearer token for scraping targets.
+                          type: string
+                        honorLabels:
+                          description: HonorLabels chooses the metric's labels on collisions
+                            with target labels.
+                          type: boolean
+                        interval:
+                          description: Interval at which metrics should be scraped
+                          type: string
+                        metricRelabelings:
+                          description: MetricRelabelConfigs to apply to samples before ingestion.
+                          items:
+                            description: 'RelabelConfig allows dynamic rewriting of the
+                              label set, being applied to samples before ingestion. It defines
+                              `<metric_relabel_configs>`-section of Prometheus configuration.
+                              More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                            properties:
+                              action:
+                                description: Action to perform based on regex matching.
+                                  Default is 'replace'
+                                type: string
+                              modulus:
+                                description: Modulus to take of the hash of the source label
+                                  values.
+                                format: int64
+                                type: integer
+                              regex:
+                                description: Regular expression against which the extracted
+                                  value is matched. defailt is '(.*)'
+                                type: string
+                              replacement:
+                                description: Replacement value against which a regex replace
+                                  is performed if the regular expression matches. Regex
+                                  capture groups are available. Default is '$1'
+                                type: string
+                              separator:
+                                description: Separator placed between concatenated source
+                                  label values. default is ';'.
+                                type: string
+                              sourceLabels:
+                                description: The source labels select values from existing
+                                  labels. Their content is concatenated using the configured
+                                  separator and matched against the configured regular expression
+                                  for the replace, keep, and drop actions.
+                                items:
+                                  type: string
+                                type: array
+                              targetLabel:
+                                description: Label to which the resulting value is written
+                                  in a replace action. It is mandatory for replace actions.
+                                  Regex capture groups are available.
+                                type: string
+                          type: array
+                        params:
+                          description: Optional HTTP URL parameters
+                          type: object
+                        path:
+                          description: HTTP path to scrape for metrics.
+                          type: string
+                        port:
+                          description: Name of the service port this endpoint refers to.
+                            Mutually exclusive with targetPort.
+                          type: string
+                        proxyUrl:
+                          description: ProxyURL eg http://proxyserver:2195 Directs scrapes
+                            to proxy through this endpoint.
+                          type: string
+                        scheme:
+                          description: HTTP scheme to use for scraping.
+                          type: string
+                        scrapeTimeout:
+                          description: Timeout after which the scrape is ended
+                          type: string
+                        targetPort:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                        tlsConfig:
+                          description: TLSConfig specifies TLS configuration parameters.
+                          properties:
+                            caFile:
+                              description: The CA cert to use for the targets.
+                              type: string
+                            certFile:
+                              description: The client cert file for the targets.
+                              type: string
+                            insecureSkipVerify:
+                              description: Disable target certificate validation.
+                              type: boolean
+                            keyFile:
+                              description: The client key file for the targets.
+                              type: string
+                            serverName:
+                              description: Used to verify the hostname for the targets.
+                              type: string
+                    type: array
+                  jobLabel:
+                    description: The label to use to retrieve the job name from.
+                    type: string
+                  namespaceSelector:
+                    description: A selector for selecting namespaces either selecting all
+                      namespaces or a list of namespaces.
+                    properties:
+                      any:
+                        description: Boolean describing whether all namespaces are selected
+                          in contrast to a list restricting them.
+                        type: boolean
+                      matchNames:
+                        description: List of namespace names.
+                        items:
+                          type: string
+                        type: array
+                  selector:
+                    description: A label selector is a label query over a set of resources.
+                      The result of matchLabels and matchExpressions are ANDed. An empty
+                      label selector matches all objects. A null label selector matches
+                      no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements.
+                          The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector that contains
+                            values, a key, and an operator that relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies
+                                to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a
+                                set of values. Valid operators are In, NotIn, Exists and
+                                DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator
+                                is In or NotIn, the values array must be non-empty. If the
+                                operator is Exists or DoesNotExist, the values array must
+                                be empty. This array is replaced during a strategic merge
+                                patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                        type: array
+                      matchLabels:
+                        description: matchLabels is a map of {key,value} pairs. A single
+                          {key,value} in the matchLabels map is equivalent to an element
+                                       of matchExpressions, whose key field is "key", the operator is
+                                       "In", and the values array contains only "value". The requirements
+                                       are ANDed.
+                        type: object
+                  targetLabels:
+                    description: TargetLabels transfers labels on the Kubernetes Service
+                      onto the target.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - endpoints
+                - selector
+        version: v1
+      
+  clusterServiceVersions: |-
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        name: amqstreams.v1.0.0.beta
+        namespace: placeholder
+        annotations:
+          alm-examples: '[{"apiVersion":"kafka.strimzi.io/v1alpha1","kind":"Kafka","metadata":{"name":"my-cluster"},"spec":{"kafka":{"replicas":3,"listeners":{"plain":{},"tls":{}},"config":{"offsets.topic.replication.factor":3,"transaction.state.log.replication.factor":3,"transaction.state.log.min.isr":2},"storage":{"type":"ephemeral"}},"zookeeper":{"replicas":3,"storage":{"type":"ephemeral"}},"entityOperator":{"topicOperator":{},"userOperator":{}}}}, {"apiVersion":"kafka.strimzi.io/v1alpha1","kind":"KafkaConnect","metadata":{"name":"my-connect-cluster"},"spec":{"replicas":1,"bootstrapServers":"my-cluster-kafka-bootstrap:9093","tls":{"trustedCertificates":[{"secretName":"my-cluster-cluster-ca-cert","certificate":"ca.crt"}]}}}, {"apiVersion":"kafka.strimzi.io/v1alpha1","kind":"KafkaConnectS2I","metadata":{"name":"my-connect-cluster"},"spec":{"replicas":1,"bootstrapServers":"my-cluster-kafka-bootstrap:9093","tls":{"trustedCertificates":[{"secretName":"my-cluster-cluster-ca-cert","certificate":"ca.crt"}]}}}, {"apiVersion":"kafka.strimzi.io/v1alpha1","kind":"KafkaTopic","metadata":{"name":"my-topic","labels":{"strimzi.io/cluster":"my-cluster"}},"spec":{"partitions":10,"replicas":3,"config":{"retention.ms":604800000,"segment.bytes":1073741824}}}, {"apiVersion":"kafka.strimzi.io/v1alpha1","kind":"KafkaUser","metadata":{"name":"my-user","labels":{"strimzi.io/cluster":"my-cluster"}},"spec":{"authentication":{"type":"tls"},"authorization":{"type":"simple","acls":[{"resource":{"type":"topic","name":"my-topic","patternType":"literal"},"operation":"Read","host":"*"},{"resource":{"type":"topic","name":"my-topic","patternType":"literal"},"operation":"Describe","host":"*"},{"resource":{"type":"group","name":"my-group","patternType":"literal"},"operation":"Read","host":"*"},{"resource":{"type":"topic","name":"my-topic","patternType":"literal"},"operation":"Write","host":"*"},{"resource":{"type":"topic","name":"my-topic","patternType":"literal"},"operation":"Create","host":"*"},{"resource":{"type":"topic","name":"my-topic","patternType":"literal"},"operation":"Describe","host":"*"}]}}}]'
+      spec:
+        displayName: AMQ Streams
+        description: |
+              **Red Hat AMQ Streams** is a massively scalable, distributed, and high performance data streaming platform based on the Apache Kafka project. 
+              AMQ Streams provides an event streaming backbone that allows microservices and other application components to exchange data with extremely high throughput and low latency. 
+              
+              **The core capabilities include**
+              * A pub/sub messaging model, similar to a traditional enterprise messaging system, in which application components publish and consume events to/from an ordered stream
+              * The long term, fault-tolerant storage of events
+              * The ability for a consumer to replay streams of events
+              * The ability to partition topics for horizontal scalability
+      
+              # Before you start
+      
+              1\. Create AMQ Streams Cluster Roles
+              ```
+              $ oc apply -f http://amq.io/amqstreams/rbac.yaml
+              ```
+              2\. Create following bindings
+              ```
+              $ oc adm policy add-cluster-role-to-user strimzi-cluster-operator -z strimzi-cluster-operator --namespace <namespace>
+              $ oc adm policy add-cluster-role-to-user strimzi-kafka-broker -z strimzi-cluster-operator --namespace <namespace>
+              ```
+        keywords: ['amq', 'streams', 'messaging', 'kafka', 'streaming']
+        version: 1.0.0-Beta
+        maturity: beta
+        maintainers:
+        - name: Red Hat, Inc.
+          email: customerservice@redhat.com
+        provider:
+          name: Red Hat, Inc.
+        links:
+        - name: Product Page
+          url: https://access.redhat.com/products/red-hat-amq-streams
+        - name: Documentation
+          url: https://access.redhat.com/documentation/en-us/red_hat_amq_streams/1.0-beta/html-single/using_amq_streams/
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAlywAAJcsBGkdkZgAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAACAASURBVHic7d13nBx3ff/x13d29/aK6kmyyjXJlnVqLpJV3ABL2GAnuIANJAZDjGkmIWCn0H4ktCTEgfwI5AeEOPyMSRwTmktiwJIlGVu2ZEkWtnxFXbrbu1M9lWtb55s/7k7tdu+2zMx3y+f5ePDgbnZn5i1Zn8/07yhEQWuvpWLAx+yETb22qFM2FwHVKKYA1RqqFVQD5UAQqByatRyoGPp5AAgP/dwHRIEBBd02dCtFNzbdQLe2OKxs2i0fbZVxDtaFGPDsDyscp0wHEGPbehWBiqNc6oNFGhYDC4E5KOrRTDMc7zDQBhwAmhQ0KYs3Og+wZxXEzUYTY5EGkGd2zyUYi7PEslmpFSvRXAbMA8pMZ8tQFEUrmh0KXlE2m+IT+d2iJqKmg4mzpAEYtnsG02IBVqO4RmlWoljC4K56MQoDr6LYrDQv6QTrF3Rw3HSoUiYNwGPrwT+jniuAW4F3AEsAy2wqY2xgu4K1NqytsHhxzoEz5yKEB6QBeGDPJVwUi3GH1tyhFDdw9uSbOF8fsEErfumL8WRjJ8dMByp20gBcsmMWdX4/tzC4pb8Z8BuOVGgSwCYFP1U2P2sM0WE6UDGSBuCgvRczMRrnvcAfAVcjf79OsTW8hOKRQICfXrqH06YDFQv5B5ojDdaueq614R7gfUCV6UxFLgw8Dfx4fhvPqME9BZElaQBZ2nMJF0XjfEzZfBhFvek8JeqA0jzsi/GDSw9x1HSYQiQNIENNs7nSsrmfwS2+nMzLDxEF/4XNN+aHeN10mEIiDSANGqzWBu5A8yngzabziFGtU5pvN7bztBq8zChGIQ1gFBqsnfXcacOXFSwwnUdkpFnD3y9o4z/kPEFq0gCSGC58DV8FGk3nETnZB/z9oTZ+KM8mjCQN4BwarNZ67tHwRQWXmM4jHKTYpTRfbWzjMTk0OEsawJCmet7qg29ouNJ0FuGqV5Xiz+cfZL3pIPmg5BvAztnMt22+ArzbdBbhqbVa88DCdt4wHcSkkm0Au2cwLV7GV4H7kNt0S1UMzQ9szV8tCtFtOowJJdcANKiWeu5Rim/kwWAaIj90A5+b38a/KtCmw3ippBpAUy1zLYvvATeaziLy0m99io/PO0iL6SBeKYkGsPUqApVHeVDBlynewTaEM2IK/tFXxl9fuoeI6TBuK/oG0FLPVRp+LDfyiAy9Yfl4f+N+XjMdxE1FOxKNBl9zPZ8BXpLiF1lYbCfY0lLPlzT4TIdxS1HuAbTMZjY2P0Lu2xfOeNm2+cCiEHtMB3Fa0e0BNDdwHzY7kOIXzrnGstjWXM8HTAdxWtHsAeyfTXkkwT9rxX2ms4jipeDHvXE+vqyTftNZnFAUDaCplrmWj5+judx0FlEStvvgrnlt7DMdJFcFfwjQUs87LItXpPiFh5YkYHtzA+80HSRXBdsANFgt9fwd8BQw2XQeUXImKM3PWur5si7gPemCDP7adKoCQf5Dwe2mswiB5hd9Ce4pxPMCBdcAmhuYqTRPActMZxHiDMXmuMXtl+3nsOkomSioBtBcx2Kl+G+gwXQWIZLYb8M7FrXRbDpIugrmHEBLHW9Xio1I8Yv8NccHG1sbWG06SLoKogE01/FeFE8DE0xnEWI0GiZpza9a67nLdJZ05H0DaK3n/Urx70DAdBYh0lSm4fHWOu41HWQsed0AWuu4X8OPkBF7ROHxacW/tdbzKdNBRpO3DaC5ns9oxXfJ44xCjEFp+FZzA180HSSVvLwK0FrHV7TK3780ITIV1vxoSTt/ZDrHhfKuATTX8YBS/KPpHEI4pc+GfhuC8JuVndxsOs+58mr3uqWBP5HiF8VkuPgBIvD2TbX83Gyi8+XNHkBLPR8EfkieNSUhsnVu8Z8rqHh0ZQcf9D7RSHlRbC0N3Ak8TJ7kESJXqYofIKL5wNZa/snbRMkZ3wNoqePtQzf5yHV+URT67cEGMJYKi88sD/GQ+4lSM9oAmupZ6IONGiaZzCGEU0bb8l9IgQ5a3LUixC/cTTVqBjOaZjPDstmE3NsvikQmxT9MQSJYxrIVB/idO6lGZ+SYu72WCkvzBFL8okhkU/wwOHx9PMaLv51h5jV1njcADVav4j/QrPR63UK4IdviHxbXVPl9vLbVwHkwzxtAaz1/gyr8sdSEgMHCz6X4h8U1MxO1PJf7kjLjaQNoqedW4DNerlMIt/SlebY/XRGbN71Sw1edW+LYPDsJOPRm3q3ARK/WKYRbct3tT8UCXWWxekmIDc4vfSRPGkB7LRW9FhuBJV6sTwg3uVX8w3wQrlbULujguHtrGeTJIUCvxXeR4hdFwO3iB0hA+UnY5O5aBrneAJobuA/y7zFIITLl1Am/dMQ0c7fU8i9ur8fVQ4Bd9VycgN8B491cjxBu82LLfyELtGWx6toQz7u4DndosBLw/5HiFwXORPED2KCweaoJytxah2sNYGcDn0de0S0KnKniHxaHCb01/NKt5btyCNDcwFKleRkXO5cQbjNd/OeqtHjfshCPOb1cxxvA7rkEY1G2K1jg9LKF8Eq6j/R6xacI63FcdP1OepxcruOHAPEon5fiF4XM6Tv8nJDQlAd6nT8UcHQPoKWGefh4DSh3crmidCl/AFVZ5dn6eqMx+nr7PFtfJhQQgLdf3cmzTi3TsRduaFCtPr6HFP9ZPh/THvgyE+68B6tKLoZkyo5G6T64D6thrmfrnAzEDnVw5Oufo2fDrz1bbzo0YCse1zBFDf6aM8f2AFob+JDW/JtTyysGk+/9U6Z/KS+Gfis4diTM0abXsermGFm/Dg+w55alJE64fjduxip8fH95O/c7sSxHzgHsnsE0rc2ObZaPxt2QV0PAFww7EuZos7niB1DlFZQvutLY+kcTSfDRjXVc4sSyHGkA8TK+BkxxYllFxS/jnGbKjkYGt/y15op/mMrT/342WH7bmfcL5NwAdjWwAPiQA1lEibOjEY6+8ZrRLX+hiGiu2DqD3891OTk3gLjNN5G394ocSfFnLmrxcK7LyKkBtDawWiluyTWEKG2Du/1S/JmKw4wtNTyQyzKybgAaLK35h1xWLsSZ4s+DY/5CFNX8jc5hDzzrGVvruQdYmu38QtjRCEebd2RU/InOdnr37kTrs5fBA8EgVSveBOr8q9p2z2l6XtuCtgdv67MZfL528tKVWJXjHPkzmJaAii2z+Bad/Ek282fVADT4WhWfd+ZWBFGK7GiEY807sGoyezVEZ9PrHKmeMWL6ZbubKZu36Lxpp7dvYm/VyItTeusmpr75xswC57GY4iNN8OAiiGY6b1aHAK31vB/NvGzmFWJ4t19lWPwAWiW/d03HRv7bt+3kN/TbdiLj9eazhKasdxbfzGbejPcANPha4XPZrEyMLXHqBD1NvyMeiVBWNY5xly3Fqqgce0at6dy4gZOhNnzBINMXLGbS/MXuB86Q6Tv8ilVc8dGt8OAyiGUyX8YNYGc9fwg0ZjqfGNuJjeto81WQKJ945omKwLYtzKkqZ9yS1C9S6m0/wLZ1axmYXguTpgOwf387U15+kaXvuxdfWdCL+GPyuviLazs/uoSmzK7jIdozuyqQ0SGABp+GL2QWTaSj59VN7C+fSOKCYo1VjmdPVBPZtzPpfIlImC3Pbxgs/nMpxfGZs3n1sUdcSpwZE7f32iV2jipmc3+mVwQyagCtDdwOzM8olUhLx6meEWexh9mBMg7tbEn62f5fPUlk6siTYsO6p9dzet8uRzJm60zxy6U+VyU0wc01/HUm82TUAJTm05lFEumwe3vonzj6oxSnxk9OOr37xIlR59NKceSN17LOlispfm9p+EQm30+7ATQ1sETDmzKPJMaUYst/Lq2S/6dKdVb8vO8YOustxe+9mKZ6aw3vTvf7aTcAS/Op7CKJsVhV4yjvH32ot/Gnu5NOn1A19mg51XO9P2rzuvjzbAQvo+Kk/4LRtBrA7hlMA96bdSIxppnWKGesbJvpNTVJP7rk5tvw95xMOeuEroNMWeztc+0mtvyldsJvNDFN49ZZ6Z2rS6sBxIJ8HBnqy1WTr72BmpOHRwzRZCXizOk/QdXly5LOVzZ+Aksa5+E/NXIPoepIB0tvfacLaVOT3X7zNJCwSGsoqjEvGWiwWm0+7N2LxEvX9NW3MOnAHk7t3UU0FiPos5i08HICNStGnW/K5Uu54ZJ57F/zDKdOdmNpmFpbR/377wXLk/e/AsPFn9m9/cIdMZvVGnxqjNshxmwALfWsVlDvXDQxmuDsuVw0O/NBMP1V47j0jve4kCg9djTC0ZY3sGpnG8sgzrLBv6WWPybEt0f73pibB6W517lYohglImGOtTZl/GBPVlLtiaa4SpL0qxl8t5AlNJ8c6zuj7gHsvZiJ0Th3OBdJFJtEJMzxnc2omXWerG/arFp8HaHzpvksReXlbx3x3eoFlxFPcg/EpCtK4yn2hOaSrVOZuewYXam+M2oDiMb5AyCNJ1FEKbKjEY61vOHNln9IxYLLqVlweVrfDcyooWZG8qsnpcAGlSjna8B9qb4z1r7QB52NJIpFIhLm2M5mT4tfZC6huXO0z1M2gN011AJXO55IFLxEJMzxXS2oGbVjf1kYFddM3NqQeuSulA0g4eNOXHp9uChcg8XfKsVfQOJx/iLVZykbgIZ3uRNHFKqzxV+6x9WFSMPbUn2WtAHsmMN04DrXEpUKXTz3pybCw7v9JVT88bjpBI6Iaao31yQfwi9pA/AnuAPwuZqqBERTDOJRaBLhMMd3l9Yxv45FCe98w3QM5yg+k2xy0gagNbe7m6Y0HP/u14kd3Gs6Rk5KsfjtgX4OffXPiR89ZDqKY2w7+WvERpzk2z+b8rDNceT6vyNUeQWVV12LNanadJSsxI8dIRI64Mm6Jj76LNbE5AOfZOPkzx7l+CPfyXi++KFOdDyjsTXzngIdn8yEVU30njt9xI1AAzbXKyl+x+jwAH0bnzMdI+/12TAh4dzAJaeeeIxDf/uXkGJo8FKjQY0/xb3AeR1xxCGABTd5lkoIBou/38E6PfXEY3R95UEp/gvENSOeFhvRALQ0AOEhx4v/yf+U4k/BhhEjw5zXAHbOYipwhWeJRElzvPifepyuLz8gxZ9CXDNuSz0XnzvtvAag/ay+cJoQbuh3o/i/9Gkp/jHYcT527u/nnQTUcvOP8IDTW/7Tv/4lh2TLnx7FqnN/tS74MPX7p4RwgOPF/5sn6Po/f4x28ApCMUvo81/rd6YB7J5LED3yJIEQTnGl+L/wCXSR3LLrhThM2Drr7GX+Mw0gHmMpkB9vkRRFx/Hif/ZJKf4sxdXZMQLONABty7P/wh2uFP/n75fiz5KCW4d/PtMAlMVyM3FEMXP6bH/Pmqek+HOkFVcN/3z2KoDmMiNpRNFyesvfs/ZpOj/3cSn+HCVsZg7/bAFsvYoAJH9eWIhsuFL8n/2YFL8DbKhogjIYagAVR5nH0AQhcuV88f83nZ+VLb9TNBCZxZthqAH4YJHRRKJoOF78z/3P0Ja/uB7PNc1WrIahBqClAQgHuFL8n/moFL8L4rAMzp4EXGgwyxmBmgamfOqLBOctRvnHfG1hehIJEr2nnVlWnosdPczAxGrwBzxbp338CJGnH+fkmqdzLn5tn72br3fdM1L8LtJD5/yGq8z461ytikrqf7KeQJ3xKAUp3Laf3mk1+Kuner7usutv4tTA++G3z+a0nJO/+HemfviBwTv8vvhJKX4X2ZpqGBoSrKWeo4D3/3LOUXn1DdT/ZL3JCAUr3LafUwNhLAPFP+zUMz+n6/P3G1u/yIwFies78VtD9wUbLX4A38RJpiMUpEhHG6cGBowWP4Bv3Hij6xeZscG3aS4TrPFl1JsOI7IT6WjjZG8vVvU001FEAfKFWWrZCeTtjgVIil/kSimWWijZAyg0UvzCCVqz0FKai0wHEemT4hdOsTUz/dqimuJ5hV1Ry6b47eNHSJzsPjvBsgjUzobAyDu/dW8P8cMd503zT69ByQm+oqSh2s/Q9UCR37Ip/sTRQ7y+/yC27/ybqmbsXUPNjSPfFNX66lb6qyacN62iaxsLr78hq8wiv2mYZIE0gHyX7W6/ffrkiOIHiFjJ7xQMV47c0g9UjC+qtxyL84y3gCmmU+TEtol1hYgd6cp41oGjhzmxu4Vob48LwZwRbtsnx/zCFTZU+QHn3sbosRMvP0+HVUY0MDiUYXD3bmpUgknXrhp9vl0t7Nj0Ev0XDb3rfvc+Jh3t5Iqb30HF9JmjzuulcNs+TvUPYE2R87TCBZpyiwJ9EejhF9ayPzj+TPEDRCrGsa98IsfWPZNyvpN7drKlZefZ4gewfJycXsdL69YS7j7mZuy0SfELt2mFz6IABwKJHNxLZ1XqUxft46cST3FIsOPF57GD5Uk/i02eRuszTzqSMRdS/MITGlWQDeDUvt2jXrnUPj89O5tGTI+e7KZ/et2oy+72mR0Z3WTxy6m+0qLBKsgGkEjjLTCxgf4R0yInutFKjb7s8oqsc+VKtvzCY4W5BxAsT74Lf953KqtGTKusqUNFI6POV9ZzIutcuZDiF15TDA4JVnANYOKiK/GNMlhE4PQJxi9ZMWK6ryzI1O5Doy57ZuXYzcVpUvzCBHtoD6Dg+CZPYQ4xVGLkKLG+yABzxldiVSW/fXXx7XdRfqQj6WeTQnuZ9667Hc06Fil+YZIfiALeb/ZyNGHF9SzY1cyRPTvpq5yATsQZ13+a6YuvIDgn9SsOgpOncN0dd7Hr6Z9xNAGJsnICfT3MmjyBuR+6f+i0iDek+IVJFuiCbQAA5fMWUj8v8/FMAxMmsuh997mQKH2RjjZjxS8v0hYweNXHYrABCA9FOto42dNjbMsvl/vEkDN7AMIjXha/f0YtE9teYqB83JlpWttMspK3gOoThzk97vw7wyf0nYAxLp2KwqTAlgbgIa+3/KpqHHNXvS3t78++aeQjwqJ4WQrbAvpMBykFpnf7hbiQ1iQsBd1jf1XkQopf5COlCFu2NABXSfGLfKUUfRaa46aDFCspfpHnTsshgEsiHW2cPC3FL/KXBSf9gJmnXy4QP3rYdATHhNv2caqvH2vqdNNRPBM/3Gk6gsjcCUtbHDGdAiD8+hYGtm8yHSNnpVj8id7TnHjsX03HEBlS0OVXNm3kwX0eOh6n/Q/fyqS7P0rZJfMzvvlk3E234Z82w8E8Mbr/9R8znEnT130Myr0fZS2mIW7gFr/4scP0PPc/xA4lf8BK5C+taVatc2jUCVpNh8lV2cWN1D++Dv/0WY4sz+7vY9eCcWN/MQ/02dBvm04hCk25xQ1WVYw2iuD28Oi+nbT9weqSOxaV4hfZ6pvINqsuxACK/BgKN0el1gSk+EW2FCRWNdE7+PC75qDhPI4plSYgxS9y4YN+GHwcGA37zMZxVrE3gX4pfpEjyxrc67cAFLSYjeO8Ym0Cffbg/4TIhYLdcLYBvGE2jjuKrQnIbr9wiqXZCkMNwFKMfItGkSiWJiDFLxylWANDDaDjILuB0QfML2CF3gSk+IXTVIiNMNQAVkEc2GU0kcsKtQlI8Qun+RX9yyAGQw1gyOuG8nim0JqAnO0XblBwpgCscya+YiaOtwqlCcjZfuEWv2LL8M9nG4BN4T+Kl6Z8bwKy2y9cpXhq+MczDaBnOtuBASOBDMjXJiDFL9zW284Twz+faQDLthEDthtJZEi+NQEpfuE2v+LkKggP/37+i/BU6RwGDMuXJiDFL7xgcf6j//5zf1Galwv+ueAsRPftpO3uGwfHE3BwUBGASe+9jwnvugerKvXYAjZgl+Jf/Fi05ljLDnwz67xbpW0T6zjIsR98k+jenZ6t1ys+WHfu7+cNu9NSwxR8HOHCPYMSUTZ3wZkmEGl5nf03X5HT8ia+6x5m/t9HHUpXYrQmtO5XBC9fbmT18eNH2X/HtSR6ThlZv1vGBZm9dP/Zp3/PK/QFHRwHXvU8VZ6I7mnh4G0rOfS5j9H+gZtzXt74W+50IFUJ0pqOdb82VvwA/inTqLjqGmPrd4MPes4tfki+pV/jUZ68FOts4+RjPyB+pCvnZanKKgcSlRit6Vj3K8ouX2Y6yaiHbYXIr0Zu3Ec0AKVKuwEIg84Uv7ktfzFT8JMLp41oAIlxbEReGCq8NrTbL8XvDgXamsGPLpw+ogEsaiIKbPAilBDAOcVvfre/WAUUh5ZtGxwG7FxJz/ZrxS/djyQEg8W/XorfbZbi6WTT/ckmqjhP4OP7qT4XwhFa07HhWcouS7/4dSRMOHTgvGm+iirKZiW5V0Brwvt3o/XZO6wsn59gwyUZv3im0CmLv082PWmBL+jgeEs9LwCrXE0lSpfWdDy/hrLFSzOaLfTCcxyZfMHNWid6WRyNEpx9yXmTu19az/7yiSOWcXHXb5l8zVsyjlyoAopjy9uSD/yb+oYfxS9cS1QiEnJ3X3Ja07H+N5QtWpLxrFGdZMutFPHe0yMmx6LRpMuIRcJJpxcrBb9O9VnKBmAl+CWDd6mKLPTZ2f/lRQ510tP8OtEM35gc6+vl8PYtHHvjNexono7wpjWd639D2WVXmU5SMvxBHkr5WaoPGkN0NNfzkoLr3YlVvLIdyadv707a9++jv3rozcIH2xn3ykvUX7GU8tqGlPPZsSjbHnuE7snT0WVBAFRzM3U+zcI7787mj+Cazg3PEpDi94xfcWLZPnak+nz0e/7VyOuGYnTZjuQzcGAvu492ny1+AMuid2YDu3bvIXY89VvcNz76Q45Prz9T/AB6wmTaqqrZ8ZMfZx7GJZ3rf0Mgw2N+kRu/4qejfT5qA9D9PA70OpqoiOXySG/7rlbscwr4XPGJk+nY9GLSzw5uWENfzeyUy+0oH09/hocSbpDi954FOhbji2N8J7VFR+lVyD0B6cil+O3wAH1TRn8M+XTlhKTTO/ftGX3hwXI6trycXTCHdG54VorfAL9i93WHSb3rSDqP/SoecSpQscp1MA87EkGPcV3aLq9MOj3O2Nezo2FzZ707NzxLIIuz/SJ3Ps23x/rOmA2g8SDrKbKXhzrJiZF8/BMn4YuNftY+cPpE0umVwbIxlz9hurODnKSrc8MaKX5DfIrYsk6+N9b3xmwACrTS/NCZWMXFyXH7p/SNPvDEtIrk5wcufdMqiCW/3g3gP36E2qvflFO2bHQ+v4bAois9X68Y5IO1Ko0r0WmN/KMS/AslNGJwOpwet3/W9asYd+Jo0s8mH+3gojffmPSzCfVzmOPTkIiP+Ez1nuaKK69E+XzOBU1D5/NrCCyU4jfJVvxpOt9LqwE0dnJMaR7LLVLxcGMAT6ssyLxVN1EX6WHcyWOU9/cw/lgXs+MDzHn7raPO2/h7t7N0dj3jD7fjP3GMwLHDVB/t4Pq3vIVpiy53NugYun67VorfsCA0XRtijLPDg9J+2MeGbyn4EKRx1qmIuTp6r2Ux7Zq3MC2LWS9adDkXeVzsF+p6YR3+BbmNoyhyZ/n4QtrfTfeLC9t5gxIfJ0CG7k6t68X1+OdfZi5AJk/3FfGTgAHFseXtPJnu9zN63Fdp/kmr0nxCUF7UmVrXxg34Gxd7sq7JleWEe06COrvtCsTClC9bOeK746bPpPLwUWzr7DkQlYgzvq7Wk6wm+BTfyeT7GTWAxnaeaq1nB2Cw1XtPtvypdb2wztMtf/V1q6lO87tVC69gwUJX4+QVnyK8PMTfZDJPRuP/K9Ba87eZxSpsUvypdb3obfGL0fkV31GQyGSejF8AsqCd/wLeyHS+QiTFn1rXi+vwN0rx5wtLEVkR4vMZz5fpDApspfh6pvMVGin+1KT480/A4rsKRt4MMoasXgHWeJDHgeJ7cdoQKf7Uul5cL8WfZ3yKyIp2/jKbebNqAAoSCr6Wzbz5Ts72p+bl2X6RvoDi+9ls/SGHl4A2tvEYsDXb+fOR07f3Ro8ccm5hhh3a/CL+eYtMx/BU/FCH6Qhj8kPv8hAPZjt/1g1AgY3Nn2c7f75xY7e/85H/hx7lQZ1C0fXy8/gubjQdw1N9r7xA//bNpmOMKQCfTeehn1RyviWqpZ4ngdtyXY5Jbh7zV81fzNRb30PZ1OljfzkPhY8eou/4MU/WNfUjD2I5+ELVeFeI07/ObDwbnUgQ2dtKz5qn0fGYY1ncELAIXRMiyQsR0pdzA2idQ6NOsAMI5LosE+SEX/64dF0zvuqpjiwr1hWi7SPvJBY6OPaXC1QF3LS8k7W5LCPrQ4Bh8/ezE80Pcl2OCVL8xakUir8MtuVa/OBAAwCwNX8Fo489lm+k+ItTKRS/BbYu4y6HlpW7RSG6NfyFE8vyghR/cSqF4gcos/jONQc44MSyHGkAAAvbeBRy3yVxmxR/cSqV4g8ojq0I8WmnludYAwDQNp8A8vbFa1L8xalUih+gXPFuJ5fnaANYGGI38HdOLtMpUvzFqcSK/1dLQs4OyuNoAwCwx/N18uxpQbm9tziVUvH7YMCa4cyJv3M53gAWNRG14Q/Ik0MBp2/vFfmhlIpfAWUW9yzbRr/Ty3a8AQAsaqNJw1+7sexMyG5/cSql4gcos3hieYifu7FsVxoAwII2voE2N4ioFH9xKrXi9ytOrgg5v+s/zLUGoMD229wDJH+nlYuk+ItTqRW/BdqCWzId5ivDdbjn0g5CGueuWaZDTvgVp1IrfoAA/PPVHWxycx2uNgAYvEFIwcNurwfkhF+xKsXiL1PsWNmZ3uu9cuF6AwAIWnwS2ObmOmS3vziVYvH7FX3xcVznxbo8aQBzDhDWPu4EXHmwXIq/OJVi8SvQQZtbrt9Jjxfr86QBACzcz0ENd+PwCQ0p/uIU7wrRdt/tJVX8ABWKv7qqixe8Wp9nDQBgYRtrILM3l4xGTvgVl/CuJgBine0cvO92Yp3thhN5q1zx3LIObwfb9fwtiRpUax3/juLuXJYjW/7iY1VUUrnsOgZe30rilOdXj40KKNqv7mCOm5f8kjHyXdGzvgAABdxJREFUmtT9sykP26wDrslmfil+UUx8it7xPuovb/P+nhlPDwGGzTlA2IpzG7An03ml+EUxsSBebrPCRPEPrd+Mxk6OWRa3ksGdglL8opgohQ7Y3HFVFy2mMhhrAACNB2hViruAMQfPlxN+otgEFZ9eeYj/MZnBaAMAmH+QdVrzXkZ5tZHc4SeKTdDioRUhvm06h5GTgMm01vN+DT/igqYku/2i2JQrfrCig4+ZzgF51AAAWhv4kNY8zFAuKX5RbMotHlsR4n2mcwzLqwYA0FrPpzR8S4pfFJug4pmVHfy+6RznyrsGALC9jkd6EnzQdA4hnFKmWHd1B281neNCedkAAF6p4cmwLuyXjgoBELT4zcoQN5vOkYzxqwCprOjg9qDFf5rOIUQuyhSP52vxQx43AICVIe4uh++aziFENsotHr66gz80nWM0ed0AAFZ08sdBi4dM5xAiExV+/mFFiI+YzjGWvD0HcKHNNTwQ03zTLqDMovQo0AHFg1d38C3TWdJRUMW0ZQa3RH08mdAETGcR4kI+RaxMccfyEM+YzpKugmoAAC/PZIG22BzXjDedRYhhfugJalaafLAnGwXXAAC2XszEWITXYpoG01mECChCExRXLArRbTpLpgqyAQBo8G2exfoovMl0FlG6yhXPLe/gbQoK8r7VvL8KkIqCxNWdvLnCxxcUaNN5RGmxQFcovrCigxsLtfihgPcAzrWphqttWBvXVJnOIoqfX9EftLnZy9F73VIUDQCGzgtEeTFms9h0FlG8Aha7A2UsX7aPU6azOKFoGsCwLbX8S1jzEa2L788mzLFAB+CfvXhdl5eKskhebeCacJxn4ppJprOIwudXnKrQ/N6STl4yncVpRdkAADRYr8ziZ1F4p5whFNlQQFDxq+Ud3KZGGbKukBXsVYCxKLBXdvKuCsV7fIqw6TyisPhgoMzHO1d08HvFWvxQxA1g2LIOfqoU1eWKp01nEYUhqHhej2f6ynaeMJ3FbUV7CJDM9lpuCGt+GtNMNZ1F5B8/HA8q3nNVB+tMZ/FKSTWAYVtq+XrE5i/sEtgDEmOzwA5aPLw8lB8j9XqpJBsAwMY6LvHb/DyiucJ0FmFO0GKbr4x3LdtHm+ksJpRsAxi2ZRY3xRU/jGlqTWcR3gnA4TLF3aW0u59MyTeAYZtm8Qlb8ZDcTlzc/Io+n+ZzKzv5juks+UAawDk0+LbM4tsxxYcTmjLTeYRzfIpIQPH95SEeLOSHd5wmDSAJDf6ttXwtqvlUQlNuOo/InqWIBBU/qgzxyUVpvIS21EgDGIUG35YavhSHB+OaStN5RPr8inBA8agK8SfLIGY6T76SBpAGDb7NNXxJwydimmrTeURqAcVxn+Lby0N8TXb1xyYNIENbZ/G2uOKhqFw+zBsKCFjs8yv+bFkJ3L3nJGkAWdpcwzwU34nZrLbBbzpPKbIUMT+sTVh88rp29prOU4ikAeRIg7W1lnsTmj+La+bLewvcF4CDfovvLgvxDdnNz438Y3XQ1qnMTJTztYTmzrhmouk8xcSvOOFX/DQW44vXHeaI6TzFQhqASzbXMM9S/Fnc5vYYTDedpxD54bQPnisr4ytLDvA703mKkTQAD2yq5VIFn7Vtfj8BF8lhQnIWaL/ikKX4b+3j71YeZL/pTMVO/iF6bDcET9TybjR3x2FlvMQvK/oU/X543VL8MlLF967fSY/pTKVEGoBhmxuYQ4yPoVid0DTGYYLpTG4KKE4paPXBc7qc76/YS7vpTKVMGkCeeamWCgvuVJrbtOKqhGamrakoxHEN/Yp+BZ0+2KosnprUzi8uhYjpXOIsaQAFoAnKIrN4cwxu1IqlGubZmmoNlTb4TGZTkPBBv1IctzS7lGKbD9bqDl6QW3DznzSAAvdiI+MrelmuLa5MaBagmQVUa5ikYbwNVWjKUYONQmt8eui/+/D/K4Ue+kUrRYLBDxNKMaCgX8Fp4JRSHFfQqTUtlmJ770S2rmqi19AfXTjgfwFVFcHePttw0QAAAABJRU5ErkJggg==
+          mediatype: image/png
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: strimzi-cluster-operator
+              rules:
+              - apiGroups:
+                - ""
+                resources:
+                - serviceaccounts
+                verbs:
+                - get
+                - create
+                - delete
+                - patch
+                - update
+              - apiGroups:
+                - rbac.authorization.k8s.io
+                resources:
+                - clusterrolebindings
+                - rolebindings
+                verbs:
+                - get
+                - create
+                - delete
+                - patch
+                - update
+              - apiGroups:
+                - ""
+                resources:
+                - configmaps
+                verbs:
+                - get
+                - list
+                - watch
+                - create
+                - delete
+                - patch
+                - update
+              - apiGroups:
+                - kafka.strimzi.io
+                resources:
+                - kafkas
+                - kafkaconnects
+                - kafkaconnects2is
+                verbs:
+                - get
+                - list
+                - watch
+                - create
+                - delete
+                - patch
+                - update
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                verbs:
+                - get
+                - list
+                - watch
+                - delete
+              - apiGroups:
+                - ""
+                resources:
+                - services
+                verbs:
+                - get
+                - list
+                - watch
+                - create
+                - delete
+                - patch
+                - update
+              - apiGroups:
+                - ""
+                resources:
+                - endpoints
+                verbs:
+                - get
+                - list
+                - watch
+              - apiGroups:
+                - extensions
+                resources:
+                - deployments
+                - deployments/scale
+                - replicasets
+                verbs:
+                - get
+                - list
+                - watch
+                - create
+                - delete
+                - patch
+                - update
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - deployments/scale
+                - deployments/status
+                - statefulsets
+                verbs:
+                - get
+                - list
+                - watch
+                - create
+                - delete
+                - patch
+                - update
+              - apiGroups:
+                - ""
+                resources:
+                - events
+                verbs:
+                - create
+              - apiGroups:
+                - extensions
+                resources:
+                - replicationcontrollers
+                verbs:
+                - get
+                - list
+                - watch
+                - create
+                - delete
+                - patch
+                - update
+              - apiGroups:
+                - apps.openshift.io
+                resources:
+                - deploymentconfigs
+                - deploymentconfigs/scale
+                - deploymentconfigs/status
+                - deploymentconfigs/finalizers
+                verbs:
+                - get
+                - list
+                - watch
+                - create
+                - delete
+                - patch
+                - update
+              - apiGroups:
+                - build.openshift.io
+                resources:
+                - buildconfigs
+                - builds
+                verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - watch
+                - update
+              - apiGroups:
+                - image.openshift.io
+                resources:
+                - imagestreams
+                - imagestreams/status
+                verbs:
+                - create
+                - delete
+                - get
+                - list
+                - watch
+                - patch
+                - update
+              - apiGroups:
+                - ""
+                resources:
+                - replicationcontrollers
+                verbs:
+                - get
+                - list
+                - watch
+                - create
+                - delete
+                - patch
+                - update
+              - apiGroups:
+                - ""
+                resources:
+                - secrets
+                verbs:
+                - get
+                - list
+                - create
+                - delete
+                - patch
+                - update
+              - apiGroups:
+                - ""
+                resources:
+                - nodes
+                verbs:
+                - get
+              - apiGroups:
+                - kafka.strimzi.io
+                resources:
+                - kafkatopics
+                verbs:
+                - get
+                - list
+                - watch
+                - create
+                - patch
+                - update
+                - delete
+              - apiGroups:
+                - ""
+                resources:
+                - events
+                verbs:
+                - create
+              - apiGroups:
+                - kafka.strimzi.io
+                resources:
+                - kafkausers
+                verbs:
+                - get
+                - list
+                - watch
+                - create
+                - patch
+                - update
+                - delete
+            deployments:
+            - name: strimzi-cluster-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: strimzi-cluster-operator-alm-owned
+                template:
+                  metadata:
+                    name: strimzi-cluster-operator-alm-owned
+                    labels:
+                      name: strimzi-cluster-operator-alm-owned
+                  spec:
+                    serviceAccountName: strimzi-cluster-operator
+                    containers:
+                    - name: cluster-operator
+                      image: registry.access.redhat.com/amqstreams-1-tech-preview/amqstreams10-clusteroperator-openshift:1.0.0-beta
+                      env:
+                        - name: STRIMZI_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                        - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
+                          value: "120000"
+                        - name: STRIMZI_OPERATION_TIMEOUT_MS
+                          value: "300000"
+                        - name: STRIMZI_DEFAULT_ZOOKEEPER_IMAGE
+                          value: registry.access.redhat.com/amqstreams-1-tech-preview/amqstreams10-zookeeper-openshift:1.0.0-beta
+                        - name: STRIMZI_DEFAULT_KAFKA_IMAGE
+                          value: registry.access.redhat.com/amqstreams-1-tech-preview/amqstreams10-kafka-openshift:1.0.0-beta
+                        - name: STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE
+                          value: registry.access.redhat.com/amqstreams-1-tech-preview/amqstreams10-kafkaconnect-openshift:1.0.0-beta
+                        - name: STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE
+                          value: registry.access.redhat.com/amqstreams-1-tech-preview/amqstreams10-kafkaconnects2i-openshift:1.0.0-beta
+                        - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
+                          value: registry.access.redhat.com/amqstreams-1-tech-preview/amqstreams10-topicoperator-openshift:1.0.0-beta
+                        - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
+                          value: registry.access.redhat.com/amqstreams-1-tech-preview/amqstreams10-useroperator-openshift:1.0.0-beta
+                        - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
+                          value: registry.access.redhat.com/amqstreams-1-tech-preview/amqstreams10-kafkainit-openshift:1.0.0-beta
+                        - name: STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE
+                          value: registry.access.redhat.com/amqstreams-1-tech-preview/amqstreams10-zookeeperstunnel-openshift:1.0.0-beta
+                        - name: STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE
+                          value: registry.access.redhat.com/amqstreams-1-tech-preview/amqstreams10-kafkastunnel-openshift:1.0.0-beta
+                        - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+                          value: registry.access.redhat.com/amqstreams-1-tech-preview/amqstreams10-entityoperatorstunnel-openshift:1.0.0-beta
+                        - name: STRIMZI_LOG_LEVEL
+                          value: INFO
+        customresourcedefinitions:
+          owned:
+          - name: kafkas.kafka.strimzi.io
+            version: v1alpha1
+            kind: Kafka
+            displayName: Kafka
+            description: Represents a Kafka cluster
+            specDescriptors:
+              - description: The desired number of Kafka brokers.
+                displayName: Kafka Brokers
+                path: kafka.replicas
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:label'
+              - description: The type of storage used by Kafka brokers
+                displayName: Kafka storage
+                path: kafka.storage.type
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:label'
+              - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+                displayName: Kafka Resource Requirements
+                path: kafka.resources
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+              - description: The desired number of Zookeeper nodes.
+                displayName: Zookeeper Nodes
+                path: zookeeper.replicas
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:label'
+              - description: The type of storage used by Zookeeper nodes
+                displayName: Zookeeper storage
+                path: zookeeper.storage.type
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:label'
+              - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+                displayName: Zookeeper Resource Requirements
+                path: zookeeper.resources
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+          - name: kafkaconnects.kafka.strimzi.io
+            version: v1alpha1
+            kind: KafkaConnect
+            displayName: Kafka Connect
+            description: Represents a Kafka Connect cluster
+            specDescriptors:
+              - description: The desired number of Kafka Connect nodes.
+                displayName: Connect nodes
+                path: replicas
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+              - description: The address of the bootstrap server
+                displayName: Bootstrap server
+                path: bootstrapServers
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:label'
+              - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+                displayName: Resource Requirements
+                path: resources
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+          - name: kafkaconnects2is.kafka.strimzi.io
+            version: v1alpha1
+            kind: KafkaConnectS2I
+            displayName: Kafka Connect S2I
+            description: Represents a Kafka Connect cluster with Source 2 Image support
+            specDescriptors:
+              - description: The desired number of Kafka Connect nodes.
+                displayName: Connect nodes
+                path: replicas
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+              - description: The address of the bootstrap server
+                displayName: Bootstrap server
+                path: bootstrapServers
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:label'
+              - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+                displayName: Resource Requirements
+                path: resources
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+          - name: kafkatopics.kafka.strimzi.io
+            version: v1alpha1
+            kind: KafkaTopic
+            displayName: Kafka Topic
+            description: Represents a topic inside a Kafka cluster
+            specDescriptors:
+              - description: The number of partitions
+                displayName: Partitions
+                path: partitions
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:label'
+              - description: The number of replicas
+                displayName: Replication factor
+                path: replicas
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - name: kafkausers.kafka.strimzi.io
+            version: v1alpha1
+            kind: KafkaUser
+            displayName: Kafka User
+            description: Represents a user inside a Kafka cluster
+            specDescriptors:
+              - description: Authentication type
+                displayName: Authentication type
+                path: authentication.type
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:label'
+              - description: Authorization type
+                displayName: Authorization type
+                path: authorization.type
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:label'
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        name: etcdoperator.v0.6.1
+        namespace: placeholder
+        annotations:		
+          tectonic-visibility: ocs		
+      spec:
+        displayName: etcd
+        description: |
+          etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. It’s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader. Your applications can read and write data into etcd.
+          A simple use-case is to store database connection details or feature flags within etcd as key value pairs. These values can be watched, allowing your app to reconfigure itself when they change. Advanced uses take advantage of the consistency guarantees to implement database leader elections or do distributed locking across a cluster of workers.
+      
+          _The etcd Open Cloud Service is Public Alpha. The goal before Beta is to fully implement backup features._
+      
+          ### Reading and writing to etcd
+      
+          Communicate with etcd though its command line utility `etcdctl` or with the API using the automatically generated Kubernetes Service.
+      
+          [Read the complete guide to using the etcd Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/etcd-ocs.html)
+      
+          ### Supported Features
+          **High availability**
+          Multiple instances of etcd are networked together and secured. Individual failures or networking issues are transparently handled to keep your cluster up and running.
+          **Automated updates**
+          Rolling out a new etcd version works like all Kubernetes rolling updates. Simply declare the desired version, and the etcd service starts a safe rolling update to the new version automatically.
+          **Backups included**
+          Coming soon, the ability to schedule backups to happen on or off cluster.
+        keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
+        version: 0.6.1
+        maturity: alpha
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+        labels:
+          alm-status-descriptors: etcdoperator.v0.6.1
+          alm-owner-etcd: etcdoperator
+          operated-by: etcdoperator
+        selector:
+          matchLabels:
+            alm-owner-etcd: etcdoperator
+            operated-by: etcdoperator
+        links:
+        - name: Blog
+          url: https://coreos.com/etcd
+        - name: Documentation
+          url: https://coreos.com/operators/etcd/docs/latest/
+        - name: etcd Operator Source Code
+          url: https://github.com/coreos/etcd-operator
+      
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAOEAAADZCAYAAADWmle6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAEKlJREFUeNrsndt1GzkShmEev4sTgeiHfRYdgVqbgOgITEVgOgLTEQydwIiKwFQCayoCU6+7DyYjsBiBFyVVz7RkXvqCSxXw/+f04XjGQ6IL+FBVuL769euXgZ7r39f/G9iP0X+u/jWDNZzZdGI/Ftama1jjuV4BwmcNpbAf1Fgu+V/9YRvNAyzT2a59+/GT/3hnn5m16wKWedJrmOCxkYztx9Q+py/+E0GJxtJdReWfz+mxNt+QzS2Mc0AI+HbBBwj9QViKbH5t64DsP2fvmGXUkWU4WgO+Uve2YQzBUGd7r+zH2ZG/tiUQc4QxKwgbwFfVGwwmdLL5wH78aPC/ZBem9jJpCAX3xtcNASSNgJLzUPSQyjB1zQNl8IQJ9MIU4lx2+Jo72ysXYKl1HSzN02BMa/vbZ5xyNJIshJzwf3L0dQhJw4Sih/SFw9Tk8sVeghVPoefaIYCkMZCKbrcP9lnZuk0uPUjGE/KE8JQry7W2tgfuC3vXgvNV+qSQbyFtAtyWk7zWiYevvuUQ9QEQCvJ+5mmu6dTjz1zFHLFj8Eb87MtxaZh/IQFIHom+9vgTWwZxAQjT9X4vtbEVPojwjiV471s00mhAckpwGuCn1HtFtRDaSh6y9zsL+LNBvCG/24ThcxHObdlWc1v+VQJe8LcO0jwtuF8BwnAAUgP9M8JPU2Me+Oh12auPGT6fHuTePE3bLDy+x9pTLnhMn+07TQGh//Bz1iI0c6kvtqInjvPZcYR3KsPVmUsPYt9nFig9SCY8VQNhpPBzn952bbgcsk2EvM89wzh3UEffBbyPqvBUBYQ8ODGPFOLsa7RF096WJ69L+E4EmnpjWu5o4ChlKaRTKT39RMMaVPEQRsz/nIWlDN80chjdJlSd1l0pJCAMVZsniobQVuxceMM9OFoaMd9zqZtjMEYYDW38Drb8Y0DYPLShxn0pvIFuOSxd7YCPet9zk452wsh54FJoeN05hcgSQoG5RR0Qh9Q4E4VvL4wcZq8UACgaRFEQKgSwWrkr5WFnGxiHSutqJGlXjBgIOayhwYBTA0ER0oisIVSUV0AAMT0IASCUO4hRIQSAEECMCCEPwqyQA0JCQBzEGjWNAqHiUVAoXUWbvggOIQCEAOJzxTjoaQ4AIaE64/aZridUsBYUgkhB15oGg1DBIl8IqirYwV6hPSGBSFteMCUBSVXwfYixBmamRubeMyjzMJQBDDowE3OesDD+zwqFoDqiEwXoXJpljB+PvWJGy75BKF1FPxhKygJuqUdYQGlLxNEXkrYyjQ0GbaAwEnUIlLRNvVjQDYUAsJB0HKLE4y0AIpQNgCIhBIhQTgCKhZBBpAN/v6LtQI50JfUgYOnnjmLUFHKhjxbAmdTCaTiBm3ovLPqG2urWAij6im0Nd9aTN9ygLUEt9LgSRnohxUPIKxlGaE+/6Y7znFf0yX+GnkvFFWmarkab2o9PmTeq8sbd2a7DaysXz7i64VeznN4jCQhN9gdDbRiuWrfrsq0mHIrlaq+hlotCtd3Um9u0BYWY8y5D67wccJoZjFca7iUs9VqZcfsZwTd1sbWGG+OcYaTnPAP7rTQVVlM4Sg3oGvB1tmNh0t/HKXZ1jFoIMwCQjtqbhNxUmkGYqgZEDZP11HN/S3gAYRozf0l8C5kKEKUvW0t1IfeWG/5MwgheZTT1E0AEhDkAePQO+Ig2H3DncAkQM4cwUQCD530dU4B5Yvmi2LlDqXfWrxMCcMth51RToRMNUXFnfc2KJ0+Ryl0VNOUwlhh6NoxK5gnViTgQpUG4SqSyt5z3zRJpuKmt3Q1614QaCBPaN6je+2XiFcWAKOXcUfIYKRyL/1lb7pe5VxSxxjQ6hImshqGRt5GWZVKO6q2wHwujfwDtIvaIdexj8Cm8+a68EqMfox6x/voMouZF4dHnEGNeCDMwT6vdNfekH1MafMk4PI06YtqLVGl95aEM9Z5vAeCTOA++YLtoVJRrsqNCaJ6WRmkdYaNec5BT/lcTRMqrhmwfjbpkj55+OKp8IEbU/JLgPJE6Wa3TTe9sHS+ShVD5QIyqIxMEwKh12olC6mHIed5ewEop80CNlfIOADYOT2nd6ZXCop+Ebqchc0JqxKcKASxChycJgUh1rnHA5ow9eTrhqNI7JWiAYYwBGGdpyNLoGw0Pkh96h1BpHihyywtATDM/7Hk2fN9EnH8BgKJCU4ooBkbXFMZJiPbrOyecGl3zgQDQL4hk10IZiOe+5w99Q/gBAEIJgPhJM4QAEEoFREAIAAEiIASAkD8Qt4AQAEIAERAGFlX4CACKAXGVM4ivMwWwCLFAlyeoaa70QePKm5Dlp+/n+ye/5dYgva6YsUaVeMa+tzNFeJtWwc+udbJ0Fg399kLielQJ5Ze61c2+7ytA6EZetiPxZC6tj22yJCv6jUwOyj/zcbqAxOMyAKEbfeHtNa7DtYXptjsk2kJxR+eIeim/tHNofUKYy8DMrQcAKWz6brpvzyIAlpwPhQ49l6b7skJf5Z+YTOYQc4FwLDxvoTDwaygQK+U/kVr+ytSFBG01Q3gnJJR4cNiAhx4HDub8/b5DULXlj6SVZghFiE+LdvE9vo/o8Lp1RmH5hzm0T6wdbZ6n+D6i44zDRc3ln6CpAEJfXiRU45oqLz8gFAThWsh7ughrRibc0QynHgZpNJa/ENJ+loCwu/qOGnFIjYR/n7TfgycULhcQhu6VC+HfF+L3BoAQ4WiZTw1M+FPCnA2gKC6/FAhXgDC+ojQGh3NuWsvfF1L/D5ohlCKtl1j2ldu9a/nPAKFwN56Bst10zCG0CPleXN/zXPgHQZXaZaBgrbzyY5V/mUA+6F0hwtGN9rwu5DVZPuwWqfxdFz1LWbJ2lwKEa+0Qsm4Dl3fp+Pu0lV97PgwIPfSsS+UQhj5Oo+vvFULazRIQyvGEcxPuNLCth2MvFsrKn8UOilAQShkh7TTczYNMoS6OdP47msrPi82lXKGWhCdMZYS0bFy+vcnGAjP1CIfvgbKNA9glecEH9RD6Ol4wRuWyN/G9MHnksS6o/GPf5XcwNSUlHzQhDuAKtWJmkwKElU7lylP5rgIcsquh/FI8YZCDpkJBuE4FQm7Icw8N+SrUGaQKyi8FwiDt1ve5o+Vu7qYHy/psgK8cvh+FTYuO77bhEC7GuaPiys/L1X4IgXDL+e3M5+ovLxBy5VLuIebw1oqcHoPfoaMJUsHays878r8KbDc3xtPx/84gZPBG/JwaufrsY/SRG/OY3//8QMNdsvdZCFtbW6f8pFuf5bflILAlX7O+4fdfugKyFYS8T2zAsXthdG0VurPGKwI06oF5vkBgHWkNp6ry29+lsPZMU3vijnXFNmoclr+6+Ou/FIb8yb30sS8YGjmTqCLyQsi5N/6ZwKs0Yenj68pfPjF6N782Dp2FzV9CTyoSeY8mLK16qGxIkLI8oa1n8tz9juP40DlK0epxYEbojbq+9QfurBeVIlCO9D2396bxiV4lkYQ3hOAFw2pbhqMGISkkQOMcQ9EqhDmGZZdo92JC0YHRNTfoSg+5e0IT+opqCKHoIU+4ztQIgBD1EFNrQAgIpYSil9lDmPHqkROPt+JC6AgPquSuumJmg0YARVCuneDfvPVeJokZ6pIXDkNxQtGzTF9/BQjRG0tQznfb74RwCQghpALBtIQnfK4zhxdyQvVCUeknMIT3hLyY+T5jo0yABqKPQNpUNw/09tGZod5jgCaYFxyYvJcNPkv9eof+I3pnCFEHIETjSM8L9tHZHYCQT9PaZGycU6yg8S4akDnJ+P03L0+t23XGzCLzRgII/Wqa+fv/xlfvmKvMUOcOrlCDdoei1MGdZm6G5VEIfRzzjd4aQs69n699Rx7ewhvCGzr2gmTPs8zNsJOrXt24FbkhhOjCfT4ICA/rPbyhUy94Dks0gJCX1NzCZui9YUd3oei+c257TalFbgg19ILHrlrL2gvWgXAL26EX76gZTNASQnad8Ibwhl284NhgXpB0c+jKhWO3Ms1hP9ihJYB9eMF6qd1BCPk0qA1s+LimFIu7m4nsdQIzPK4VbQ8hYvrnuSH2G9b2ggP78QmWqBdF9Vx8SSY6QYdUW7BTA1schZATyhvY8lHvcRbNUS9YGFy2U+qmzh2YPVc0I7yAOFyHfRpyUwtCSzOdPXMHmz7qDIM0e0V2wZTEk+6Ym6N63eBLp/b5Bts+2cKCSJ/LuoZO3ANSiE5hKAZjnvNSS4931jcw9jpwT0feV/qSJ1pVtCyfHKDkvK8Ejx7pUxGh2xFNSwx8QTi2H9ceC0/nni64MS/5N5dG39pDqvRV+WgGk71c9VFXF9b+xYvOw/d61iv7m3MvEHryhvecwC52jSSx4VIIgwnMNT/UsTxIgpPt3K/ARj15CptwL3Zd/ceDSATj2DGQjbxgWwhdeMMte7zpy5On9vymRm/YxBYljGVjKWF9VJf7I1+sex3wY8w/V1QPTborW/72gkdsRDaZMJBdbdHIC7aCkAu9atlLbtnrzerMnyToDaGwelOnk3/hHSem/ZK7e/t7jeeR20LYBgqa8J80gS8jbwi5F02Uj1u2NYJxap8PLkJfLxA2hIJyvnHX/AfeEPLpBfe0uSFHbnXaea3Qd5d6HcpYZ8L6M7lnFwMQ3MNg+RxUR1+6AshtbsVgfXTEg1sIGax9UND2p7f270wdG3eK9gXVGHdw2k5sOyZv+Nbs39Z308XR9DqWb2J+PwKDhuKHPobfuXf7gnYGHdCs7bhDDadD4entDug7LWNsnRNW4mYqwJ9dk+GGSTPBiA2j0G8RWNM5upZtcG4/3vMfP7KnbK2egx6CCnDPhRn7NgD3cghLIad5WcM2SO38iqHvvMOosyeMpQ5zlVCaaj06GVs9xUbHdiKoqrHWgquFEFMWUEWfXUxJAML23hAHFOctmjZQffKD2pywkhtSGHKNtpitLroscAeE7kCkSsC60vxEl6yMtL9EL5HKGCMszU5bk8gdkklAyEn5FO0yK419rIxBOIqwFMooDE0tHEVYijAUECIshRCGIhxFWIowFJ5QkEYIS5PTJrUwNGlPyN6QQPyKtpuM1E/K5+YJDV/MiA3AaehzqgAm7QnZG9IGYKo8bHnSK7VblLL3hOwNHziPuEGOqE5brrdR6i+atCfckyeWD47HkAkepRGLY/e8A8J0gCwYSNypF08bBm+e6zVz2UL4AshhBUjML/rXLefqC82bcQFhGC9JDwZ1uuu+At0S5gCETYHsV4DUeD9fDN2Zfy5OXaW2zAwQygCzBLJ8cvaW5OXKC1FxfTggFAHmoAJnSiOw2wps9KwRWgJCLaEswaj5NqkLwAYIU4BxqTSXbHXpJdRMPZgAOiAMqABCNGYIEEJutEK5IUAIwYMDQgiCACEEAcJs1Vda7gGqDhCmoiEghAAhBAHCrKXVo2C1DCBMRlp37uMIEECoX7xrX3P5C9QiINSuIcoPAUI0YkAICLNWgfJDh4T9hH7zqYH9+JHAq7zBqWjwhPAicTVCVQJCNF50JghHocahKK0X/ZnQKyEkhSdUpzG8OgQI42qC94EQjsYLRSmH+pbgq73L6bYkeEJ4DYTYmeg1TOBFc/usTTp3V9DdEuXJ2xDCUbXhaXk0/kAYmBvuMB4qkC35E5e5AMKkwSQgyxufyuPy6fMMgAFCSI73LFXU/N8AmEL9X4ABACNSKMHAgb34AAAAAElFTkSuQmCC
+          mediatype: image/png
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: etcd-operator
+              rules:
+              - apiGroups:
+                - etcd.database.coreos.com
+                resources:
+                - etcdclusters
+                verbs:
+                - "*"
+              - apiGroups:
+                - storage.k8s.io
+                resources:
+                - storageclasses
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - secrets
+                verbs:
+                - get
+            deployments:
+            - name: etcd-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: etcd-operator-alm-owned
+                template:
+                  metadata:
+                    name: etcd-operator-alm-owned
+                    labels:
+                      name: etcd-operator-alm-owned
+                  spec:
+                    serviceAccountName: etcd-operator
+                    containers:
+                    - name: etcd-operator
+                      command:
+                      - etcd-operator
+                      - --create-crd=false
+                      image: quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+        customresourcedefinitions:
+          owned:
+          - name: etcdclusters.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdCluster
+            displayName: etcd Cluster
+            description: Represents a cluster of etcd nodes.
+            resources:
+              - kind: Service
+                version: v1
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of member Pods for the etcd cluster.
+                displayName: Size
+                path: size
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            statusDescriptors:
+              - description: The status of each of the member Pods for the etcd cluster.
+                displayName: Member Status
+                path: members
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+              - description: The service at which the running etcd cluster can be accessed.
+                displayName: Service
+                path: service
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The current size of the etcd cluster.
+                displayName: Cluster Size
+                path: size
+              - description: The current version of the etcd cluster.
+                displayName: Current Version
+                path: currentVersion
+              - description: 'The target version of the etcd cluster, after upgrading.'
+                displayName: Target Version
+                path: targetVersion
+              - description: The current status of the etcd cluster.
+                displayName: Status
+                path: phase
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase'
+              - description: Explanation for the current status of the cluster.
+                displayName: Status Details
+                path: reason
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        name: etcdoperator.v0.9.0
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
+      spec:
+        displayName: etcd
+        description: |
+          etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. It’s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader. Your applications can read and write data into etcd.
+          A simple use-case is to store database connection details or feature flags within etcd as key value pairs. These values can be watched, allowing your app to reconfigure itself when they change. Advanced uses take advantage of the consistency guarantees to implement database leader elections or do distributed locking across a cluster of workers.
+      
+          _The etcd Open Cloud Service is Public Alpha. The goal before Beta is to fully implement backup features._
+      
+          ### Reading and writing to etcd
+      
+          Communicate with etcd though its command line utility `etcdctl` or with the API using the automatically generated Kubernetes Service.
+      
+          [Read the complete guide to using the etcd Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/etcd-ocs.html)
+      
+          ### Supported Features
+      
+      
+          **High availability**
+      
+      
+          Multiple instances of etcd are networked together and secured. Individual failures or networking issues are transparently handled to keep your cluster up and running.
+      
+      
+          **Automated updates**
+      
+      
+          Rolling out a new etcd version works like all Kubernetes rolling updates. Simply declare the desired version, and the etcd service starts a safe rolling update to the new version automatically.
+      
+      
+          **Backups included**
+      
+      
+          Coming soon, the ability to schedule backups to happen on or off cluster.
+        keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
+        version: 0.9.0
+        maturity: alpha
+        replaces: etcdoperator.v0.6.1
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+        labels:
+          alm-owner-etcd: etcdoperator
+          operated-by: etcdoperator
+        selector:
+          matchLabels:
+            alm-owner-etcd: etcdoperator
+            operated-by: etcdoperator
+        links:
+        - name: Blog
+          url: https://coreos.com/etcd
+        - name: Documentation
+          url: https://coreos.com/operators/etcd/docs/latest/
+        - name: etcd Operator Source Code
+          url: https://github.com/coreos/etcd-operator
+      
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAOEAAADZCAYAAADWmle6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAEKlJREFUeNrsndt1GzkShmEev4sTgeiHfRYdgVqbgOgITEVgOgLTEQydwIiKwFQCayoCU6+7DyYjsBiBFyVVz7RkXvqCSxXw/+f04XjGQ6IL+FBVuL769euXgZ7r39f/G9iP0X+u/jWDNZzZdGI/Ftama1jjuV4BwmcNpbAf1Fgu+V/9YRvNAyzT2a59+/GT/3hnn5m16wKWedJrmOCxkYztx9Q+py/+E0GJxtJdReWfz+mxNt+QzS2Mc0AI+HbBBwj9QViKbH5t64DsP2fvmGXUkWU4WgO+Uve2YQzBUGd7r+zH2ZG/tiUQc4QxKwgbwFfVGwwmdLL5wH78aPC/ZBem9jJpCAX3xtcNASSNgJLzUPSQyjB1zQNl8IQJ9MIU4lx2+Jo72ysXYKl1HSzN02BMa/vbZ5xyNJIshJzwf3L0dQhJw4Sih/SFw9Tk8sVeghVPoefaIYCkMZCKbrcP9lnZuk0uPUjGE/KE8JQry7W2tgfuC3vXgvNV+qSQbyFtAtyWk7zWiYevvuUQ9QEQCvJ+5mmu6dTjz1zFHLFj8Eb87MtxaZh/IQFIHom+9vgTWwZxAQjT9X4vtbEVPojwjiV471s00mhAckpwGuCn1HtFtRDaSh6y9zsL+LNBvCG/24ThcxHObdlWc1v+VQJe8LcO0jwtuF8BwnAAUgP9M8JPU2Me+Oh12auPGT6fHuTePE3bLDy+x9pTLnhMn+07TQGh//Bz1iI0c6kvtqInjvPZcYR3KsPVmUsPYt9nFig9SCY8VQNhpPBzn952bbgcsk2EvM89wzh3UEffBbyPqvBUBYQ8ODGPFOLsa7RF096WJ69L+E4EmnpjWu5o4ChlKaRTKT39RMMaVPEQRsz/nIWlDN80chjdJlSd1l0pJCAMVZsniobQVuxceMM9OFoaMd9zqZtjMEYYDW38Drb8Y0DYPLShxn0pvIFuOSxd7YCPet9zk452wsh54FJoeN05hcgSQoG5RR0Qh9Q4E4VvL4wcZq8UACgaRFEQKgSwWrkr5WFnGxiHSutqJGlXjBgIOayhwYBTA0ER0oisIVSUV0AAMT0IASCUO4hRIQSAEECMCCEPwqyQA0JCQBzEGjWNAqHiUVAoXUWbvggOIQCEAOJzxTjoaQ4AIaE64/aZridUsBYUgkhB15oGg1DBIl8IqirYwV6hPSGBSFteMCUBSVXwfYixBmamRubeMyjzMJQBDDowE3OesDD+zwqFoDqiEwXoXJpljB+PvWJGy75BKF1FPxhKygJuqUdYQGlLxNEXkrYyjQ0GbaAwEnUIlLRNvVjQDYUAsJB0HKLE4y0AIpQNgCIhBIhQTgCKhZBBpAN/v6LtQI50JfUgYOnnjmLUFHKhjxbAmdTCaTiBm3ovLPqG2urWAij6im0Nd9aTN9ygLUEt9LgSRnohxUPIKxlGaE+/6Y7znFf0yX+GnkvFFWmarkab2o9PmTeq8sbd2a7DaysXz7i64VeznN4jCQhN9gdDbRiuWrfrsq0mHIrlaq+hlotCtd3Um9u0BYWY8y5D67wccJoZjFca7iUs9VqZcfsZwTd1sbWGG+OcYaTnPAP7rTQVVlM4Sg3oGvB1tmNh0t/HKXZ1jFoIMwCQjtqbhNxUmkGYqgZEDZP11HN/S3gAYRozf0l8C5kKEKUvW0t1IfeWG/5MwgheZTT1E0AEhDkAePQO+Ig2H3DncAkQM4cwUQCD530dU4B5Yvmi2LlDqXfWrxMCcMth51RToRMNUXFnfc2KJ0+Ryl0VNOUwlhh6NoxK5gnViTgQpUG4SqSyt5z3zRJpuKmt3Q1614QaCBPaN6je+2XiFcWAKOXcUfIYKRyL/1lb7pe5VxSxxjQ6hImshqGRt5GWZVKO6q2wHwujfwDtIvaIdexj8Cm8+a68EqMfox6x/voMouZF4dHnEGNeCDMwT6vdNfekH1MafMk4PI06YtqLVGl95aEM9Z5vAeCTOA++YLtoVJRrsqNCaJ6WRmkdYaNec5BT/lcTRMqrhmwfjbpkj55+OKp8IEbU/JLgPJE6Wa3TTe9sHS+ShVD5QIyqIxMEwKh12olC6mHIed5ewEop80CNlfIOADYOT2nd6ZXCop+Ebqchc0JqxKcKASxChycJgUh1rnHA5ow9eTrhqNI7JWiAYYwBGGdpyNLoGw0Pkh96h1BpHihyywtATDM/7Hk2fN9EnH8BgKJCU4ooBkbXFMZJiPbrOyecGl3zgQDQL4hk10IZiOe+5w99Q/gBAEIJgPhJM4QAEEoFREAIAAEiIASAkD8Qt4AQAEIAERAGFlX4CACKAXGVM4ivMwWwCLFAlyeoaa70QePKm5Dlp+/n+ye/5dYgva6YsUaVeMa+tzNFeJtWwc+udbJ0Fg399kLielQJ5Ze61c2+7ytA6EZetiPxZC6tj22yJCv6jUwOyj/zcbqAxOMyAKEbfeHtNa7DtYXptjsk2kJxR+eIeim/tHNofUKYy8DMrQcAKWz6brpvzyIAlpwPhQ49l6b7skJf5Z+YTOYQc4FwLDxvoTDwaygQK+U/kVr+ytSFBG01Q3gnJJR4cNiAhx4HDub8/b5DULXlj6SVZghFiE+LdvE9vo/o8Lp1RmH5hzm0T6wdbZ6n+D6i44zDRc3ln6CpAEJfXiRU45oqLz8gFAThWsh7ughrRibc0QynHgZpNJa/ENJ+loCwu/qOGnFIjYR/n7TfgycULhcQhu6VC+HfF+L3BoAQ4WiZTw1M+FPCnA2gKC6/FAhXgDC+ojQGh3NuWsvfF1L/D5ohlCKtl1j2ldu9a/nPAKFwN56Bst10zCG0CPleXN/zXPgHQZXaZaBgrbzyY5V/mUA+6F0hwtGN9rwu5DVZPuwWqfxdFz1LWbJ2lwKEa+0Qsm4Dl3fp+Pu0lV97PgwIPfSsS+UQhj5Oo+vvFULazRIQyvGEcxPuNLCth2MvFsrKn8UOilAQShkh7TTczYNMoS6OdP47msrPi82lXKGWhCdMZYS0bFy+vcnGAjP1CIfvgbKNA9glecEH9RD6Ol4wRuWyN/G9MHnksS6o/GPf5XcwNSUlHzQhDuAKtWJmkwKElU7lylP5rgIcsquh/FI8YZCDpkJBuE4FQm7Icw8N+SrUGaQKyi8FwiDt1ve5o+Vu7qYHy/psgK8cvh+FTYuO77bhEC7GuaPiys/L1X4IgXDL+e3M5+ovLxBy5VLuIebw1oqcHoPfoaMJUsHays878r8KbDc3xtPx/84gZPBG/JwaufrsY/SRG/OY3//8QMNdsvdZCFtbW6f8pFuf5bflILAlX7O+4fdfugKyFYS8T2zAsXthdG0VurPGKwI06oF5vkBgHWkNp6ry29+lsPZMU3vijnXFNmoclr+6+Ou/FIb8yb30sS8YGjmTqCLyQsi5N/6ZwKs0Yenj68pfPjF6N782Dp2FzV9CTyoSeY8mLK16qGxIkLI8oa1n8tz9juP40DlK0epxYEbojbq+9QfurBeVIlCO9D2396bxiV4lkYQ3hOAFw2pbhqMGISkkQOMcQ9EqhDmGZZdo92JC0YHRNTfoSg+5e0IT+opqCKHoIU+4ztQIgBD1EFNrQAgIpYSil9lDmPHqkROPt+JC6AgPquSuumJmg0YARVCuneDfvPVeJokZ6pIXDkNxQtGzTF9/BQjRG0tQznfb74RwCQghpALBtIQnfK4zhxdyQvVCUeknMIT3hLyY+T5jo0yABqKPQNpUNw/09tGZod5jgCaYFxyYvJcNPkv9eof+I3pnCFEHIETjSM8L9tHZHYCQT9PaZGycU6yg8S4akDnJ+P03L0+t23XGzCLzRgII/Wqa+fv/xlfvmKvMUOcOrlCDdoei1MGdZm6G5VEIfRzzjd4aQs69n699Rx7ewhvCGzr2gmTPs8zNsJOrXt24FbkhhOjCfT4ICA/rPbyhUy94Dks0gJCX1NzCZui9YUd3oei+c257TalFbgg19ILHrlrL2gvWgXAL26EX76gZTNASQnad8Ibwhl284NhgXpB0c+jKhWO3Ms1hP9ihJYB9eMF6qd1BCPk0qA1s+LimFIu7m4nsdQIzPK4VbQ8hYvrnuSH2G9b2ggP78QmWqBdF9Vx8SSY6QYdUW7BTA1schZATyhvY8lHvcRbNUS9YGFy2U+qmzh2YPVc0I7yAOFyHfRpyUwtCSzOdPXMHmz7qDIM0e0V2wZTEk+6Ym6N63eBLp/b5Bts+2cKCSJ/LuoZO3ANSiE5hKAZjnvNSS4931jcw9jpwT0feV/qSJ1pVtCyfHKDkvK8Ejx7pUxGh2xFNSwx8QTi2H9ceC0/nni64MS/5N5dG39pDqvRV+WgGk71c9VFXF9b+xYvOw/d61iv7m3MvEHryhvecwC52jSSx4VIIgwnMNT/UsTxIgpPt3K/ARj15CptwL3Zd/ceDSATj2DGQjbxgWwhdeMMte7zpy5On9vymRm/YxBYljGVjKWF9VJf7I1+sex3wY8w/V1QPTborW/72gkdsRDaZMJBdbdHIC7aCkAu9atlLbtnrzerMnyToDaGwelOnk3/hHSem/ZK7e/t7jeeR20LYBgqa8J80gS8jbwi5F02Uj1u2NYJxap8PLkJfLxA2hIJyvnHX/AfeEPLpBfe0uSFHbnXaea3Qd5d6HcpYZ8L6M7lnFwMQ3MNg+RxUR1+6AshtbsVgfXTEg1sIGax9UND2p7f270wdG3eK9gXVGHdw2k5sOyZv+Nbs39Z308XR9DqWb2J+PwKDhuKHPobfuXf7gnYGHdCs7bhDDadD4entDug7LWNsnRNW4mYqwJ9dk+GGSTPBiA2j0G8RWNM5upZtcG4/3vMfP7KnbK2egx6CCnDPhRn7NgD3cghLIad5WcM2SO38iqHvvMOosyeMpQ5zlVCaaj06GVs9xUbHdiKoqrHWgquFEFMWUEWfXUxJAML23hAHFOctmjZQffKD2pywkhtSGHKNtpitLroscAeE7kCkSsC60vxEl6yMtL9EL5HKGCMszU5bk8gdkklAyEn5FO0yK419rIxBOIqwFMooDE0tHEVYijAUECIshRCGIhxFWIowFJ5QkEYIS5PTJrUwNGlPyN6QQPyKtpuM1E/K5+YJDV/MiA3AaehzqgAm7QnZG9IGYKo8bHnSK7VblLL3hOwNHziPuEGOqE5brrdR6i+atCfckyeWD47HkAkepRGLY/e8A8J0gCwYSNypF08bBm+e6zVz2UL4AshhBUjML/rXLefqC82bcQFhGC9JDwZ1uuu+At0S5gCETYHsV4DUeD9fDN2Zfy5OXaW2zAwQygCzBLJ8cvaW5OXKC1FxfTggFAHmoAJnSiOw2wps9KwRWgJCLaEswaj5NqkLwAYIU4BxqTSXbHXpJdRMPZgAOiAMqABCNGYIEEJutEK5IUAIwYMDQgiCACEEAcJs1Vda7gGqDhCmoiEghAAhBAHCrKXVo2C1DCBMRlp37uMIEECoX7xrX3P5C9QiINSuIcoPAUI0YkAICLNWgfJDh4T9hH7zqYH9+JHAq7zBqWjwhPAicTVCVQJCNF50JghHocahKK0X/ZnQKyEkhSdUpzG8OgQI42qC94EQjsYLRSmH+pbgq73L6bYkeEJ4DYTYmeg1TOBFc/usTTp3V9DdEuXJ2xDCUbXhaXk0/kAYmBvuMB4qkC35E5e5AMKkwSQgyxufyuPy6fMMgAFCSI73LFXU/N8AmEL9X4ABACNSKMHAgb34AAAAAElFTkSuQmCC
+          mediatype: image/png
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: etcd-operator
+              rules:
+              - apiGroups:
+                - etcd.database.coreos.com
+                resources:
+                - etcdclusters
+                - etcdbackups
+                - etcdrestores
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - secrets
+                verbs:
+                - get
+            deployments:
+            - name: etcd-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: etcd-operator-alm-owned
+                template:
+                  metadata:
+                    name: etcd-operator-alm-owned
+                    labels:
+                      name: etcd-operator-alm-owned
+                  spec:
+                    serviceAccountName: etcd-operator
+                    containers:
+                    - name: etcd-operator
+                      command:
+                      - etcd-operator
+                      - --create-crd=false
+                      image: quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                    - name: etcd-backup-operator
+                      image: quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8
+                      command:
+                      - etcd-backup-operator
+                      - --create-crd=false
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                    - name: etcd-restore-operator
+                      image: quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8
+                      command:
+                      - etcd-restore-operator
+                      - --create-crd=false
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+        customresourcedefinitions:
+          owned:
+          - name: etcdclusters.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdCluster
+            displayName: etcd Cluster
+            description: Represents a cluster of etcd nodes.
+            resources:
+              - kind: Service
+                version: v1
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of member Pods for the etcd cluster.
+                displayName: Size
+                path: size
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+              - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+                displayName: Resource Requirements
+                path: pod.resources
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+            statusDescriptors:
+              - description: The status of each of the member Pods for the etcd cluster.
+                displayName: Member Status
+                path: members
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+              - description: The service at which the running etcd cluster can be accessed.
+                displayName: Service
+                path: serviceName
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The current size of the etcd cluster.
+                displayName: Cluster Size
+                path: size
+              - description: The current version of the etcd cluster.
+                displayName: Current Version
+                path: currentVersion
+              - description: 'The target version of the etcd cluster, after upgrading.'
+                displayName: Target Version
+                path: targetVersion
+              - description: The current status of the etcd cluster.
+                displayName: Status
+                path: phase
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase'
+              - description: Explanation for the current status of the cluster.
+                displayName: Status Details
+                path: reason
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+          - name: etcdbackups.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdBackup
+            displayName: etcd Backup
+            description: Represents the intent to backup an etcd cluster.
+            specDescriptors:
+              - description: Specifies the endpoints of an etcd cluster.
+                displayName: etcd Endpoint(s)
+                path: etcdEndpoints
+                x-descriptors: 
+                  - 'urn:alm:descriptor:etcd:endpoint'
+              - description: The full AWS S3 path where the backup is saved.
+                displayName: S3 Path
+                path: s3.path
+                x-descriptors: 
+                  - 'urn:alm:descriptor:aws:s3:path'
+              - description: The name of the secret object that stores the AWS credential and config files.
+                displayName: AWS Secret
+                path: s3.awsSecret
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:Secret'
+            statusDescriptors:
+              - description: Indicates if the backup was successful.
+                displayName: Succeeded
+                path: succeeded
+                x-descriptors: 
+                  - 'urn:alm:descriptor:text'
+              - description: Indicates the reason for any backup related failures.
+                displayName: Reason
+                path: reason
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+          - name: etcdrestores.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdRestore
+            displayName: etcd Restore
+            description: Represents the intent to restore an etcd cluster from a backup.
+            specDescriptors:
+              - description: References the EtcdCluster which should be restored,
+                displayName: etcd Cluster
+                path: etcdCluster.name
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:EtcdCluster'
+                  - 'urn:alm:descriptor:text'
+              - description: The full AWS S3 path where the backup is saved.
+                displayName: S3 Path
+                path: s3.path
+                x-descriptors: 
+                  - 'urn:alm:descriptor:aws:s3:path'
+              - description: The name of the secret object that stores the AWS credential and config files.
+                displayName: AWS Secret
+                path: s3.awsSecret
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:Secret'
+            statusDescriptors:
+              - description: Indicates if the restore was successful.
+                displayName: Succeeded
+                path: succeeded
+                x-descriptors: 
+                  - 'urn:alm:descriptor:text'
+              - description: Indicates the reason for any restore related failures.
+                displayName: Reason
+                path: reason
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        name: etcdoperator.v0.9.2
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
+      spec:
+        displayName: etcd
+        description: |
+          etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. It’s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader. Your applications can read and write data into etcd.
+          A simple use-case is to store database connection details or feature flags within etcd as key value pairs. These values can be watched, allowing your app to reconfigure itself when they change. Advanced uses take advantage of the consistency guarantees to implement database leader elections or do distributed locking across a cluster of workers.
+      
+          _The etcd Open Cloud Service is Public Alpha. The goal before Beta is to fully implement backup features._
+      
+          ### Reading and writing to etcd
+      
+          Communicate with etcd though its command line utility `etcdctl` or with the API using the automatically generated Kubernetes Service.
+      
+          [Read the complete guide to using the etcd Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/etcd-ocs.html)
+      
+          ### Supported Features
+      
+      
+          **High availability**
+      
+      
+          Multiple instances of etcd are networked together and secured. Individual failures or networking issues are transparently handled to keep your cluster up and running.
+      
+      
+          **Automated updates**
+      
+      
+          Rolling out a new etcd version works like all Kubernetes rolling updates. Simply declare the desired version, and the etcd service starts a safe rolling update to the new version automatically.
+      
+      
+          **Backups included**
+      
+      
+          Coming soon, the ability to schedule backups to happen on or off cluster.
+        keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']
+        version: 0.9.2
+        maturity: alpha
+        replaces: etcdoperator.v0.9.0
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+        labels:
+          alm-owner-etcd: etcdoperator
+          operated-by: etcdoperator
+        selector:
+          matchLabels:
+            alm-owner-etcd: etcdoperator
+            operated-by: etcdoperator
+        links:
+        - name: Blog
+          url: https://coreos.com/etcd
+        - name: Documentation
+          url: https://coreos.com/operators/etcd/docs/latest/
+        - name: etcd Operator Source Code
+          url: https://github.com/coreos/etcd-operator
+      
+        icon:
+        - base64data: iVBORw0KGgoAAAANSUhEUgAAAOEAAADZCAYAAADWmle6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAEKlJREFUeNrsndt1GzkShmEev4sTgeiHfRYdgVqbgOgITEVgOgLTEQydwIiKwFQCayoCU6+7DyYjsBiBFyVVz7RkXvqCSxXw/+f04XjGQ6IL+FBVuL769euXgZ7r39f/G9iP0X+u/jWDNZzZdGI/Ftama1jjuV4BwmcNpbAf1Fgu+V/9YRvNAyzT2a59+/GT/3hnn5m16wKWedJrmOCxkYztx9Q+py/+E0GJxtJdReWfz+mxNt+QzS2Mc0AI+HbBBwj9QViKbH5t64DsP2fvmGXUkWU4WgO+Uve2YQzBUGd7r+zH2ZG/tiUQc4QxKwgbwFfVGwwmdLL5wH78aPC/ZBem9jJpCAX3xtcNASSNgJLzUPSQyjB1zQNl8IQJ9MIU4lx2+Jo72ysXYKl1HSzN02BMa/vbZ5xyNJIshJzwf3L0dQhJw4Sih/SFw9Tk8sVeghVPoefaIYCkMZCKbrcP9lnZuk0uPUjGE/KE8JQry7W2tgfuC3vXgvNV+qSQbyFtAtyWk7zWiYevvuUQ9QEQCvJ+5mmu6dTjz1zFHLFj8Eb87MtxaZh/IQFIHom+9vgTWwZxAQjT9X4vtbEVPojwjiV471s00mhAckpwGuCn1HtFtRDaSh6y9zsL+LNBvCG/24ThcxHObdlWc1v+VQJe8LcO0jwtuF8BwnAAUgP9M8JPU2Me+Oh12auPGT6fHuTePE3bLDy+x9pTLnhMn+07TQGh//Bz1iI0c6kvtqInjvPZcYR3KsPVmUsPYt9nFig9SCY8VQNhpPBzn952bbgcsk2EvM89wzh3UEffBbyPqvBUBYQ8ODGPFOLsa7RF096WJ69L+E4EmnpjWu5o4ChlKaRTKT39RMMaVPEQRsz/nIWlDN80chjdJlSd1l0pJCAMVZsniobQVuxceMM9OFoaMd9zqZtjMEYYDW38Drb8Y0DYPLShxn0pvIFuOSxd7YCPet9zk452wsh54FJoeN05hcgSQoG5RR0Qh9Q4E4VvL4wcZq8UACgaRFEQKgSwWrkr5WFnGxiHSutqJGlXjBgIOayhwYBTA0ER0oisIVSUV0AAMT0IASCUO4hRIQSAEECMCCEPwqyQA0JCQBzEGjWNAqHiUVAoXUWbvggOIQCEAOJzxTjoaQ4AIaE64/aZridUsBYUgkhB15oGg1DBIl8IqirYwV6hPSGBSFteMCUBSVXwfYixBmamRubeMyjzMJQBDDowE3OesDD+zwqFoDqiEwXoXJpljB+PvWJGy75BKF1FPxhKygJuqUdYQGlLxNEXkrYyjQ0GbaAwEnUIlLRNvVjQDYUAsJB0HKLE4y0AIpQNgCIhBIhQTgCKhZBBpAN/v6LtQI50JfUgYOnnjmLUFHKhjxbAmdTCaTiBm3ovLPqG2urWAij6im0Nd9aTN9ygLUEt9LgSRnohxUPIKxlGaE+/6Y7znFf0yX+GnkvFFWmarkab2o9PmTeq8sbd2a7DaysXz7i64VeznN4jCQhN9gdDbRiuWrfrsq0mHIrlaq+hlotCtd3Um9u0BYWY8y5D67wccJoZjFca7iUs9VqZcfsZwTd1sbWGG+OcYaTnPAP7rTQVVlM4Sg3oGvB1tmNh0t/HKXZ1jFoIMwCQjtqbhNxUmkGYqgZEDZP11HN/S3gAYRozf0l8C5kKEKUvW0t1IfeWG/5MwgheZTT1E0AEhDkAePQO+Ig2H3DncAkQM4cwUQCD530dU4B5Yvmi2LlDqXfWrxMCcMth51RToRMNUXFnfc2KJ0+Ryl0VNOUwlhh6NoxK5gnViTgQpUG4SqSyt5z3zRJpuKmt3Q1614QaCBPaN6je+2XiFcWAKOXcUfIYKRyL/1lb7pe5VxSxxjQ6hImshqGRt5GWZVKO6q2wHwujfwDtIvaIdexj8Cm8+a68EqMfox6x/voMouZF4dHnEGNeCDMwT6vdNfekH1MafMk4PI06YtqLVGl95aEM9Z5vAeCTOA++YLtoVJRrsqNCaJ6WRmkdYaNec5BT/lcTRMqrhmwfjbpkj55+OKp8IEbU/JLgPJE6Wa3TTe9sHS+ShVD5QIyqIxMEwKh12olC6mHIed5ewEop80CNlfIOADYOT2nd6ZXCop+Ebqchc0JqxKcKASxChycJgUh1rnHA5ow9eTrhqNI7JWiAYYwBGGdpyNLoGw0Pkh96h1BpHihyywtATDM/7Hk2fN9EnH8BgKJCU4ooBkbXFMZJiPbrOyecGl3zgQDQL4hk10IZiOe+5w99Q/gBAEIJgPhJM4QAEEoFREAIAAEiIASAkD8Qt4AQAEIAERAGFlX4CACKAXGVM4ivMwWwCLFAlyeoaa70QePKm5Dlp+/n+ye/5dYgva6YsUaVeMa+tzNFeJtWwc+udbJ0Fg399kLielQJ5Ze61c2+7ytA6EZetiPxZC6tj22yJCv6jUwOyj/zcbqAxOMyAKEbfeHtNa7DtYXptjsk2kJxR+eIeim/tHNofUKYy8DMrQcAKWz6brpvzyIAlpwPhQ49l6b7skJf5Z+YTOYQc4FwLDxvoTDwaygQK+U/kVr+ytSFBG01Q3gnJJR4cNiAhx4HDub8/b5DULXlj6SVZghFiE+LdvE9vo/o8Lp1RmH5hzm0T6wdbZ6n+D6i44zDRc3ln6CpAEJfXiRU45oqLz8gFAThWsh7ughrRibc0QynHgZpNJa/ENJ+loCwu/qOGnFIjYR/n7TfgycULhcQhu6VC+HfF+L3BoAQ4WiZTw1M+FPCnA2gKC6/FAhXgDC+ojQGh3NuWsvfF1L/D5ohlCKtl1j2ldu9a/nPAKFwN56Bst10zCG0CPleXN/zXPgHQZXaZaBgrbzyY5V/mUA+6F0hwtGN9rwu5DVZPuwWqfxdFz1LWbJ2lwKEa+0Qsm4Dl3fp+Pu0lV97PgwIPfSsS+UQhj5Oo+vvFULazRIQyvGEcxPuNLCth2MvFsrKn8UOilAQShkh7TTczYNMoS6OdP47msrPi82lXKGWhCdMZYS0bFy+vcnGAjP1CIfvgbKNA9glecEH9RD6Ol4wRuWyN/G9MHnksS6o/GPf5XcwNSUlHzQhDuAKtWJmkwKElU7lylP5rgIcsquh/FI8YZCDpkJBuE4FQm7Icw8N+SrUGaQKyi8FwiDt1ve5o+Vu7qYHy/psgK8cvh+FTYuO77bhEC7GuaPiys/L1X4IgXDL+e3M5+ovLxBy5VLuIebw1oqcHoPfoaMJUsHays878r8KbDc3xtPx/84gZPBG/JwaufrsY/SRG/OY3//8QMNdsvdZCFtbW6f8pFuf5bflILAlX7O+4fdfugKyFYS8T2zAsXthdG0VurPGKwI06oF5vkBgHWkNp6ry29+lsPZMU3vijnXFNmoclr+6+Ou/FIb8yb30sS8YGjmTqCLyQsi5N/6ZwKs0Yenj68pfPjF6N782Dp2FzV9CTyoSeY8mLK16qGxIkLI8oa1n8tz9juP40DlK0epxYEbojbq+9QfurBeVIlCO9D2396bxiV4lkYQ3hOAFw2pbhqMGISkkQOMcQ9EqhDmGZZdo92JC0YHRNTfoSg+5e0IT+opqCKHoIU+4ztQIgBD1EFNrQAgIpYSil9lDmPHqkROPt+JC6AgPquSuumJmg0YARVCuneDfvPVeJokZ6pIXDkNxQtGzTF9/BQjRG0tQznfb74RwCQghpALBtIQnfK4zhxdyQvVCUeknMIT3hLyY+T5jo0yABqKPQNpUNw/09tGZod5jgCaYFxyYvJcNPkv9eof+I3pnCFEHIETjSM8L9tHZHYCQT9PaZGycU6yg8S4akDnJ+P03L0+t23XGzCLzRgII/Wqa+fv/xlfvmKvMUOcOrlCDdoei1MGdZm6G5VEIfRzzjd4aQs69n699Rx7ewhvCGzr2gmTPs8zNsJOrXt24FbkhhOjCfT4ICA/rPbyhUy94Dks0gJCX1NzCZui9YUd3oei+c257TalFbgg19ILHrlrL2gvWgXAL26EX76gZTNASQnad8Ibwhl284NhgXpB0c+jKhWO3Ms1hP9ihJYB9eMF6qd1BCPk0qA1s+LimFIu7m4nsdQIzPK4VbQ8hYvrnuSH2G9b2ggP78QmWqBdF9Vx8SSY6QYdUW7BTA1schZATyhvY8lHvcRbNUS9YGFy2U+qmzh2YPVc0I7yAOFyHfRpyUwtCSzOdPXMHmz7qDIM0e0V2wZTEk+6Ym6N63eBLp/b5Bts+2cKCSJ/LuoZO3ANSiE5hKAZjnvNSS4931jcw9jpwT0feV/qSJ1pVtCyfHKDkvK8Ejx7pUxGh2xFNSwx8QTi2H9ceC0/nni64MS/5N5dG39pDqvRV+WgGk71c9VFXF9b+xYvOw/d61iv7m3MvEHryhvecwC52jSSx4VIIgwnMNT/UsTxIgpPt3K/ARj15CptwL3Zd/ceDSATj2DGQjbxgWwhdeMMte7zpy5On9vymRm/YxBYljGVjKWF9VJf7I1+sex3wY8w/V1QPTborW/72gkdsRDaZMJBdbdHIC7aCkAu9atlLbtnrzerMnyToDaGwelOnk3/hHSem/ZK7e/t7jeeR20LYBgqa8J80gS8jbwi5F02Uj1u2NYJxap8PLkJfLxA2hIJyvnHX/AfeEPLpBfe0uSFHbnXaea3Qd5d6HcpYZ8L6M7lnFwMQ3MNg+RxUR1+6AshtbsVgfXTEg1sIGax9UND2p7f270wdG3eK9gXVGHdw2k5sOyZv+Nbs39Z308XR9DqWb2J+PwKDhuKHPobfuXf7gnYGHdCs7bhDDadD4entDug7LWNsnRNW4mYqwJ9dk+GGSTPBiA2j0G8RWNM5upZtcG4/3vMfP7KnbK2egx6CCnDPhRn7NgD3cghLIad5WcM2SO38iqHvvMOosyeMpQ5zlVCaaj06GVs9xUbHdiKoqrHWgquFEFMWUEWfXUxJAML23hAHFOctmjZQffKD2pywkhtSGHKNtpitLroscAeE7kCkSsC60vxEl6yMtL9EL5HKGCMszU5bk8gdkklAyEn5FO0yK419rIxBOIqwFMooDE0tHEVYijAUECIshRCGIhxFWIowFJ5QkEYIS5PTJrUwNGlPyN6QQPyKtpuM1E/K5+YJDV/MiA3AaehzqgAm7QnZG9IGYKo8bHnSK7VblLL3hOwNHziPuEGOqE5brrdR6i+atCfckyeWD47HkAkepRGLY/e8A8J0gCwYSNypF08bBm+e6zVz2UL4AshhBUjML/rXLefqC82bcQFhGC9JDwZ1uuu+At0S5gCETYHsV4DUeD9fDN2Zfy5OXaW2zAwQygCzBLJ8cvaW5OXKC1FxfTggFAHmoAJnSiOw2wps9KwRWgJCLaEswaj5NqkLwAYIU4BxqTSXbHXpJdRMPZgAOiAMqABCNGYIEEJutEK5IUAIwYMDQgiCACEEAcJs1Vda7gGqDhCmoiEghAAhBAHCrKXVo2C1DCBMRlp37uMIEECoX7xrX3P5C9QiINSuIcoPAUI0YkAICLNWgfJDh4T9hH7zqYH9+JHAq7zBqWjwhPAicTVCVQJCNF50JghHocahKK0X/ZnQKyEkhSdUpzG8OgQI42qC94EQjsYLRSmH+pbgq73L6bYkeEJ4DYTYmeg1TOBFc/usTTp3V9DdEuXJ2xDCUbXhaXk0/kAYmBvuMB4qkC35E5e5AMKkwSQgyxufyuPy6fMMgAFCSI73LFXU/N8AmEL9X4ABACNSKMHAgb34AAAAAElFTkSuQmCC
+          mediatype: image/png
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: etcd-operator
+              rules:
+              - apiGroups:
+                - etcd.database.coreos.com
+                resources:
+                - etcdclusters
+                - etcdbackups
+                - etcdrestores
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - secrets
+                verbs:
+                - get
+            deployments:
+            - name: etcd-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: etcd-operator-alm-owned
+                template:
+                  metadata:
+                    name: etcd-operator-alm-owned
+                    labels:
+                      name: etcd-operator-alm-owned
+                  spec:
+                    serviceAccountName: etcd-operator
+                    containers:
+                    - name: etcd-operator
+                      command:
+                      - etcd-operator
+                      - --create-crd=false
+                      image: quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                    - name: etcd-backup-operator
+                      image: quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2
+                      command:
+                      - etcd-backup-operator
+                      - --create-crd=false
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                    - name: etcd-restore-operator
+                      image: quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2
+                      command:
+                      - etcd-restore-operator
+                      - --create-crd=false
+                      env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+        customresourcedefinitions:
+          owned:
+          - name: etcdclusters.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdCluster
+            displayName: etcd Cluster
+            description: Represents a cluster of etcd nodes.
+            resources:
+              - kind: Service
+                version: v1
+              - kind: Pod
+                version: v1
+            specDescriptors:
+              - description: The desired number of member Pods for the etcd cluster.
+                displayName: Size
+                path: size
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+              - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+                displayName: Resource Requirements
+                path: pod.resources
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+            statusDescriptors:
+              - description: The status of each of the member Pods for the etcd cluster.
+                displayName: Member Status
+                path: members
+                x-descriptors:
+                  - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+              - description: The service at which the running etcd cluster can be accessed.
+                displayName: Service
+                path: serviceName
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes:Service'
+              - description: The current size of the etcd cluster.
+                displayName: Cluster Size
+                path: size
+              - description: The current version of the etcd cluster.
+                displayName: Current Version
+                path: currentVersion
+              - description: 'The target version of the etcd cluster, after upgrading.'
+                displayName: Target Version
+                path: targetVersion
+              - description: The current status of the etcd cluster.
+                displayName: Status
+                path: phase
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase'
+              - description: Explanation for the current status of the cluster.
+                displayName: Status Details
+                path: reason
+                x-descriptors:
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+          - name: etcdbackups.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdBackup
+            displayName: etcd Backup
+            description: Represents the intent to backup an etcd cluster.
+            specDescriptors:
+              - description: Specifies the endpoints of an etcd cluster.
+                displayName: etcd Endpoint(s)
+                path: etcdEndpoints
+                x-descriptors: 
+                  - 'urn:alm:descriptor:etcd:endpoint'
+              - description: The full AWS S3 path where the backup is saved.
+                displayName: S3 Path
+                path: s3.path
+                x-descriptors: 
+                  - 'urn:alm:descriptor:aws:s3:path'
+              - description: The name of the secret object that stores the AWS credential and config files.
+                displayName: AWS Secret
+                path: s3.awsSecret
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:Secret'
+            statusDescriptors:
+              - description: Indicates if the backup was successful.
+                displayName: Succeeded
+                path: succeeded
+                x-descriptors: 
+                  - 'urn:alm:descriptor:text'
+              - description: Indicates the reason for any backup related failures.
+                displayName: Reason
+                path: reason
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+          - name: etcdrestores.etcd.database.coreos.com
+            version: v1beta2
+            kind: EtcdRestore
+            displayName: etcd Restore
+            description: Represents the intent to restore an etcd cluster from a backup.
+            specDescriptors:
+              - description: References the EtcdCluster which should be restored,
+                displayName: etcd Cluster
+                path: etcdCluster.name
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:EtcdCluster'
+                  - 'urn:alm:descriptor:text'
+              - description: The full AWS S3 path where the backup is saved.
+                displayName: S3 Path
+                path: s3.path
+                x-descriptors: 
+                  - 'urn:alm:descriptor:aws:s3:path'
+              - description: The name of the secret object that stores the AWS credential and config files.
+                displayName: AWS Secret
+                path: s3.awsSecret
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes:Secret'
+            statusDescriptors:
+              - description: Indicates if the restore was successful.
+                displayName: Succeeded
+                path: succeeded
+                x-descriptors: 
+                  - 'urn:alm:descriptor:text'
+              - description: Indicates the reason for any restore related failures.
+                displayName: Reason
+                path: reason
+                x-descriptors: 
+                  - 'urn:alm:descriptor:io.kubernetes.phase:reason'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        name: prometheusoperator.0.14.0
+        namespace: placeholder
+      spec:
+        displayName: Prometheus
+        description: |
+          An open-source monitoring system with a dimensional data model, flexible query language, efficient time series database and modern alerting approach.
+      
+          _The Prometheus Open Cloud Service is Public Alpha. The goal before Beta is for additional user testing and minor bug fixes._
+      
+          ### Monitoring applications
+      
+          Prometheus scrapes your application metrics based on targets maintained in a ServiceMonitor object. When alerts need to be sent, they are processsed by an AlertManager.
+      
+          [Read the complete guide to monitoring applications with the Prometheus Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/prometheus-ocs.html)
+      
+          ## Supported Features
+      
+          **High availability**
+          Multiple instances are run across failure zones and data is replicated. This keeps your monitoring available during an outage, when you need it most.
+          **Updates via automated operations**
+          New Prometheus versions are deployed using a rolling update with no downtime, making it easy to stay up to date.
+          **Handles the dynamic nature of containers**
+          Alerting rules are attached to groups of containers instead of individual instances, which is ideal for the highly dynamic nature of container deployment.
+      
+        keywords: ['prometheus', 'monitoring', 'tsdb', 'alerting']
+      
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+      
+        links:
+        - name: Prometheus
+          url: https://www.prometheus.io/
+        - name: Documentation
+          url: https://coreos.com/operators/prometheus/docs/latest/
+        - name: Prometheus Operator Source Code
+          url: https://github.com/coreos/prometheus-operator
+      
+        labels:
+          alm-status-descriptors: prometheusoperator.0.14.0
+          alm-owner-prometheus: prometheusoperator
+      
+        selector:
+          matchLabels:
+            alm-owner-prometheus: prometheusoperator
+      
+        icon:
+        - base64data: PHN2ZyB3aWR0aD0iMjQ5MCIgaGVpZ2h0PSIyNTAwIiB2aWV3Qm94PSIwIDAgMjU2IDI1NyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCI+PHBhdGggZD0iTTEyOC4wMDEuNjY3QzU3LjMxMS42NjcgMCA1Ny45NzEgMCAxMjguNjY0YzAgNzAuNjkgNTcuMzExIDEyNy45OTggMTI4LjAwMSAxMjcuOTk4UzI1NiAxOTkuMzU0IDI1NiAxMjguNjY0QzI1NiA1Ny45NyAxOTguNjg5LjY2NyAxMjguMDAxLjY2N3ptMCAyMzkuNTZjLTIwLjExMiAwLTM2LjQxOS0xMy40MzUtMzYuNDE5LTMwLjAwNGg3Mi44MzhjMCAxNi41NjYtMTYuMzA2IDMwLjAwNC0zNi40MTkgMzAuMDA0em02MC4xNTMtMzkuOTRINjcuODQyVjE3OC40N2gxMjAuMzE0djIxLjgxNmgtLjAwMnptLS40MzItMzMuMDQ1SDY4LjE4NWMtLjM5OC0uNDU4LS44MDQtLjkxLTEuMTg4LTEuMzc1LTEyLjMxNS0xNC45NTQtMTUuMjE2LTIyLjc2LTE4LjAzMi0zMC43MTYtLjA0OC0uMjYyIDE0LjkzMyAzLjA2IDI1LjU1NiA1LjQ1IDAgMCA1LjQ2NiAxLjI2NSAxMy40NTggMi43MjItNy42NzMtOC45OTQtMTIuMjMtMjAuNDI4LTEyLjIzLTMyLjExNiAwLTI1LjY1OCAxOS42OC00OC4wNzkgMTIuNTgtNjYuMjAxIDYuOTEuNTYyIDE0LjMgMTQuNTgzIDE0LjggMzYuNTA1IDcuMzQ2LTEwLjE1MiAxMC40Mi0yOC42OSAxMC40Mi00MC4wNTYgMC0xMS43NjkgNy43NTUtMjUuNDQgMTUuNTEyLTI1LjkwNy02LjkxNSAxMS4zOTYgMS43OSAyMS4xNjUgOS41MyA0NS40IDIuOTAyIDkuMTAzIDIuNTMyIDI0LjQyMyA0Ljc3MiAzNC4xMzguNzQ0LTIwLjE3OCA0LjIxMy00OS42MiAxNy4wMTQtNTkuNzg0LTUuNjQ3IDEyLjguODM2IDI4LjgxOCA1LjI3IDM2LjUxOCA3LjE1NCAxMi40MjQgMTEuNDkgMjEuODM2IDExLjQ5IDM5LjYzOCAwIDExLjkzNi00LjQwNyAyMy4xNzMtMTEuODQgMzEuOTU4IDguNDUyLTEuNTg2IDE0LjI4OS0zLjAxNiAxNC4yODktMy4wMTZsMjcuNDUtNS4zNTVjLjAwMi0uMDAyLTMuOTg3IDE2LjQwMS0xOS4zMTQgMzIuMTk3eiIgZmlsbD0iI0RBNEUzMSIvPjwvc3ZnPg==
+          mediatype: image/svg+xml
+      
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: prometheus-k8s
+              rules:
+              - apiGroups: [""]
+                resources:
+                - nodes
+                - services
+                - endpoints
+                - pods
+                verbs: ["get", "list", "watch"]
+              - apiGroups: [""]
+                resources:
+                - configmaps
+                verbs: ["get"]
+            - serviceAccountName: prometheus-operator-0-14-0
+              rules:
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs: ["get", "list"]
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - alertmanagers
+                - prometheuses
+                - servicemonitors
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - statefulsets
+                verbs: ["*"]
+              - apiGroups: [""]
+                resources:
+                - configmaps
+                - secrets
+                verbs: ["*"]
+              - apiGroups: [""]
+                resources:
+                - pods
+                verbs: ["list", "delete"]
+              - apiGroups: [""]
+                resources:
+                - services
+                - endpoints
+                verbs: ["get", "create", "update"]
+              - apiGroups: [""]
+                resources:
+                - nodes
+                verbs: ["list", "watch"]
+              - apiGroups: [""]
+                resources:
+                - namespaces
+                verbs: ['list']
+            deployments:
+            - name: prometheus-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    k8s-app: prometheus-operator
+                template:
+                  metadata:
+                    labels:
+                      k8s-app: prometheus-operator
+                  spec:
+                    serviceAccount: prometheus-operator-0-14-0
+                    containers:
+                    - name: prometheus-operator
+                      image: quay.io/coreos/prometheus-operator@sha256:5037b4e90dbb03ebdefaa547ddf6a1f748c8eeebeedf6b9d9f0913ad662b5731
+                      command:
+                        - sh
+                        - -c
+                        - >
+                          /bin/operator --namespace=$K8S_NAMESPACE --crd-apigroup monitoring.coreos.com
+                          --labels alm-status-descriptors=prometheusoperator.0.14.0,alm-owner-prometheus=prometheusoperator
+                          --kubelet-service=kube-system/kubelet
+                          --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+                      env:
+                        - name: K8S_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                      ports:
+                      - containerPort: 8080
+                        name: http
+                      resources:
+                        limits:
+                          cpu: 200m
+                          memory: 100Mi
+                        requests:
+                          cpu: 100m
+                          memory: 50Mi
+        maturity: alpha
+        version: 0.14.0
+        customresourcedefinitions:
+          owned:
+          - name: prometheuses.monitoring.coreos.com
+            version: v1
+            kind: Prometheus
+            displayName: Prometheus
+            description: A running Prometheus instance
+            resources:
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            - description: A selector for the ConfigMaps from which to load rule files
+              displayName: Rule Config Map Selector
+              path: ruleSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:ConfigMap'
+            - description: ServiceMonitors to be selected for target discovery
+              displayName: Service Monitor Selector
+              path: serviceMonitorSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:selector:monitoring.coreos.com:v1:ServiceMonitor'
+            - description: The ServiceAccount to use to run the Prometheus pods
+              displayName: Service Account
+              path: serviceAccountName
+              x-descriptors:
+                - 'urn:alm:descriptor:io.kubernetes:ServiceAccount'
+            - description: Define resources requests and limits for single Pods
+              displayName: Resource Request
+              path: resources.requests
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+            statusDescriptors:
+              - description: The current number of Pods for the cluster
+                displayName: Cluster Size
+                path: replicas
+              - path: prometheusSelector
+                displayName: Prometheus Service Selector
+                description: Label selector to find the service that routes to this prometheus
+                x-descriptors:
+                - 'urn:alm:descriptor:label:selector'
+          - name: servicemonitors.monitoring.coreos.com
+            version: v1
+            kind: ServiceMonitor
+            displayName: Service Monitor
+            description: Configures prometheus to monitor a particular k8s service
+            resources:
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Selector to select which namespaces the Endpoints objects are discovered from
+              displayName: Monitoring Namespaces
+              path: namespaceSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:namespaceSelector'
+            - description: The label to use to retrieve the job name from
+              displayName: Job Label
+              path: jobLabel
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:label'
+            - description: A list of endpoints allowed as part of this ServiceMonitor
+              displayName: Endpoints
+              path: endpoints
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:endpointList'
+          - name: alertmanagers.monitoring.coreos.com
+            version: v1
+            kind: Alertmanager
+            displayName: Alert Manager
+            description: Configures an Alert Manager for the namespace
+            resources:
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        name: prometheusoperator.0.15.0
+        namespace: placeholder
+        annotations:
+          tectonic-visibility: ocs
+          alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v1.7.0","serviceAccountName":"prometheus-k8s","serviceMonitorSelector":{"matchExpressions":[{"key":"k8s-app","operator":"Exists"}]},"ruleSelector":{"matchLabels":{"role":"prometheus-rulefiles","prometheus":"k8s"}},"resources":{"requests":{"memory":"400Mi"}},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus","prometheus":"k8s"}},"namespaceSelector":{"matchNames":["monitoring"]},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3}}]'
+      spec:
+        replaces: prometheusoperator.0.14.0
+        displayName: Prometheus
+        description: |
+          An open-source monitoring system with a dimensional data model, flexible query language, efficient time series database and modern alerting approach.
+      
+          _The Prometheus Open Cloud Service is Public Alpha. The goal before Beta is for additional user testing and minor bug fixes._
+      
+          ### Monitoring applications
+      
+          Prometheus scrapes your application metrics based on targets maintained in a ServiceMonitor object. When alerts need to be sent, they are processsed by an AlertManager.
+      
+          [Read the complete guide to monitoring applications with the Prometheus Open Cloud Service](https://coreos.com/tectonic/docs/latest/alm/prometheus-ocs.html)
+      
+          ### Supported Features
+      
+      
+          **High availability**
+      
+      
+          Multiple instances are run across failure zones and data is replicated. This keeps your monitoring available during an outage, when you need it most.
+      
+      
+          **Updates via automated operations**
+      
+      
+          New Prometheus versions are deployed using a rolling update with no downtime, making it easy to stay up to date.
+      
+      
+          **Handles the dynamic nature of containers**
+      
+      
+          Alerting rules are attached to groups of containers instead of individual instances, which is ideal for the highly dynamic nature of container deployment.
+      
+        keywords: ['prometheus', 'monitoring', 'tsdb', 'alerting']
+      
+        maintainers:
+        - name: CoreOS, Inc
+          email: support@coreos.com
+      
+        provider:
+          name: CoreOS, Inc
+      
+        links:
+        - name: Prometheus
+          url: https://www.prometheus.io/
+        - name: Documentation
+          url: https://coreos.com/operators/prometheus/docs/latest/
+        - name: Prometheus Operator Source Code
+          url: https://github.com/coreos/prometheus-operator
+      
+        labels:
+          alm-status-descriptors: prometheusoperator.0.15.0
+          alm-owner-prometheus: prometheusoperator
+      
+        selector:
+          matchLabels:
+            alm-owner-prometheus: prometheusoperator
+      
+        icon:
+        - base64data: PHN2ZyB3aWR0aD0iMjQ5MCIgaGVpZ2h0PSIyNTAwIiB2aWV3Qm94PSIwIDAgMjU2IDI1NyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCI+PHBhdGggZD0iTTEyOC4wMDEuNjY3QzU3LjMxMS42NjcgMCA1Ny45NzEgMCAxMjguNjY0YzAgNzAuNjkgNTcuMzExIDEyNy45OTggMTI4LjAwMSAxMjcuOTk4UzI1NiAxOTkuMzU0IDI1NiAxMjguNjY0QzI1NiA1Ny45NyAxOTguNjg5LjY2NyAxMjguMDAxLjY2N3ptMCAyMzkuNTZjLTIwLjExMiAwLTM2LjQxOS0xMy40MzUtMzYuNDE5LTMwLjAwNGg3Mi44MzhjMCAxNi41NjYtMTYuMzA2IDMwLjAwNC0zNi40MTkgMzAuMDA0em02MC4xNTMtMzkuOTRINjcuODQyVjE3OC40N2gxMjAuMzE0djIxLjgxNmgtLjAwMnptLS40MzItMzMuMDQ1SDY4LjE4NWMtLjM5OC0uNDU4LS44MDQtLjkxLTEuMTg4LTEuMzc1LTEyLjMxNS0xNC45NTQtMTUuMjE2LTIyLjc2LTE4LjAzMi0zMC43MTYtLjA0OC0uMjYyIDE0LjkzMyAzLjA2IDI1LjU1NiA1LjQ1IDAgMCA1LjQ2NiAxLjI2NSAxMy40NTggMi43MjItNy42NzMtOC45OTQtMTIuMjMtMjAuNDI4LTEyLjIzLTMyLjExNiAwLTI1LjY1OCAxOS42OC00OC4wNzkgMTIuNTgtNjYuMjAxIDYuOTEuNTYyIDE0LjMgMTQuNTgzIDE0LjggMzYuNTA1IDcuMzQ2LTEwLjE1MiAxMC40Mi0yOC42OSAxMC40Mi00MC4wNTYgMC0xMS43NjkgNy43NTUtMjUuNDQgMTUuNTEyLTI1LjkwNy02LjkxNSAxMS4zOTYgMS43OSAyMS4xNjUgOS41MyA0NS40IDIuOTAyIDkuMTAzIDIuNTMyIDI0LjQyMyA0Ljc3MiAzNC4xMzguNzQ0LTIwLjE3OCA0LjIxMy00OS42MiAxNy4wMTQtNTkuNzg0LTUuNjQ3IDEyLjguODM2IDI4LjgxOCA1LjI3IDM2LjUxOCA3LjE1NCAxMi40MjQgMTEuNDkgMjEuODM2IDExLjQ5IDM5LjYzOCAwIDExLjkzNi00LjQwNyAyMy4xNzMtMTEuODQgMzEuOTU4IDguNDUyLTEuNTg2IDE0LjI4OS0zLjAxNiAxNC4yODktMy4wMTZsMjcuNDUtNS4zNTVjLjAwMi0uMDAyLTMuOTg3IDE2LjQwMS0xOS4zMTQgMzIuMTk3eiIgZmlsbD0iI0RBNEUzMSIvPjwvc3ZnPg==
+          mediatype: image/svg+xml
+      
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: prometheus-k8s
+              rules:
+              - apiGroups: [""]
+                resources:
+                - nodes
+                - services
+                - endpoints
+                - pods
+                verbs: ["get", "list", "watch"]
+              - apiGroups: [""]
+                resources:
+                - configmaps
+                verbs: ["get"]
+            - serviceAccountName: prometheus-operator-0-14-0
+              rules:
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs: ["get", "list"]
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - alertmanagers
+                - prometheuses
+                - servicemonitors
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - statefulsets
+                verbs: ["*"]
+              - apiGroups: [""]
+                resources:
+                - configmaps
+                - secrets
+                verbs: ["*"]
+              - apiGroups: [""]
+                resources:
+                - pods
+                verbs: ["list", "delete"]
+              - apiGroups: [""]
+                resources:
+                - services
+                - endpoints
+                verbs: ["get", "create", "update"]
+              - apiGroups: [""]
+                resources:
+                - nodes
+                verbs: ["list", "watch"]
+              - apiGroups: [""]
+                resources:
+                - namespaces
+                verbs: ['list']
+            deployments:
+            - name: prometheus-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    k8s-app: prometheus-operator
+                template:
+                  metadata:
+                    labels:
+                      k8s-app: prometheus-operator
+                  spec:
+                    serviceAccount: prometheus-operator-0-14-0
+                    containers:
+                    - name: prometheus-operator
+                      image: quay.io/coreos/prometheus-operator@sha256:0e92dd9b5789c4b13d53e1319d0a6375bcca4caaf0d698af61198061222a576d
+                      command:
+                        - sh
+                        - -c
+                        - >
+                          /bin/operator --namespace=$K8S_NAMESPACE --crd-apigroup monitoring.coreos.com
+                          --labels alm-status-descriptors=prometheusoperator.0.15.0,alm-owner-prometheus=prometheusoperator
+                          --kubelet-service=kube-system/kubelet
+                          --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+                      env:
+                        - name: K8S_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                      ports:
+                      - containerPort: 8080
+                        name: http
+                      resources:
+                        limits:
+                          cpu: 200m
+                          memory: 100Mi
+                        requests:
+                          cpu: 100m
+                          memory: 50Mi
+        maturity: alpha
+        version: 0.15.0
+        customresourcedefinitions:
+          owned:
+          - name: prometheuses.monitoring.coreos.com
+            version: v1
+            kind: Prometheus
+            displayName: Prometheus
+            description: A running Prometheus instance
+            resources:
+              - kind: StatefulSet
+                version: v1beta2
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            - description: A selector for the ConfigMaps from which to load rule files
+              displayName: Rule Config Map Selector
+              path: ruleSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:ConfigMap'
+            - description: ServiceMonitors to be selected for target discovery
+              displayName: Service Monitor Selector
+              path: serviceMonitorSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:selector:monitoring.coreos.com:v1:ServiceMonitor'
+            - description: The ServiceAccount to use to run the Prometheus pods
+              displayName: Service Account
+              path: serviceAccountName
+              x-descriptors:
+                - 'urn:alm:descriptor:io.kubernetes:ServiceAccount'
+            - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+              displayName: Resource Requirements
+              path: resources
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+            statusDescriptors:
+              - description: The current number of Pods for the cluster
+                displayName: Cluster Size
+                path: replicas
+              - path: prometheusSelector
+                displayName: Prometheus Service Selector
+                description: Label selector to find the service that routes to this prometheus
+                x-descriptors:
+                - 'urn:alm:descriptor:label:selector'
+          - name: servicemonitors.monitoring.coreos.com
+            version: v1
+            kind: ServiceMonitor
+            displayName: Service Monitor
+            description: Configures prometheus to monitor a particular k8s service
+            resources:
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Selector to select which namespaces the Endpoints objects are discovered from
+              displayName: Monitoring Namespaces
+              path: namespaceSelector
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:namespaceSelector'
+            - description: The label to use to retrieve the job name from
+              displayName: Job Label
+              path: jobLabel
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:label'
+            - description: A list of endpoints allowed as part of this ServiceMonitor
+              displayName: Endpoints
+              path: endpoints
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:endpointList'
+          - name: alertmanagers.monitoring.coreos.com
+            version: v1
+            kind: Alertmanager
+            displayName: Alert Manager
+            description: Configures an Alert Manager for the namespace
+            resources:
+              - kind: StatefulSet
+                version: v1beta2
+              - kind: Pod
+                version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+              displayName: Resource Requirements
+              path: resources
+              x-descriptors:
+                - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      
+    - #! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
+      #! parse-kind: ClusterServiceVersion
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        name: prometheusoperator.0.22.2
+        namespace: placeholder
+        annotations:
+          alm-examples: '[{"apiVersion":"monitoring.coreos.com/v1","kind":"Prometheus","metadata":{"name":"example","labels":{"prometheus":"k8s"}},"spec":{"replicas":2,"version":"v2.3.2","serviceAccountName":"prometheus-k8s","securityContext": {}, "serviceMonitorSelector":{"matchExpressions":[{"key":"k8s-app","operator":"Exists"}]},"ruleSelector":{"matchLabels":{"role":"prometheus-rulefiles","prometheus":"k8s"}},"alerting":{"alertmanagers":[{"namespace":"monitoring","name":"alertmanager-main","port":"web"}]}}},{"apiVersion":"monitoring.coreos.com/v1","kind":"ServiceMonitor","metadata":{"name":"example","labels":{"k8s-app":"prometheus"}},"spec":{"selector":{"matchLabels":{"k8s-app":"prometheus"}},"endpoints":[{"port":"web","interval":"30s"}]}},{"apiVersion":"monitoring.coreos.com/v1","kind":"Alertmanager","metadata":{"name":"alertmanager-main"},"spec":{"replicas":3, "securityContext": {}}}]'
+      spec:
+        replaces: prometheusoperator.0.15.0
+        displayName: Prometheus Operator
+        description: |
+          The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
+      
+          Once installed, the Prometheus Operator provides the following features:
+      
+          * **Create/Destroy**: Easily launch a Prometheus instance for your Kubernetes namespace, a specific application or team easily using the Operator.
+      
+          * **Simple Configuration**: Configure the fundamentals of Prometheus like versions, persistence, retention policies, and replicas from a native Kubernetes resource.
+      
+          * **Target Services via Labels**: Automatically generate monitoring target configurations based on familiar Kubernetes label queries; no need to learn a Prometheus specific configuration language.
+      
+          ### Other Supported Features
+      
+          **High availability**
+      
+          Multiple instances are run across failure zones and data is replicated. This keeps your monitoring available during an outage, when you need it most.
+      
+          **Updates via automated operations**
+      
+          New Prometheus versions are deployed using a rolling update with no downtime, making it easy to stay up to date.
+      
+          **Handles the dynamic nature of containers**
+      
+          Alerting rules are attached to groups of containers instead of individual instances, which is ideal for the highly dynamic nature of container deployment.
+      
+        keywords: ['prometheus', 'monitoring', 'tsdb', 'alerting']
+      
+        maintainers:
+        - name: Red Hat
+          email: openshift-operators@redhat.com
+      
+        provider:
+          name: Red Hat
+      
+        links:
+        - name: Prometheus
+          url: https://www.prometheus.io/
+        - name: Documentation
+          url: https://coreos.com/operators/prometheus/docs/latest/
+        - name: Prometheus Operator
+          url: https://github.com/coreos/prometheus-operator
+      
+        labels:
+          alm-status-descriptors: prometheusoperator.0.22.2
+          alm-owner-prometheus: prometheusoperator
+      
+        selector:
+          matchLabels:
+            alm-owner-prometheus: prometheusoperator
+      
+        icon:
+        - base64data: PHN2ZyB3aWR0aD0iMjQ5MCIgaGVpZ2h0PSIyNTAwIiB2aWV3Qm94PSIwIDAgMjU2IDI1NyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCI+PHBhdGggZD0iTTEyOC4wMDEuNjY3QzU3LjMxMS42NjcgMCA1Ny45NzEgMCAxMjguNjY0YzAgNzAuNjkgNTcuMzExIDEyNy45OTggMTI4LjAwMSAxMjcuOTk4UzI1NiAxOTkuMzU0IDI1NiAxMjguNjY0QzI1NiA1Ny45NyAxOTguNjg5LjY2NyAxMjguMDAxLjY2N3ptMCAyMzkuNTZjLTIwLjExMiAwLTM2LjQxOS0xMy40MzUtMzYuNDE5LTMwLjAwNGg3Mi44MzhjMCAxNi41NjYtMTYuMzA2IDMwLjAwNC0zNi40MTkgMzAuMDA0em02MC4xNTMtMzkuOTRINjcuODQyVjE3OC40N2gxMjAuMzE0djIxLjgxNmgtLjAwMnptLS40MzItMzMuMDQ1SDY4LjE4NWMtLjM5OC0uNDU4LS44MDQtLjkxLTEuMTg4LTEuMzc1LTEyLjMxNS0xNC45NTQtMTUuMjE2LTIyLjc2LTE4LjAzMi0zMC43MTYtLjA0OC0uMjYyIDE0LjkzMyAzLjA2IDI1LjU1NiA1LjQ1IDAgMCA1LjQ2NiAxLjI2NSAxMy40NTggMi43MjItNy42NzMtOC45OTQtMTIuMjMtMjAuNDI4LTEyLjIzLTMyLjExNiAwLTI1LjY1OCAxOS42OC00OC4wNzkgMTIuNTgtNjYuMjAxIDYuOTEuNTYyIDE0LjMgMTQuNTgzIDE0LjggMzYuNTA1IDcuMzQ2LTEwLjE1MiAxMC40Mi0yOC42OSAxMC40Mi00MC4wNTYgMC0xMS43NjkgNy43NTUtMjUuNDQgMTUuNTEyLTI1LjkwNy02LjkxNSAxMS4zOTYgMS43OSAyMS4xNjUgOS41MyA0NS40IDIuOTAyIDkuMTAzIDIuNTMyIDI0LjQyMyA0Ljc3MiAzNC4xMzguNzQ0LTIwLjE3OCA0LjIxMy00OS42MiAxNy4wMTQtNTkuNzg0LTUuNjQ3IDEyLjguODM2IDI4LjgxOCA1LjI3IDM2LjUxOCA3LjE1NCAxMi40MjQgMTEuNDkgMjEuODM2IDExLjQ5IDM5LjYzOCAwIDExLjkzNi00LjQwNyAyMy4xNzMtMTEuODQgMzEuOTU4IDguNDUyLTEuNTg2IDE0LjI4OS0zLjAxNiAxNC4yODktMy4wMTZsMjcuNDUtNS4zNTVjLjAwMi0uMDAyLTMuOTg3IDE2LjQwMS0xOS4zMTQgMzIuMTk3eiIgZmlsbD0iI0RBNEUzMSIvPjwvc3ZnPg==
+          mediatype: image/svg+xml
+      
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: prometheus-k8s
+              rules:
+              - apiGroups: [""]
+                resources:
+                - nodes
+                - services
+                - endpoints
+                - pods
+                verbs: ["get", "list", "watch"]
+              - apiGroups: [""]
+                resources:
+                - configmaps
+                verbs: ["get"]
+            - serviceAccountName: prometheus-operator-0-22-2
+              rules:
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs:
+                - '*'
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - alertmanagers
+                - prometheuses
+                - prometheuses/finalizers
+                - alertmanagers/finalizers
+                - servicemonitors
+                - prometheusrules
+                verbs:
+                - '*'
+              - apiGroups:
+                - apps
+                resources:
+                - statefulsets
+                verbs:
+                - '*'
+              - apiGroups:
+                - ""
+                resources:
+                - configmaps
+                - secrets
+                verbs:
+                - '*'
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                verbs:
+                - list
+                - delete
+              - apiGroups:
+                - ""
+                resources:
+                - services
+                - endpoints
+                verbs:
+                - get
+                - create
+                - update
+              - apiGroups:
+                - ""
+                resources:
+                - nodes
+                verbs:
+                - list
+                - watch
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - list
+                - watch
+            deployments:
+            - name: prometheus-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    k8s-app: prometheus-operator
+                template:
+                  metadata:
+                    labels:
+                      k8s-app: prometheus-operator
+                  spec:
+                    serviceAccount: prometheus-operator-0-22-2
+                    containers:
+                    - name: prometheus-operator
+                      image: quay.io/coreos/prometheus-operator@sha256:3daa69a8c6c2f1d35dcf1fe48a7cd8b230e55f5229a1ded438f687debade5bcf
+                      args:
+                      - -namespace=$(K8S_NAMESPACE)
+                      - -manage-crds=false
+                      - -logtostderr=true
+                      - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+                      - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.22.2
+                      env:
+                      - name: K8S_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      ports:
+                      - containerPort: 8080
+                        name: http
+                      resources:
+                        limits:
+                          cpu: 200m
+                          memory: 100Mi
+                        requests:
+                          cpu: 100m
+                          memory: 50Mi
+                      securityContext:
+                        allowPrivilegeEscalation: false
+                        readOnlyRootFilesystem: true
+                    nodeSelector:
+                      beta.kubernetes.io/os: linux
+        maturity: beta
+        version: 0.22.2
+        customresourcedefinitions:
+          owned:
+          - name: prometheuses.monitoring.coreos.com
+            version: v1
+            kind: Prometheus
+            displayName: Prometheus
+            description: A running Prometheus instance
+            resources:
+            - kind: StatefulSet
+              version: v1beta2
+            - kind: Pod
+              version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            - description: A selector for the ConfigMaps from which to load rule files
+              displayName: Rule Config Map Selector
+              path: ruleSelector
+              x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:ConfigMap'
+            - description: ServiceMonitors to be selected for target discovery
+              displayName: Service Monitor Selector
+              path: serviceMonitorSelector
+              x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:selector:monitoring.coreos.com:v1:ServiceMonitor'
+            - description: The ServiceAccount to use to run the Prometheus pods
+              displayName: Service Account
+              path: serviceAccountName
+              x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes:ServiceAccount'
+            - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+              displayName: Resource Requirements
+              path: resources
+              x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+          - name: prometheusrules.monitoring.coreos.com
+            version: v1
+            kind: PrometheusRule
+            displayName: Prometheus Rule
+            description: A Prometheus Rule configures groups of sequentially evaluated recording and alerting rules.
+          - name: servicemonitors.monitoring.coreos.com
+            version: v1
+            kind: ServiceMonitor
+            displayName: Service Monitor
+            description: Configures prometheus to monitor a particular k8s service
+            resources:
+            - kind: Pod
+              version: v1
+            specDescriptors:
+            - description: The label to use to retrieve the job name from
+              displayName: Job Label
+              path: jobLabel
+              x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+            - description: A list of endpoints allowed as part of this ServiceMonitor
+              displayName: Endpoints
+              path: endpoints
+              x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:endpointList'
+          - name: alertmanagers.monitoring.coreos.com
+            version: v1
+            kind: Alertmanager
+            displayName: Alertmanager
+            description: Configures an Alertmanager for the namespace
+            resources:
+            - kind: StatefulSet
+              version: v1beta2
+            - kind: Pod
+              version: v1
+            specDescriptors:
+            - description: Desired number of Pods for the cluster
+              displayName: Size
+              path: replicas
+              x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+            - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+              displayName: Resource Requirements
+              path: resources
+              x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      
+  packages: |-
+    - #! package-manifest: ./deploy/chart/catalog_resources/rh-operators/amq-streams.v1.0.0-clusterserviceversion
+      packageName: amq-streams
+      channels:
+      - name: preview
+        currentCSV: amqstreams.v1.0.0.beta
+      
+    - #! package-manifest: ./deploy/chart/catalog_resources/rh-operators/etcdoperator.v0.9.2.clusterserviceversion.yaml
+      packageName: etcd
+      channels:
+      - name: alpha
+        currentCSV: etcdoperator.v0.9.2
+      
+    - #! package-manifest: ./deploy/chart/catalog_resources/rh-operators/prometheusoperator.0.22.2.clusterserviceversion.yaml
+      packageName: prometheus
+      channels:
+      - name: preview
+        currentCSV: prometheusoperator.0.22.2
+      
+

--- a/ansible/roles/olm_setup/files/0.7.0/10-rh-operators.catalogsource.yaml
+++ b/ansible/roles/olm_setup/files/0.7.0/10-rh-operators.catalogsource.yaml
@@ -1,0 +1,16 @@
+##---
+# Source: olm/templates/10-rh-operators.catalogsource.yaml
+
+#! validate-crd: ./deploy/chart/templates/05-catalogsource.crd.yaml
+#! parse-kind: CatalogSource
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: rh-operators
+  namespace: operator-lifecycle-manager
+spec:
+  sourceType: internal
+  configMap: rh-operators
+  displayName: Red Hat Operators
+  publisher: Red Hat
+

--- a/ansible/roles/olm_setup/files/0.7.0/12-olm-operator.deployment.yaml
+++ b/ansible/roles/olm_setup/files/0.7.0/12-olm-operator.deployment.yaml
@@ -1,0 +1,47 @@
+##---
+# Source: olm/templates/12-olm-operator.deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: olm-operator
+  namespace: operator-lifecycle-manager
+  labels:
+    app: olm-operator
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: olm-operator
+  template:
+    metadata:
+      labels:
+        app: olm-operator
+    spec:
+      serviceAccountName: olm-operator-serviceaccount
+      containers:
+        - name: olm-operator
+          command:
+          - /bin/olm
+          image: quay.io/coreos/olm@sha256:5f593ae61902caef7f2add7e27d1f672a14091a399b852b1b6722ef5f8b9c8e3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          env:
+          - name: OPERATOR_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: OPERATOR_NAME
+            value: olm-operator
+      imagePullSecrets:
+        - name: coreos-pull-secret

--- a/ansible/roles/olm_setup/files/0.7.0/13-catalog-operator.deployment.yaml
+++ b/ansible/roles/olm_setup/files/0.7.0/13-catalog-operator.deployment.yaml
@@ -1,0 +1,43 @@
+##---
+# Source: olm/templates/13-catalog-operator.deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: catalog-operator
+  namespace: operator-lifecycle-manager
+  labels:
+    app: catalog-operator
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: catalog-operator
+  template:
+    metadata:
+      labels:
+        app: catalog-operator
+    spec:
+      serviceAccountName: olm-operator-serviceaccount
+      containers:
+        - name: catalog-operator
+          command:
+          - /bin/catalog
+          - '-namespace'
+          - operator-lifecycle-manager
+          - '-debug'
+          image: quay.io/coreos/catalog@sha256:8fc933e660a5b143bce7a5e4cb1606630fa9497cc252a7e47e0def3c18268f45
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+      imagePullSecrets:
+        - name: coreos-pull-secret

--- a/ansible/roles/olm_setup/files/0.7.0/20-aggregated-edit.clusterrole.yaml
+++ b/ansible/roles/olm_setup/files/0.7.0/20-aggregated-edit.clusterrole.yaml
@@ -1,0 +1,14 @@
+##---
+# Source: olm/templates/20-aggregated-edit.clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-olm-edit
+  labels:
+    # Add these permissions to the "admin" and "edit" default roles.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["operators.coreos.com"]
+  resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions", "packagemanifests"]
+  verbs: ["create", "update", "patch", "delete"]

--- a/ansible/roles/olm_setup/files/0.7.0/21-aggregated-view.clusterrole.yaml
+++ b/ansible/roles/olm_setup/files/0.7.0/21-aggregated-view.clusterrole.yaml
@@ -1,0 +1,13 @@
+##---
+# Source: olm/templates/21-aggregated-view.clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-olm-view
+  labels:
+    # Add these permissions to the "view" default roles
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups: ["operators.coreos.com"]
+  resources: ["clusterserviceversions", "catalogsources", "installplans", "subscriptions", "packagemanifests"]
+  verbs: ["get", "list", "watch"]

--- a/ansible/roles/olm_setup/files/0.7.0/22-packageserver.yaml
+++ b/ansible/roles/olm_setup/files/0.7.0/22-packageserver.yaml
@@ -1,0 +1,149 @@
+##---
+# Source: olm/templates/22-packageserver.yaml
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1alpha1.packages.apps.redhat.com
+spec:
+  caBundle: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM5VENDQWQyZ0F3SUJBZ0lCQVRBTkJna3Foa2lHOXcwQkFRc0ZBREFjTVJvd0dBWURWUVFERXhGd1lXTnIKWVdkbExYTmxjblpsY2kxallUQWVGdzB4T0RBNU1UUXlNakF3TURaYUZ3MHhPVEE1TVRReU1qQXdNRFphTUJ3eApHakFZQmdOVkJBTVRFWEJoWTJ0aFoyVXRjMlZ5ZG1WeUxXTmhNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DCkFROEFNSUlCQ2dLQ0FRRUExYnl6WHZIeXgzajV3Wk1FTkVYTVBaY2VGeVQwdUdLbnk0ejJtUHh0ZEp3TGNDNngKZzJsd2QyUjE3eGxqYjNlS2o1cC94cmt2UUd4ci9IMjI1bm1zS24vQnMyV0pZUXQvcW1teFBKdUpESWJwZXMzSgpET0FVNlBPV1N5ZUNkOWNrUWNidjJVMWVXUGhldUR6ZWdFb0NWUHN6bVpYNFpHSlVGZUZESkpKK0lBZFRiZ09FCjkxUTlEQUY3NDZ3WWFNYmV1cUVtMFlIUm5DWVdhRTlvWDdNd0tSUkdqdzVjblZ4aVFWM3JuSi8yZFdDNm1FcEwKdENQOFV3N3NmcExLSDVhQW96cGVhMURmTXBwTXJRL3J1Smhyd1FzR1RNc1BUUWJjQXNkUkJ6bzN2RU55dlJmaQpPUGovSStmY1c2VWRxNFBtUkJuYlladXlyYTcrTUdsR2VPN3MwUUlEQVFBQm8wSXdRREFPQmdOVkhROEJBZjhFCkJBTUNBcVF3SFFZRFZSMGxCQll3RkFZSUt3WUJCUVVIQXdFR0NDc0dBUVVGQndNQ01BOEdBMVVkRXdFQi93UUYKTUFNQkFmOHdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBR0NtY0dia29NVXk0NlRjOHJyWlg3clU5a2dVZWpvYgpwNFduVmorWGxpbjRzVGFRQXo1NEJFVzVuajM1dXpta0hFN1c2Tjd6ZWdQVnRqbFZ3ZHdQU0tzWEo1V2VlNjVzCjhPdTVTaXZzK0lMM1MzTHhUa1NTM3h0akVHUkVvczR2WmZFWGN0aWZUOG1UY1NFa3NWK0Z4WldIQ0loeE1ienMKZFphbWVJUm03ZWlvZkRUVjVrSW9IK1pjSFJwQitxTmlwelZacTVYbmFCS0dIQ2pkN0pyUkRKK3Nyb3dIdHNodAoya1gzaUYrckF4UE5SNURSb3FjWXdENkhhNW1UZW1QOEdBQzRZeXBKZFgveVFtZmh3VDFHZEVMSFRXU3Mxdjc0CnhZUnI0Z2IxMmxjUUdkZWJQbXNMV2JuQ0dqRXhYL3NIN3hNajAxTmJ6WjA2Ry9vcERmeUR0SG89Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+  group: packages.apps.redhat.com
+  groupPriorityMinimum: 2000
+  versionPriority: 15
+  service:
+    name: package-server
+    namespace: operator-lifecycle-manager
+  version: v1alpha1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: packagemanifest:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: olm-operator-serviceaccount
+  namespace: operator-lifecycle-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: packagemanifest-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: olm-operator-serviceaccount
+  namespace: operator-lifecycle-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: packagemanifest-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: olm-operator-serviceaccount
+  namespace: operator-lifecycle-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: package-apiserver-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aggregated-apiserver-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: olm-operator-serviceaccount
+  namespace: operator-lifecycle-manager
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: package-server-certs
+  namespace: operator-lifecycle-manager
+  labels:
+    app: package-server
+data:
+  tls.crt: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURWakNDQWo2Z0F3SUJBZ0lCQVRBTkJna3Foa2lHOXcwQkFRc0ZBREFjTVJvd0dBWURWUVFERXhGd1lXTnIKWVdkbExYTmxjblpsY2kxallUQWVGdzB4T0RBNU1UUXlNakF3TURaYUZ3MHhPVEE1TVRReU1qQXdNRFphTUJreApGekFWQmdOVkJBTVREbkJoWTJ0aFoyVXRjMlZ5ZG1WeU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTJVRWhaQ3BtSmFocThFZTlrRmdjeHMwcWxPMWhxM1laSkU4dFFsRlpuNCszWDZ5cEtORlcKbDdTbVFQeGcwZUg2Y0creG5jb1pma2N4aXJZeU1xOVc3QVMvWEg4TXl1b05sa3REY2QrcjZ4VmRLRDdNb3ZZcwpBUGF4TENoWmlHREZSdjY1R28xV2FPYWs3RzlmNHc0QjdSRFczaHNIUDV2WFhLaGdTdTVXMzYxclpWdm0vUk1qCjJNVzNSeGQ5VDR3UlNKQTErL2FCSVNVOTN6U3BSUmdxd0VjamJYTlpkMGtjbVJUY294NGZzTkVoQmNVMk1NblIKNE92c1U1RFNHZXNFUTZvaFVydHEzV0Z3WlBxZDQ1aFk2dWRXb3ovTkJOYVN5SVVUaUxoRG9QamFYbmVrOUZKMgprbkRlZFRDTlRtanhJT3ZDZzRLejNKa1kvbmQxNzVUeTVRSURBUUFCbzRHbE1JR2lNQTRHQTFVZER3RUIvd1FFCkF3SUZvREFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0RBWURWUjBUQVFIL0JBSXcKQURCakJnTlZIUkVFWERCYWdpbHdZV05yWVdkbExYTmxjblpsY2k1dmNHVnlZWFJ2Y2kxc2FXWmxZM2xqYkdVdApiV0Z1WVdkbGNvSXRjR0ZqYTJGblpTMXpaWEoyWlhJdWIzQmxjbUYwYjNJdGJHbG1aV041WTJ4bExXMWhibUZuClpYSXVjM1pqTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBMWV2MGdxZmJ5NmxmR0VSYjJhVVhJVUJXWDJOS04KUHlhbTROMXVmbEVIemR1b0pVVXVIK0ZlYUZUK1VYSTQxbnRIYmZ1b0VzRTU5NU8yTXU2Ny9ZbGtvWDI2OTQ1egpkRkJjcFNGdVRLdlJJWDlCWWNIZTJaZGJEcmszM2E2S2hnd3hRcEJ5WGNzdmNjaTQ5c2xvTzVsTkdrSUtoMDRLCk5rNEQ4THg5TXl2TDN6YlZUR3dnMHJtbkJPc1JUWXZiYUFuY3I2TU9EdC9UZGJkNm5QTVJGMThwUzlQSWNGQ1UKSUhlQXdxZ29TakhIbC9EUUJMSXB0aGxobGZad1hwT0lrNEMzc1FuK2Z2aHk4UmxpOFNDNC83SmNTVlJ4Z1FWcQp2M2wvZjVFcXg2Z2x3cnBRNi9YenJzOWQ4ZWVnZUJ2bVVNbWlCZnFSYUIrcXJ1dlJMbVVqT2gyYwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+  tls.key: "LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBMlVFaFpDcG1KYWhxOEVlOWtGZ2N4czBxbE8xaHEzWVpKRTh0UWxGWm40KzNYNnlwCktORldsN1NtUVB4ZzBlSDZjRyt4bmNvWmZrY3hpcll5TXE5VzdBUy9YSDhNeXVvTmxrdERjZCtyNnhWZEtEN00Kb3ZZc0FQYXhMQ2haaUdERlJ2NjVHbzFXYU9hazdHOWY0dzRCN1JEVzNoc0hQNXZYWEtoZ1N1NVczNjFyWlZ2bQovUk1qMk1XM1J4ZDlUNHdSU0pBMSsvYUJJU1U5M3pTcFJSZ3F3RWNqYlhOWmQwa2NtUlRjb3g0ZnNORWhCY1UyCk1NblI0T3ZzVTVEU0dlc0VRNm9oVXJ0cTNXRndaUHFkNDVoWTZ1ZFdvei9OQk5hU3lJVVRpTGhEb1BqYVhuZWsKOUZKMmtuRGVkVENOVG1qeElPdkNnNEt6M0prWS9uZDE3NVR5NVFJREFRQUJBb0lCQVFDTTVuakpoZFlKeGxqVQp6VEpjVTBrV2hpbC92UlVESnV6WFo2SnF5R2ZmM0UySmQybWVWMlpacllmRnplamROam8rZ2JJb0s5S3MyMjkrCkR2d3ZjeGhrcWcrUjViUmVSYjNhSTZYeVRLWXJLUWZwK2hDdUFBbzU5Y1NpWnVqcVVoaWdHc1BpUEpnMklLQUYKMTVYUXBGMExhMGh2ZEFnWGNQTVQzUC9XbVEwdXN4QkRsRTdIVktkQ1VtTDFLSEc0SkdVc2hiOUtzT0tqS3RJagpId0RuaHlacUsrLzR2RlRHQlpuL1VleGJNY1M5ZENTTWNmVGFsYzAvTFYvdzUrek9rQUJFUzE4bjhOSC9KNkxJCjVndTJ4dHorMDdMZXZzLzM1RWY3cmF2WVRWWjZRQjkwZWNBUDg1WnlDdDV5V013L2VkbHdPWXFhTXUzRW10QjIKOVNsMlRrcGhBb0dCQVBSWGJUdVhHRkM2dXRtdHNSY0VaWU01dHlBbUNyYnRVd21kb1RwSURzTXdTUE02Z3huUwo0UUIvZEpRNnlRZDlYQmFJS0RLMzl1dm8xM1lpVnJKOWo0TFZOM1Q0c3JtWk9NMThOMkk4cU45VUIzMkNTRGYwClNLK05sZXJhekRoTjBTOGl4WXdKRVdTcWMxUERmRTBITUxaTk9WSWN6OU4wWEU2bDFEZXlyMXY3QW9HQkFPT2UKMTJIeHljZzc2QXVSdCtLT1NDZTExY2tzTjR6OEZuOGxZYThJaldSZjE5Nk1NbXQ1cDBkS2pxQWVocmxoVXFBeApvdnNETVFDSlZvYmZ6Q0pGSGJGbGd4VkduYmFFdHc1Q1lScHNxblFEa3BsMm9LcW9wUVE4Zlg4VndEUlU1ZU5LCms4TXduZUdqOG5UaU9zblhUT1VrMGdmUjdCNTRlTXY1UytJdnBkYWZBb0dCQUtEV3UreXg5U3VPLzFneTRaT0oKTFZsSU1LZFU0MUN1d0M1Z09MVW9vYThTcGJLV0haNXVGZlpCNy9kekNzbUhWNHJ0YmFpVk9GRHFJSXArNkJydQpVLzJIWk0zMnQ0ODhzUXR5YlBLWmc0QWV6Qjl1RnlQZUJjcXBwTG5IOVE1TEN4dkFBOUcrVmxpeGF1RUVtVm9MCkZhR3JDOFJsZXRoeWpDQ3BRQnk1M256cEFvR0FCL2x3b2tYT1ErMlZXNUpuVnRDVlJvN2dSb1ArRGpwbXIxMm4KNW5IdVFpMzVhaHFQU2FTaGI2WDFDVGNJa1VZUGx2MG1NSlVVQ21qRlYwUlA2b054WHQybmtmOC9WejJmRENqWApMZzNRaXUvMUd0dEZGYldDMG5zc0NsL0F0QlNsV1NrcnRCTG45UmZCVHNiK09FUUt0WnhzbjBtRGRDM1VUWkVXClQzNUwyUkVDZ1lBampFRGxlWkh6RzZ3aGtXVWFsOVloa2M0UG0zSXVCUWdOcEE1cGRpK1k0ai9oRWhBMlA2THYKTk1majRCR3JOcHZLczNURStOZ3dDTEV0ZHBxcEFuV1ZEYUdIVERhMmJLelNSSm9Vb3A2c3lVQnZkV0Y1Zi9mYgp6dzdKRXhhdWpPMnNPN1dkcGpoWXRnWmpaNi9reHgzVWNyR1hFU3dqb1U3UWxzVXBDbFVKY2c9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo="
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: package-server
+  namespace: operator-lifecycle-manager
+  labels:
+    app: package-server
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: package-server
+  template:
+    metadata:
+      labels:
+        app: package-server
+    spec:
+      serviceAccountName: olm-operator-serviceaccount
+      containers:
+      - name: package-server
+        command:
+        - /bin/package-server
+        - -v=4
+        - --debug
+        image: quay.io/coreos/package-server:master
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 443
+        volumeMounts:
+        - name: certs
+          mountPath: /apiserver.local.config/certificates
+          readOnly: true
+        livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /healthz
+              port: 443
+        readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /healthz
+              port: 443
+      volumes:
+      - name: certs
+        secret:
+          secretName: package-server-certs
+          items:
+          - key: tls.crt
+            path: apiserver.crt
+          - key: tls.key
+            path: apiserver.key
+      imagePullSecrets:
+        - name: coreos-pull-secret
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: package-server
+  namespace: operator-lifecycle-manager
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    app: package-server

--- a/ansible/roles/olm_setup/tasks/main.yml
+++ b/ansible/roles/olm_setup/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+
+  - name: Deploy Operator Lifecycle Manager (OLM) from manifest for 3.11+
+    shell: "{{ oc_cmd }} create -f {{ role_path }}/files/{{ olm_version }}"
+    when: not("v3.6" in origin_image_tag) and
+          not("v3.7" in origin_image_tag) and
+          not("v3.9" in origin_image_tag) and
+          not("v3.10" in origin_image_tag)

--- a/ansible/roles/olm_setup/tasks/main.yml
+++ b/ansible/roles/olm_setup/tasks/main.yml
@@ -22,6 +22,9 @@
         src: "{{ role_path }}/files/{{ olm_version }}"
         dest: "/tmp/olm_manifests/"
 
+    - name: Create operator-lifecycle-manager namespace
+      shell: "{{ oc_cmd }} new-project operator-lifecycle-manager"
+
     - name: Deploy Operator Lifecycle Manager (OLM)
       shell: "{{ oc_cmd }} create -f /tmp/olm_manifests/{{ olm_version }}"
 

--- a/ansible/roles/olm_setup/tasks/main.yml
+++ b/ansible/roles/olm_setup/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
   - name: Set default for 3.11+ compatibility flag
-    set_fact: is_311_plus=false  
+    set_fact: is_311_plus=false
 
   - name: Set compatibility flag for 3.11+
     when: not("v3.6" in origin_image_tag) and

--- a/ansible/roles/olm_setup/tasks/main.yml
+++ b/ansible/roles/olm_setup/tasks/main.yml
@@ -6,9 +6,21 @@
           not("v3.10" in origin_image_tag)
     set_fact: is_311_plus=true
 
-  - name: Deploy Operator Lifecycle Manager (OLM) from manifest for 3.11+
-    shell: "{{ oc_cmd }} create -f {{ role_path }}/files/{{ olm_version }}"
+  - name: Deploy Operator Lifecycle Manager (OLM) for 3.11+
     when: deploy_olm == true and is_311_plus == true
+    block:
+    - name: "Create /tmp/olm_manifests on OpenShift host"
+      file:
+        path: /tmp/olm_manifests
+        state: directory
+
+    - name: "Sync Operator Lifecycle Manager (OLM) manifest version {{ olm_version }}"
+      synchronize:
+        src: "{{ role_path }}/files/{{ olm_version }}"
+        dest: "/tmp/olm_manifests/"
+
+    - name: Deploy Operator Lifecycle Manager (OLM)
+      shell: "{{ oc_cmd }} create -f /tmp/olm_manifests/{{ olm_version }}"
 
   - name: Deploy OpenShift Admin Console for interacting with OLM on 3.11+
     when: deploy_admin_console == true and is_311_plus == true

--- a/ansible/roles/olm_setup/tasks/main.yml
+++ b/ansible/roles/olm_setup/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+  - name: Set default for 3.11+ compatibility flag
+    set_fact: is_311_plus=false  
+
   - name: Set compatibility flag for 3.11+
     when: not("v3.6" in origin_image_tag) and
           not("v3.7" in origin_image_tag) and

--- a/ansible/roles/olm_setup/tasks/main.yml
+++ b/ansible/roles/olm_setup/tasks/main.yml
@@ -1,8 +1,42 @@
 ---
-
-  - name: Deploy Operator Lifecycle Manager (OLM) from manifest for 3.11+
-    shell: "{{ oc_cmd }} create -f {{ role_path }}/files/{{ olm_version }}"
+  - name: Set compatibility flag for 3.11+
     when: not("v3.6" in origin_image_tag) and
           not("v3.7" in origin_image_tag) and
           not("v3.9" in origin_image_tag) and
           not("v3.10" in origin_image_tag)
+    set_fact: is_311_plus=true
+
+  - name: Deploy Operator Lifecycle Manager (OLM) from manifest for 3.11+
+    shell: "{{ oc_cmd }} create -f {{ role_path }}/files/{{ olm_version }}"
+    when: deploy_olm == true and is_311_plus == true
+
+  - name: Deploy OpenShift Admin Console for interacting with OLM on 3.11+
+    when: deploy_admin_console == true and is_311_plus == true
+    block:
+    - name: Create admin-console namespace
+      shell: "{{ oc_cmd }} new-project admin-console"
+
+    - name: Create admin-console-sa service account
+      shell: "{{ oc_cmd }} create serviceaccount admin-console-sa -n admin-console"
+
+    - name: Assign cluster-admin role to admin-console-sa
+      shell: "{{ oc_cmd }} create clusterrolebinding admin-console-sa --clusterrole=cluster-admin --serviceaccount=admin-console:admin-console-sa"
+
+    - name: Create deployment of OpenShift Admin Console from {{ admin_console_image }}
+      shell: "{{ oc_cmd }} new-app --docker-image {{ admin_console_image }} --name=origin-console -n admin-console"
+
+    - name: Patch origin-console deployment config to use admin-console-sa service account
+      shell: "{{ oc_cmd }} patch dc origin-console --patch '{\"spec\":{\"template\":{\"spec\":{\"serviceAccountName\": \"admin-console-sa\"}}}}' -n admin-console"
+
+    - name: Create admin-console service
+      shell: "{{ oc_cmd }} expose dc origin-console --port 9000 -n admin-console"
+
+    - name: Create admin-console route
+      shell: "{{ oc_cmd }} expose svc origin-console -n admin-console"
+
+    - name: Record URL endpoint for origin-console route
+      shell: "{{ oc_cmd }} get route origin-console --template=\"{{'{{'}}.spec.host{{'}}'}}\""
+      register: result
+
+    - set_fact: admin_console_url="{{ result.stdout }}"
+

--- a/ansible/roles/openshift_setup/defaults/main.yml
+++ b/ansible/roles/openshift_setup/defaults/main.yml
@@ -10,6 +10,9 @@ openshift_clients:
   '3.9':
     url: https://github.com/openshift/origin/releases/download/v3.9.0
     release_ver: openshift-origin-client-tools-v3.9.0-191fece
+  '3.10':
+    url: https://github.com/openshift/origin/releases/download/v3.10.0
+    release_ver: openshift-origin-client-tools-v3.10.0-dd10d17
   latest:
     url: https://apb-oc.s3.amazonaws.com/apb-oc
     release_ver: oc

--- a/ansible/roles/openshift_setup/tasks/main.yml
+++ b/ansible/roles/openshift_setup/tasks/main.yml
@@ -299,10 +299,10 @@
         --base-dir={{ oc_cluster_up_base_dir }}
         --tag={{ origin_image_tag }}
         --image={{ origin_image_name }}-\${component}:\${version}
-        --enable=service-catalog,template-service-broker,router,registry,web-console,persistent-volumes,sample-templates,rhel-imagestreams{{ ",automation-service-broker" if enable_broker else "" }}
     when: ("v3.10" in origin_image_tag) or
           ("latest" in origin_image_tag)
 
+  #        --enable=service-catalog,template-service-broker,router,registry,web-console,persistent-volumes,sample-templates,rhel-imagestreams{{ ",automation-service-broker" if enable_broker else "" }}
   - name: Add proxy options to oc cluster up command
     set_fact:
       oc_cluster_up_cmd: "{{ oc_cluster_up_cmd }} --http-proxy='http://{{ proxy_private_ip }}:3128' --https-proxy='http://{{ proxy_private_ip }}:3128'"
@@ -451,6 +451,25 @@
     retries: "{{ oc_cluster_up_retries }}"
     delay: 10
     until: oc_cluster_up.rc == 0
+
+  - name: Enable cluster components for v3.10+
+    shell: "{{ oc_cmd }} cluster add {{ item }}"
+    with_items:
+      - service-catalog
+      - template-service-broker
+      - router
+      - registry
+      - web-console
+      - persistent-volumes
+      - sample-templates
+      - rhel-imagestreams
+    when: ("v3.10" in origin_image_tag) or 
+          ("latest" in origin_image_tag)
+
+  - name: Enable automation-service-broker for v3.10+
+    shell: "{{ oc_cmd }} cluster add automation-service-broker"
+    when: (enable_broker == true) and
+          (("v3.10" in origin_image_tag) or ("latest" in origin_image_tag))
   #
   # Add permissions to desired openshift user
   # Would be nice if we looked at existing users and permissions and made decisions of what to run

--- a/ansible/roles/openshift_setup/tasks/main.yml
+++ b/ansible/roles/openshift_setup/tasks/main.yml
@@ -299,9 +299,9 @@
         --base-dir={{ oc_cluster_up_base_dir }}
         --tag={{ origin_image_tag }}
         --image={{ origin_image_name }}-\${component}:\${version}
-    when: ("v3.10" in origin_image_tag) or
-          ("latest" in origin_image_tag)
-
+    when: not("v3.6" in origin_image_tag) and
+          not("v3.7" in origin_image_tag) and
+          not("v3.9" in origin_image_tag)
   #        --enable=service-catalog,template-service-broker,router,registry,web-console,persistent-volumes,sample-templates,rhel-imagestreams{{ ",automation-service-broker" if enable_broker else "" }}
   - name: Add proxy options to oc cluster up command
     set_fact:
@@ -463,13 +463,16 @@
       - persistent-volumes
       - sample-templates
       - rhel-imagestreams
-    when: ("v3.10" in origin_image_tag) or
-          ("latest" in origin_image_tag)
+    when: not("v3.6" in origin_image_tag) and
+          not("v3.7" in origin_image_tag) and
+          not("v3.9" in origin_image_tag)
 
   - name: Enable automation-service-broker for v3.10+
     shell: "{{ oc_cmd }} cluster add automation-service-broker --base-dir=/tmp/openshift.local.clusterup"
     when: (enable_broker == true) and
-          (("v3.10" in origin_image_tag) or ("latest" in origin_image_tag))
+          not("v3.6" in origin_image_tag) and
+          not("v3.7" in origin_image_tag) and
+          not("v3.9" in origin_image_tag)
   #
   # Add permissions to desired openshift user
   # Would be nice if we looked at existing users and permissions and made decisions of what to run

--- a/ansible/roles/openshift_setup/tasks/main.yml
+++ b/ansible/roles/openshift_setup/tasks/main.yml
@@ -453,7 +453,7 @@
     until: oc_cluster_up.rc == 0
 
   - name: Enable cluster components for v3.10+
-    shell: "{{ oc_cmd }} cluster add {{ item }}"
+    shell: "{{ oc_cmd }} cluster add {{ item }} --base-dir=/tmp/openshift.local.clusterup"
     with_items:
       - service-catalog
       - template-service-broker
@@ -463,11 +463,11 @@
       - persistent-volumes
       - sample-templates
       - rhel-imagestreams
-    when: ("v3.10" in origin_image_tag) or 
+    when: ("v3.10" in origin_image_tag) or
           ("latest" in origin_image_tag)
 
   - name: Enable automation-service-broker for v3.10+
-    shell: "{{ oc_cmd }} cluster add automation-service-broker"
+    shell: "{{ oc_cmd }} cluster add automation-service-broker --base-dir=/tmp/openshift.local.clusterup"
     when: (enable_broker == true) and
           (("v3.10" in origin_image_tag) or ("latest" in origin_image_tag))
   #

--- a/ansible/setup_aws_environment.yml
+++ b/ansible/setup_aws_environment.yml
@@ -72,7 +72,7 @@
             Hostname:                  {{ hostname }}
             SSH Key Name:              {{ ssh_key_name }}
             Region:                    {{ aws_region }}
-            Web: https://{{ hostname }}:8443
+            OpenShift Web Console: https://{{ hostname }}:8443/console
             CLI: oc login --insecure-skip-tls-verify {{ hostname }}:8443 -u {{ cluster_user }} -p {{ cluster_user_password }}
 
     - set_fact:

--- a/ansible/setup_aws_environment.yml
+++ b/ansible/setup_aws_environment.yml
@@ -64,6 +64,7 @@
     - { role: env_hacks, when: cluster == 'openshift' }
     - { role: ansible_service_broker_setup, when: deploy_asb == True}
     - { role: awsservicebroker_setup, when: deploy_awsservicebroker == True}
+    - olm_setup
   post_tasks:
     - set_fact:
         msg: |
@@ -85,3 +86,7 @@
 
     - debug:
         msg: "{{ msg.split('\n') }}"
+
+    - debug:
+        msg: "OpenShift Admin Console: http://{{ admin_console_url }}"
+      when: (cluster == 'openshift') and (deploy_admin_console == true)

--- a/ansible/setup_local_environment.yml
+++ b/ansible/setup_local_environment.yml
@@ -11,12 +11,12 @@
     - "{{ cluster }}_setup"
     - { role: ansible_service_broker_setup, when: (not broker_ci) and (deploy_asb == True)}
     - { role: awsservicebroker_setup, when: (not broker_ci) and (deploy_awsservicebroker == True)}
-    - { role: olm_setup, when: deploy_olm == True}
+    - { role: olm_setup, when: (not broker_ci)}
   post_tasks:
     - set_fact:
         msg: |
             Hostname:                  {{ hostname }}
-            Web: https://{{ hostname }}:8443
+            OpenShift Web Console: https://{{ hostname }}:8443
             CLI: oc login --insecure-skip-tls-verify {{ hostname }}:8443 -u {{ cluster_user }} -p {{ cluster_user_password }}
       when: cluster == 'openshift'
     - set_fact:
@@ -26,3 +26,6 @@
       when: cluster == 'kubernetes'
     - debug:
         msg: "{{ msg.split('\n') }}"
+    - debug:
+        msg: "OpenShift Admin Console: http://{{ admin_console_url }}"
+      when: (cluster == 'openshift') and (deploy_admin_console == true)

--- a/ansible/setup_local_environment.yml
+++ b/ansible/setup_local_environment.yml
@@ -16,7 +16,7 @@
     - set_fact:
         msg: |
             Hostname:                  {{ hostname }}
-            OpenShift Web Console: https://{{ hostname }}:8443
+            OpenShift Web Console: https://{{ hostname }}:8443/console
             CLI: oc login --insecure-skip-tls-verify {{ hostname }}:8443 -u {{ cluster_user }} -p {{ cluster_user_password }}
       when: cluster == 'openshift'
     - set_fact:

--- a/ansible/setup_local_environment.yml
+++ b/ansible/setup_local_environment.yml
@@ -28,4 +28,4 @@
         msg: "{{ msg.split('\n') }}"
     - debug:
         msg: "OpenShift Admin Console: http://{{ admin_console_url }}"
-      when: (cluster == 'openshift') and (deploy_admin_console == true)
+      when: (cluster == 'openshift') and (admin_console_url is defined)

--- a/ansible/setup_local_environment.yml
+++ b/ansible/setup_local_environment.yml
@@ -11,6 +11,7 @@
     - "{{ cluster }}_setup"
     - { role: ansible_service_broker_setup, when: (not broker_ci) and (deploy_asb == True)}
     - { role: awsservicebroker_setup, when: (not broker_ci) and (deploy_awsservicebroker == True)}
+    - { role: olm_setup, when: deploy_olm == True}
   post_tasks:
     - set_fact:
         msg: |

--- a/config/my_vars.yml.example
+++ b/config/my_vars.yml.example
@@ -41,7 +41,11 @@ dockerhub_org: ansibleplaybookbundle
 # hostname: 172.17.0.1
 # openshift_routing_suffix: 172.17.0.1.nip.io
 
-# Deploy Operator Lifecycle Manager (OLM) and OpenShift Admin Console (3.11+)
+#############################################################################
+# Switches for deploying OLM and the OpenShift Admin Console (3.11+)
+# Note: admin-console will run with a cluster-admin serviceaccount, so anyone
+#       with the URL can control the cluster (no password required)
+#
 # deploy_olm: false
 # deploy_admin_console: false
 # olm_version: "0.6.0"

--- a/config/my_vars.yml.example
+++ b/config/my_vars.yml.example
@@ -41,6 +41,9 @@ dockerhub_org: ansibleplaybookbundle
 # hostname: 172.17.0.1
 # openshift_routing_suffix: 172.17.0.1.nip.io
 
+# Deploy Operator Lifecycle Manager (OLM)
+# deploy_olm: true
+
 # Default to the "anyuid" scc for pod deployments.
 # scc_anyuid: true
 

--- a/config/my_vars.yml.example
+++ b/config/my_vars.yml.example
@@ -76,20 +76,19 @@ dockerhub_org: ansibleplaybookbundle
 # Select AWS region and AMI for EC2 deployments.
 # us-east-1
 # aws_region: us-east-1
-# aws_ami_id: ami-26ebbc5c
+# aws_ami_id: ami-6871a115
 # us-east-2
 # aws_region: us-east-2
-# aws_ami_id: ami-0b1e356e
+# aws_ami_id: ami-03291866 
 # us-west-1
 # aws_region: us-west-1
-# aws_ami_id: ami-77a2a317
+# aws_ami_id: ami-18726478
 # us-west-2
 # aws_region: us-west-2
-# aws_ami_id: ami-223f945a
+# aws_ami_id: ami-28e07e50
 # ca-central-1
 # aws_region: ca-central-1
-# aws_ami_id: ami-c1cb4ea5
-
+# aws_ami_id: ami-49f0762d
 
 # Enable 'ec2_use_proxy' to send cluster egress through a squid proxy. Only affects EC2 deployments.
 # ec2_use_proxy: True

--- a/config/my_vars.yml.example
+++ b/config/my_vars.yml.example
@@ -48,7 +48,7 @@ dockerhub_org: ansibleplaybookbundle
 #
 # deploy_olm: false
 # deploy_admin_console: false
-# olm_version: "0.6.0"
+# olm_version: "0.7.0"
 # admin_console_image: "quay.io/openshift/origin-console:latest"
 
 # Default to the "anyuid" scc for pod deployments.

--- a/config/my_vars.yml.example
+++ b/config/my_vars.yml.example
@@ -41,8 +41,11 @@ dockerhub_org: ansibleplaybookbundle
 # hostname: 172.17.0.1
 # openshift_routing_suffix: 172.17.0.1.nip.io
 
-# Deploy Operator Lifecycle Manager (OLM)
-# deploy_olm: true
+# Deploy Operator Lifecycle Manager (OLM) and OpenShift Admin Console (3.11+)
+# deploy_olm: false
+# deploy_admin_console: false
+# olm_version: "0.6.0"
+# admin_console_image: "quay.io/openshift/origin-console:latest"
 
 # Default to the "anyuid" scc for pod deployments.
 # scc_anyuid: true


### PR DESCRIPTION
## Changes:
 - Add upstream OLM 0.6.0 deploy manifest to repo
 - Add OLM deploy capability for 3.11+, enabled by default
 - Add ability to deploy next-gen OpenShift admin console for interaction with OLM



## To test this PR:
_Excerpt from_ `config/my_vars.yml.example`:
```
# Make sure these config variables match what's shown here.
deploy_olm: true                 # set to true to deploy OLM                                     
deploy_admin_console: true       # set to true to deploy the OpenShift "Admin Console" in addition to the regular console      
                                               
origin_image_tag: v3.11          # needed to isolate from instability in latest
openshift_client_version: latest # can't use 3.11 tag here yet since official 3.11 client isn't released yet

# OTHER new variables added, no need to adjust these
# olm_version: "0.6.0"                                                             
# admin_console_image: "quay.io/openshift/origin-console:latest"
```

_Sample catasb output when admin console is enabled_:
```
TASK [debug] **********************************************************************************************************
ok: [localhost] => {
    "msg": [
        "Hostname:                  <my_ip>", 
        "OpenShift Web Console: https://<my_ip>:8443", 
        "CLI: oc login --insecure-skip-tls-verify <my_ip>:8443 -u admin -p admin", 
        ""
    ]
}

TASK [debug] **********************************************************************************************************
ok: [localhost] => {
    "msg": "OpenShift Admin Console: http://origin-console-admin-console.<my_ip>.nip.io"
}
```

## New "admin console" with OLM UI:
![image](https://user-images.githubusercontent.com/7576968/45575113-5fd4cf00-b840-11e8-8a9c-a0e36e998d42.png)

